### PR TITLE
#4 [feat] : Campaign 엔티티에 Domain 필드 추가

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/diagnostic/entity/Campaign.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/entity/Campaign.java
@@ -1,5 +1,6 @@
 package com.smartchain.platform.domain.diagnostic.entity;
 
+import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -21,6 +22,11 @@ public class Campaign extends BaseTimeEntity {
     private String campaignCode;
 
     private Long ownerCompanyId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "domain_id")
+    private Domain domain;
+
     private String title;
     private String content;
 
@@ -29,10 +35,11 @@ public class Campaign extends BaseTimeEntity {
     private LocalDate deadline;
 
     @Builder
-    public Campaign(String campaignCode, Long ownerCompanyId, String title, String content,
+    public Campaign(String campaignCode, Long ownerCompanyId, Domain domain, String title, String content,
                     LocalDate periodStartDate, LocalDate periodEndDate, LocalDate deadline) {
         this.campaignCode = campaignCode;
         this.ownerCompanyId = ownerCompanyId;
+        this.domain = domain;
         this.title = title;
         this.content = content;
         this.periodStartDate = periodStartDate;

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/repository/CampaignRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/repository/CampaignRepository.java
@@ -1,12 +1,20 @@
 package com.smartchain.platform.domain.diagnostic.repository;
 
 import com.smartchain.platform.domain.diagnostic.entity.Campaign;
+import com.smartchain.platform.domain.user.entity.Domain;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CampaignRepository extends JpaRepository<Campaign, Long> {
     Optional<Campaign> findByCampaignCode(String campaignCode);
+
+    List<Campaign> findByDomain(Domain domain);
+
+    Page<Campaign> findByDomainOrderByCreatedAtDesc(Domain domain, Pageable pageable);
 }

--- a/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
+++ b/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
@@ -226,6 +226,7 @@ public class DataInitializer implements CommandLineRunner {
         Campaign campaign2026 = campaignRepository.save(Campaign.builder()
                 .campaignCode("CAMP-2026-001")
                 .ownerCompanyId(ownerCompany.getCompanyId())
+                .domain(esgDomain)
                 .title("2026년 ESG 공급망 진단")
                 .content("2026년도 협력사 ESG 경영 현황 진단 및 평가")
                 .periodStartDate(LocalDate.of(2026, 1, 1))

--- a/src/test/java/com/smartchain/platform/domain/diagnostic/repository/CampaignRepositoryTest.java
+++ b/src/test/java/com/smartchain/platform/domain/diagnostic/repository/CampaignRepositoryTest.java
@@ -1,0 +1,151 @@
+package com.smartchain.platform.domain.diagnostic.repository;
+
+import com.smartchain.platform.domain.diagnostic.entity.Campaign;
+import com.smartchain.platform.domain.user.entity.Domain;
+import com.smartchain.platform.domain.user.repository.DomainRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class CampaignRepositoryTest {
+
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    @Autowired
+    private DomainRepository domainRepository;
+
+    private Domain esgDomain;
+    private Domain safetyDomain;
+
+    @BeforeEach
+    void setUp() {
+        esgDomain = domainRepository.save(Domain.builder()
+                .code("ESG")
+                .name("ESG 실사")
+                .description("ESG 공급망 실사")
+                .isActive(true)
+                .build());
+
+        safetyDomain = domainRepository.save(Domain.builder()
+                .code("SAFETY")
+                .name("안전보건")
+                .description("안전보건 관리")
+                .isActive(true)
+                .build());
+    }
+
+    @Test
+    @DisplayName("Domain으로 Campaign 목록 조회 성공")
+    void findByDomain_Success() {
+        // given
+        Campaign esgCampaign1 = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-ESG-001")
+                .ownerCompanyId(1L)
+                .domain(esgDomain)
+                .title("ESG 캠페인 1")
+                .content("ESG 캠페인 내용")
+                .periodStartDate(LocalDate.of(2026, 1, 1))
+                .periodEndDate(LocalDate.of(2026, 12, 31))
+                .deadline(LocalDate.of(2026, 3, 31))
+                .build());
+
+        Campaign esgCampaign2 = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-ESG-002")
+                .ownerCompanyId(1L)
+                .domain(esgDomain)
+                .title("ESG 캠페인 2")
+                .content("ESG 캠페인 내용 2")
+                .periodStartDate(LocalDate.of(2026, 1, 1))
+                .periodEndDate(LocalDate.of(2026, 12, 31))
+                .deadline(LocalDate.of(2026, 3, 31))
+                .build());
+
+        Campaign safetyCampaign = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-SAFETY-001")
+                .ownerCompanyId(1L)
+                .domain(safetyDomain)
+                .title("안전보건 캠페인")
+                .content("안전보건 캠페인 내용")
+                .periodStartDate(LocalDate.of(2026, 1, 1))
+                .periodEndDate(LocalDate.of(2026, 12, 31))
+                .deadline(LocalDate.of(2026, 3, 31))
+                .build());
+
+        // when
+        List<Campaign> esgCampaigns = campaignRepository.findByDomain(esgDomain);
+        List<Campaign> safetyCampaigns = campaignRepository.findByDomain(safetyDomain);
+
+        // then
+        assertThat(esgCampaigns).hasSize(2);
+        assertThat(esgCampaigns).extracting(Campaign::getDomain)
+                .allMatch(domain -> domain.getCode().equals("ESG"));
+
+        assertThat(safetyCampaigns).hasSize(1);
+        assertThat(safetyCampaigns.get(0).getTitle()).isEqualTo("안전보건 캠페인");
+    }
+
+    @Test
+    @DisplayName("Domain으로 Campaign 페이징 조회 성공")
+    void findByDomainOrderByCreatedAtDesc_Success() {
+        // given
+        for (int i = 1; i <= 5; i++) {
+            campaignRepository.save(Campaign.builder()
+                    .campaignCode("CAMP-ESG-00" + i)
+                    .ownerCompanyId(1L)
+                    .domain(esgDomain)
+                    .title("ESG 캠페인 " + i)
+                    .content("ESG 캠페인 내용 " + i)
+                    .periodStartDate(LocalDate.of(2026, 1, 1))
+                    .periodEndDate(LocalDate.of(2026, 12, 31))
+                    .deadline(LocalDate.of(2026, 3, 31))
+                    .build());
+        }
+
+        // when
+        Page<Campaign> page = campaignRepository.findByDomainOrderByCreatedAtDesc(
+                esgDomain, PageRequest.of(0, 3));
+
+        // then
+        assertThat(page.getContent()).hasSize(3);
+        assertThat(page.getTotalElements()).isEqualTo(5);
+        assertThat(page.getTotalPages()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Campaign 엔티티에 Domain 필드가 정상적으로 저장되고 조회됨")
+    void campaignDomainField_PersistenceTest() {
+        // given
+        Campaign campaign = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-DOMAIN-TEST")
+                .ownerCompanyId(1L)
+                .domain(esgDomain)
+                .title("도메인 테스트 캠페인")
+                .content("도메인 테스트 내용")
+                .periodStartDate(LocalDate.of(2026, 1, 1))
+                .periodEndDate(LocalDate.of(2026, 12, 31))
+                .deadline(LocalDate.of(2026, 3, 31))
+                .build());
+
+        // when
+        Campaign found = campaignRepository.findById(campaign.getCampaignId()).orElseThrow();
+
+        // then
+        assertThat(found.getDomain()).isNotNull();
+        assertThat(found.getDomain().getDomainId()).isEqualTo(esgDomain.getDomainId());
+        assertThat(found.getDomain().getCode()).isEqualTo("ESG");
+        assertThat(found.getDomain().getName()).isEqualTo("ESG 실사");
+    }
+}


### PR DESCRIPTION
## 변경요약
- Campaign 엔티티에 `@ManyToOne Domain domain` 필드 추가
- `@JoinColumn(name = "domain_id")` 설정으로 FK 매핑
- Builder 패턴에 domain 파라미터 추가
- CampaignRepository에 도메인별 조회 메서드 추가
  - `findByDomain(Domain)`: 도메인별 캠페인 목록 조회
  - `findByDomainOrderByCreatedAtDesc(Domain, Pageable)`: 페이징 지원 조회
- DataInitializer에서 기존 Campaign에 ESG 도메인 연결

## 관련 이슈
- Closes #4

## 테스트 방법
1. `./gradlew test` 실행하여 전체 테스트 통과 확인
2. `./gradlew build` 실행하여 빌드 성공 확인
3. 로컬 실행 후 Campaign 테이블에 `domain_id` 컬럼 생성 확인
4. DataInitializer로 생성된 Campaign에 ESG 도메인이 연결되었는지 확인

## 명세 준수 체크
- [x] Campaign 엔티티에 Domain 필드 추가됨
- [x] `@JoinColumn(name = "domain_id")` 설정됨
- [x] Builder 패턴에 domain 포함됨
- [x] CampaignRepository에 도메인별 조회 메서드 추가됨
- [x] 빌드 성공 (`./gradlew build`)
- [x] 테스트 통과 (`./gradlew test`)

## 리뷰 포인트
1. Domain 필드가 nullable인데, 기존 데이터 마이그레이션 시 이슈가 될 수 있음
2. Issue #3(Diagnostic)과 동일한 패턴으로 구현 - 일관성 유지
3. Campaign과 Diagnostic 모두 같은 Domain을 참조하므로 데이터 정합성 관리 필요

## TODO / 질문
- [ ] 기존 데이터 마이그레이션 스크립트가 필요한 경우 별도 이슈로 처리 예정
- [ ] Campaign CRUD API 구현은 별도 이슈로 처리 (Issue #4 범위 외)
- Q: Campaign과 Diagnostic의 Domain이 반드시 일치해야 하는지 비즈니스 규칙 확인 필요