### PR TITLE
#6 [feat] : Review 엔티티에 Domain 필드 추가

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
+++ b/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
@@ -2,6 +2,7 @@ package com.smartchain.platform.domain.review.entity;
 
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.user.entity.Company;
+import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.global.entity.BaseTimeEntity;
 import com.smartchain.platform.global.enums.ReviewStatus;
@@ -36,6 +37,10 @@ public class Review extends BaseTimeEntity {
     @JoinColumn(name = "assigned_reviewer_id")
     private User assignedReviewer;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "domain_id")
+    private Domain domain;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ReviewStatus status;
@@ -66,11 +71,12 @@ public class Review extends BaseTimeEntity {
     private String categoryCommentG;
 
     @Builder
-    public Review(Diagnostic diagnostic, Company company, User assignedReviewer,
+    public Review(Diagnostic diagnostic, Company company, User assignedReviewer, Domain domain,
                   Integer score, LocalDateTime submittedAt) {
         this.diagnostic = diagnostic;
         this.company = company;
         this.assignedReviewer = assignedReviewer;
+        this.domain = domain;
         this.score = score;
         this.riskLevel = RiskLevel.fromScore(score);
         this.submittedAt = submittedAt;

--- a/src/main/java/com/smartchain/platform/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/review/repository/ReviewRepository.java
@@ -2,6 +2,8 @@ package com.smartchain.platform.domain.review.repository;
 
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.user.entity.Company;
+import com.smartchain.platform.domain.user.entity.Domain;
+import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.global.enums.ReviewStatus;
 import com.smartchain.platform.global.enums.RiskLevel;
 import org.springframework.data.domain.Page;
@@ -51,4 +53,14 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // 최근 활동 조회 (상위 N개)
     @Query("SELECT r FROM Review r ORDER BY r.submittedAt DESC")
     List<Review> findTopNByOrderBySubmittedAtDesc(Pageable pageable);
+
+    // 도메인별 조회
+    List<Review> findByDomain(Domain domain);
+
+    Page<Review> findByDomainOrderByCreatedAtDesc(Domain domain, Pageable pageable);
+
+    // 담당 심사자 + 도메인별 조회
+    Page<Review> findByAssignedReviewerAndDomainOrderByCreatedAtDesc(User assignedReviewer, Domain domain, Pageable pageable);
+
+    List<Review> findByAssignedReviewerAndDomain(User assignedReviewer, Domain domain);
 }

--- a/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
+++ b/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
@@ -293,6 +293,7 @@ public class DataInitializer implements CommandLineRunner {
                 .diagnostic(diagnosticForReview)
                 .company(partnerCompany1)
                 .assignedReviewer(reviewer)
+                .domain(esgDomain)
                 .score(72)
                 .submittedAt(LocalDateTime.now().minusDays(5))
                 .build());

--- a/src/test/java/com/smartchain/platform/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/smartchain/platform/domain/review/repository/ReviewRepositoryTest.java
@@ -1,0 +1,263 @@
+package com.smartchain.platform.domain.review.repository;
+
+import com.smartchain.platform.domain.diagnostic.entity.Campaign;
+import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.domain.diagnostic.repository.CampaignRepository;
+import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
+import com.smartchain.platform.domain.review.entity.Review;
+import com.smartchain.platform.domain.user.entity.Company;
+import com.smartchain.platform.domain.user.entity.Domain;
+import com.smartchain.platform.domain.user.entity.Industry;
+import com.smartchain.platform.domain.user.entity.Role;
+import com.smartchain.platform.domain.user.entity.User;
+import com.smartchain.platform.domain.user.repository.CompanyRepository;
+import com.smartchain.platform.domain.user.repository.DomainRepository;
+import com.smartchain.platform.domain.user.repository.IndustryRepository;
+import com.smartchain.platform.domain.user.repository.RoleRepository;
+import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.global.enums.CompanyStatus;
+import com.smartchain.platform.global.enums.CompanyType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ReviewRepositoryTest {
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private DomainRepository domainRepository;
+
+    @Autowired
+    private DiagnosticRepository diagnosticRepository;
+
+    @Autowired
+    private CampaignRepository campaignRepository;
+
+    @Autowired
+    private CompanyRepository companyRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private IndustryRepository industryRepository;
+
+    private Domain esgDomain;
+    private Domain safetyDomain;
+    private Company company;
+    private User reviewer;
+    private Diagnostic diagnostic;
+
+    @BeforeEach
+    void setUp() {
+        // Domain 생성
+        esgDomain = domainRepository.save(Domain.builder()
+                .code("ESG")
+                .name("ESG 실사")
+                .description("ESG 공급망 실사")
+                .isActive(true)
+                .build());
+
+        safetyDomain = domainRepository.save(Domain.builder()
+                .code("SAFETY")
+                .name("안전보건")
+                .description("안전보건 관리")
+                .isActive(true)
+                .build());
+
+        // Industry 생성
+        Industry industry = industryRepository.save(new Industry("제조업", "MANUFACTURING"));
+
+        // Company 생성
+        company = companyRepository.save(Company.builder()
+                .industry(industry)
+                .name("(주)테스트회사")
+                .scale("중소기업")
+                .sales(10000000000L)
+                .asset(20000000000L)
+                .businessNumber("123-45-67890")
+                .companyType(CompanyType.TIER2)
+                .ceoName("테스트")
+                .address("서울시")
+                .contactEmail("test@test.com")
+                .contactPhone("02-1234-5678")
+                .status(CompanyStatus.ACTIVE)
+                .build());
+
+        // Role 생성
+        Role reviewerRole = roleRepository.save(new Role("심사자", "REVIEWER"));
+
+        // User 생성
+        reviewer = userRepository.save(User.builder()
+                .name("심사자")
+                .email("reviewer@test.com")
+                .userPassword("password")
+                .company(company)
+                .role(reviewerRole)
+                .build());
+
+        // Campaign 생성
+        Campaign campaign = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-TEST-001")
+                .ownerCompanyId(company.getCompanyId())
+                .title("테스트 캠페인")
+                .content("테스트용 캠페인")
+                .periodStartDate(LocalDate.of(2026, 1, 1))
+                .periodEndDate(LocalDate.of(2026, 12, 31))
+                .deadline(LocalDate.of(2026, 3, 31))
+                .build());
+
+        // Diagnostic 생성
+        diagnostic = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-TEST-001")
+                .title("테스트 진단")
+                .campaign(campaign)
+                .company(company)
+                .drafterId(1L)
+                .periodStartDate(LocalDate.of(2026, 1, 1))
+                .periodEndDate(LocalDate.of(2026, 12, 31))
+                .deadline(LocalDate.of(2026, 3, 31))
+                .build());
+    }
+
+    @Test
+    @DisplayName("Domain으로 Review 목록 조회 성공")
+    void findByDomain_Success() {
+        // given
+        Review esgReview1 = reviewRepository.save(Review.builder()
+                .diagnostic(diagnostic)
+                .company(company)
+                .assignedReviewer(reviewer)
+                .domain(esgDomain)
+                .score(80)
+                .submittedAt(LocalDateTime.now())
+                .build());
+
+        Review esgReview2 = reviewRepository.save(Review.builder()
+                .diagnostic(diagnostic)
+                .company(company)
+                .assignedReviewer(reviewer)
+                .domain(esgDomain)
+                .score(75)
+                .submittedAt(LocalDateTime.now())
+                .build());
+
+        Review safetyReview = reviewRepository.save(Review.builder()
+                .diagnostic(diagnostic)
+                .company(company)
+                .assignedReviewer(reviewer)
+                .domain(safetyDomain)
+                .score(85)
+                .submittedAt(LocalDateTime.now())
+                .build());
+
+        // when
+        List<Review> esgReviews = reviewRepository.findByDomain(esgDomain);
+        List<Review> safetyReviews = reviewRepository.findByDomain(safetyDomain);
+
+        // then
+        assertThat(esgReviews).hasSize(2);
+        assertThat(esgReviews).extracting(Review::getDomain)
+                .allMatch(domain -> domain.getCode().equals("ESG"));
+
+        assertThat(safetyReviews).hasSize(1);
+        assertThat(safetyReviews.get(0).getScore()).isEqualTo(85);
+    }
+
+    @Test
+    @DisplayName("담당 심사자와 Domain으로 Review 목록 조회 성공")
+    void findByAssignedReviewerAndDomain_Success() {
+        // given
+        Review review1 = reviewRepository.save(Review.builder()
+                .diagnostic(diagnostic)
+                .company(company)
+                .assignedReviewer(reviewer)
+                .domain(esgDomain)
+                .score(80)
+                .submittedAt(LocalDateTime.now())
+                .build());
+
+        Review review2 = reviewRepository.save(Review.builder()
+                .diagnostic(diagnostic)
+                .company(company)
+                .assignedReviewer(reviewer)
+                .domain(esgDomain)
+                .score(75)
+                .submittedAt(LocalDateTime.now())
+                .build());
+
+        // when
+        List<Review> reviews = reviewRepository.findByAssignedReviewerAndDomain(reviewer, esgDomain);
+
+        // then
+        assertThat(reviews).hasSize(2);
+        assertThat(reviews).allMatch(r -> r.getAssignedReviewer().getUserId().equals(reviewer.getUserId()));
+        assertThat(reviews).allMatch(r -> r.getDomain().getCode().equals("ESG"));
+    }
+
+    @Test
+    @DisplayName("Domain으로 Review 페이징 조회 성공")
+    void findByDomainOrderByCreatedAtDesc_Success() {
+        // given
+        for (int i = 1; i <= 5; i++) {
+            reviewRepository.save(Review.builder()
+                    .diagnostic(diagnostic)
+                    .company(company)
+                    .assignedReviewer(reviewer)
+                    .domain(esgDomain)
+                    .score(70 + i)
+                    .submittedAt(LocalDateTime.now())
+                    .build());
+        }
+
+        // when
+        Page<Review> page = reviewRepository.findByDomainOrderByCreatedAtDesc(
+                esgDomain, PageRequest.of(0, 3));
+
+        // then
+        assertThat(page.getContent()).hasSize(3);
+        assertThat(page.getTotalElements()).isEqualTo(5);
+        assertThat(page.getTotalPages()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Review 엔티티에 Domain 필드가 정상적으로 저장되고 조회됨")
+    void reviewDomainField_PersistenceTest() {
+        // given
+        Review review = reviewRepository.save(Review.builder()
+                .diagnostic(diagnostic)
+                .company(company)
+                .assignedReviewer(reviewer)
+                .domain(esgDomain)
+                .score(85)
+                .submittedAt(LocalDateTime.now())
+                .build());
+
+        // when
+        Review found = reviewRepository.findById(review.getReviewId()).orElseThrow();
+
+        // then
+        assertThat(found.getDomain()).isNotNull();
+        assertThat(found.getDomain().getDomainId()).isEqualTo(esgDomain.getDomainId());
+        assertThat(found.getDomain().getCode()).isEqualTo("ESG");
+        assertThat(found.getDomain().getName()).isEqualTo("ESG 실사");
+    }
+}


### PR DESCRIPTION
## 변경요약
- Review 엔티티에 `@ManyToOne Domain domain` 필드 추가
- `@JoinColumn(name = "domain_id")` 설정으로 FK 매핑
- Builder 패턴에 domain 파라미터 추가
- ReviewRepository에 도메인별 조회 메서드 추가
  - `findByDomain(Domain)`: 도메인별 심사 목록 조회
  - `findByDomainOrderByCreatedAtDesc(Domain, Pageable)`: 페이징 지원 조회
  - `findByAssignedReviewerAndDomain(User, Domain)`: 담당 심사자 + 도메인별 조회
  - `findByAssignedReviewerAndDomainOrderByCreatedAtDesc(User, Domain, Pageable)`: 페이징 지원
- DataInitializer에서 기존 Review에 ESG 도메인 연결

## 관련 이슈
- Closes #6

## 테스트 방법
1. `./gradlew test` 실행하여 전체 테스트 통과 확인
2. `./gradlew build` 실행하여 빌드 성공 확인
3. 로컬 실행 후 Review 테이블에 `domain_id` 컬럼 생성 확인
4. DataInitializer로 생성된 Review에 ESG 도메인이 연결되었는지 확인

## 명세 준수 체크
- [x] Review 엔티티에 Domain 필드 추가됨
- [x] `@JoinColumn(name = "domain_id")` 설정됨
- [x] Builder 패턴에 domain 포함됨
- [x] ReviewRepository에 도메인별 조회 메서드 추가됨 (`findByDomain`, `findByAssignedReviewerAndDomain`)
- [x] DataInitializer 업데이트됨
- [x] 빌드 성공 (`./gradlew build`)
- [x] 테스트 통과 (`./gradlew test`)

## 리뷰 포인트
1. Domain 필드가 nullable인데, 기존 데이터 마이그레이션 시 이슈가 될 수 있음
2. Issue #3(Diagnostic), #4(Campaign)와 동일한 패턴으로 구현 - 일관성 유지
3. Review는 Diagnostic과 연결되어 있으므로 Domain 중복 저장에 대한 논의 필요 (Diagnostic.domain vs Review.domain)
4. `findByAssignedReviewerAndDomain` 메서드 추가 - 심사자별 도메인 필터링에 활용

## TODO / 질문
- [ ] 기존 데이터 마이그레이션 스크립트가 필요한 경우 별도 이슈로 처리 예정
- [ ] ReviewService 권한 체크 로직은 별도 이슈로 처리 (Issue #6 범위 외)
- [ ] ReviewController 도메인 필터링은 별도 이슈로 처리 (Issue #6 범위 외)
- Q: Review.domain은 항상 Diagnostic.domain과 일치해야 하는지, 아니면 독립적으로 관리되어야 하는지 확인 필요