### PR TITLE
#5 [feat] : DiagnosticCreateRequest에 domainCode 필드 추가

### DIFF
--- a/src/main/java/com/smartchain/platform/dto/diagnostic/common/DomainSimpleDto.java
+++ b/src/main/java/com/smartchain/platform/dto/diagnostic/common/DomainSimpleDto.java
@@ -1,0 +1,16 @@
+package com.smartchain.platform.dto.diagnostic.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DomainSimpleDto {
+    private Long domainId;
+    private String code;
+    private String name;
+}

--- a/src/main/java/com/smartchain/platform/dto/diagnostic/create/DiagnosticCreateRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/diagnostic/create/DiagnosticCreateRequest.java
@@ -13,4 +13,7 @@ import lombok.NoArgsConstructor;
 public class DiagnosticCreateRequest {
     @NotNull(message = "캠페인을 선택해주세요")
     private Long campaignId;
+
+    @NotNull(message = "도메인을 선택해주세요")
+    private String domainCode;
 }

--- a/src/main/java/com/smartchain/platform/dto/diagnostic/create/DiagnosticCreateResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/diagnostic/create/DiagnosticCreateResponse.java
@@ -14,6 +14,8 @@ import java.time.LocalDateTime;
 public class DiagnosticCreateResponse {
     private Long diagnosticId;
     private String diagnosticCode;
+    private String domainCode;
+    private String domainName;
     private String status;               // WRITING
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/smartchain/platform/dto/diagnostic/detail/DiagnosticDetailResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/diagnostic/detail/DiagnosticDetailResponse.java
@@ -1,6 +1,7 @@
 package com.smartchain.platform.dto.diagnostic.detail;
 
 import com.smartchain.platform.dto.diagnostic.common.CompanySimpleDto;
+import com.smartchain.platform.dto.diagnostic.common.DomainSimpleDto;
 import com.smartchain.platform.dto.diagnostic.common.PeriodDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 public class DiagnosticDetailResponse {
     private Long diagnosticId;
     private String diagnosticCode;
+    private DomainSimpleDto domain;          // v3.0: 도메인 정보
     private CampaignDetailDto campaign;      // v3.0: 구조화
     private CompanySimpleDto company;        // v3.0: 구조화
     private PeriodDto period;

--- a/src/main/java/com/smartchain/platform/dto/diagnostic/list/DiagnosticListItemDto.java
+++ b/src/main/java/com/smartchain/platform/dto/diagnostic/list/DiagnosticListItemDto.java
@@ -1,6 +1,7 @@
 package com.smartchain.platform.dto.diagnostic.list;
 
 import com.smartchain.platform.dto.diagnostic.common.CampaignSimpleDto;
+import com.smartchain.platform.dto.diagnostic.common.DomainSimpleDto;
 import com.smartchain.platform.dto.diagnostic.common.PeriodDto;
 import com.smartchain.platform.dto.diagnostic.common.ProgressDto;
 import lombok.AllArgsConstructor;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 public class DiagnosticListItemDto {
     private Long diagnosticId;
     private String diagnosticCode;       // v3.0: "DG-2026-00001"
+    private DomainSimpleDto domain;      // v3.0: 도메인 정보
     private CampaignSimpleDto campaign;  // v3.0: 구조화
     private String summary;              // "○ 25년도 상반기 ESG 보고서 제..."
     private PeriodDto period;            // v3.0: 구조화

--- a/src/test/java/com/smartchain/platform/dto/diagnostic/DiagnosticDtoTest.java
+++ b/src/test/java/com/smartchain/platform/dto/diagnostic/DiagnosticDtoTest.java
@@ -1,0 +1,115 @@
+package com.smartchain.platform.dto.diagnostic;
+
+import com.smartchain.platform.dto.diagnostic.common.DomainSimpleDto;
+import com.smartchain.platform.dto.diagnostic.create.DiagnosticCreateRequest;
+import com.smartchain.platform.dto.diagnostic.create.DiagnosticCreateResponse;
+import com.smartchain.platform.dto.diagnostic.detail.DiagnosticDetailResponse;
+import com.smartchain.platform.dto.diagnostic.list.DiagnosticListItemDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiagnosticDtoTest {
+
+    @Test
+    @DisplayName("DiagnosticCreateRequest에 domainCode 필드가 포함됨")
+    void diagnosticCreateRequest_hasDomainCode() {
+        // given
+        DiagnosticCreateRequest request = DiagnosticCreateRequest.builder()
+                .campaignId(1L)
+                .domainCode("ESG")
+                .build();
+
+        // then
+        assertThat(request.getCampaignId()).isEqualTo(1L);
+        assertThat(request.getDomainCode()).isEqualTo("ESG");
+    }
+
+    @Test
+    @DisplayName("DiagnosticCreateResponse에 domainCode, domainName 필드가 포함됨")
+    void diagnosticCreateResponse_hasDomainInfo() {
+        // given
+        DiagnosticCreateResponse response = DiagnosticCreateResponse.builder()
+                .diagnosticId(1L)
+                .diagnosticCode("DG-2026-00001")
+                .domainCode("ESG")
+                .domainName("ESG 실사")
+                .status("WRITING")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        // then
+        assertThat(response.getDiagnosticId()).isEqualTo(1L);
+        assertThat(response.getDomainCode()).isEqualTo("ESG");
+        assertThat(response.getDomainName()).isEqualTo("ESG 실사");
+    }
+
+    @Test
+    @DisplayName("DiagnosticDetailResponse에 domain 정보가 포함됨")
+    void diagnosticDetailResponse_hasDomainInfo() {
+        // given
+        DomainSimpleDto domain = DomainSimpleDto.builder()
+                .domainId(1L)
+                .code("ESG")
+                .name("ESG 실사")
+                .build();
+
+        DiagnosticDetailResponse response = DiagnosticDetailResponse.builder()
+                .diagnosticId(1L)
+                .diagnosticCode("DG-2026-00001")
+                .domain(domain)
+                .status("WRITING")
+                .statusLabel("작성중")
+                .build();
+
+        // then
+        assertThat(response.getDomain()).isNotNull();
+        assertThat(response.getDomain().getDomainId()).isEqualTo(1L);
+        assertThat(response.getDomain().getCode()).isEqualTo("ESG");
+        assertThat(response.getDomain().getName()).isEqualTo("ESG 실사");
+    }
+
+    @Test
+    @DisplayName("DiagnosticListItemDto에 domain 정보가 포함됨")
+    void diagnosticListItemDto_hasDomainInfo() {
+        // given
+        DomainSimpleDto domain = DomainSimpleDto.builder()
+                .domainId(1L)
+                .code("ESG")
+                .name("ESG 실사")
+                .build();
+
+        DiagnosticListItemDto item = DiagnosticListItemDto.builder()
+                .diagnosticId(1L)
+                .diagnosticCode("DG-2026-00001")
+                .domain(domain)
+                .status("WRITING")
+                .statusLabel("작성중")
+                .build();
+
+        // then
+        assertThat(item.getDomain()).isNotNull();
+        assertThat(item.getDomain().getDomainId()).isEqualTo(1L);
+        assertThat(item.getDomain().getCode()).isEqualTo("ESG");
+        assertThat(item.getDomain().getName()).isEqualTo("ESG 실사");
+    }
+
+    @Test
+    @DisplayName("DomainSimpleDto 빌더 및 getter 테스트")
+    void domainSimpleDto_builderAndGetterTest() {
+        // given
+        DomainSimpleDto dto = DomainSimpleDto.builder()
+                .domainId(1L)
+                .code("SAFETY")
+                .name("안전보건")
+                .build();
+
+        // then
+        assertThat(dto.getDomainId()).isEqualTo(1L);
+        assertThat(dto.getCode()).isEqualTo("SAFETY");
+        assertThat(dto.getName()).isEqualTo("안전보건");
+    }
+}


### PR DESCRIPTION
## 변경요약
- **DiagnosticCreateRequest**: `domainCode` 필드 추가 (String, @NotNull 필수값)
- **DiagnosticCreateResponse**: `domainCode`, `domainName` 필드 추가
- **DiagnosticDetailResponse**: `DomainSimpleDto domain` 필드 추가 (구조화)
- **DiagnosticListItemDto**: `DomainSimpleDto domain` 필드 추가 (구조화)
- **DomainSimpleDto**: 신규 생성 (diagnostic/common 패키지, domainId/code/name 포함)

## 관련 이슈
- Closes #5

## 테스트 방법
1. `./gradlew test` 실행하여 전체 테스트 통과 확인
2. `./gradlew build` 실행하여 빌드 성공 확인
3. DiagnosticDtoTest에서 각 DTO의 도메인 필드 검증 확인

## 명세 준수 체크
- [x] DiagnosticCreateRequest에 domainCode 필드 추가됨
- [x] DiagnosticCreateResponse에 도메인 정보 추가됨 (domainCode, domainName)
- [x] DiagnosticDetailResponse에 도메인 정보 추가됨 (DomainSimpleDto)
- [x] DiagnosticListResponse 항목에 도메인 정보 추가됨 (DiagnosticListItemDto.domain)
- [x] 빌드 성공 (`./gradlew build`)
- [x] 테스트 통과 (`./gradlew test`)

## 리뷰 포인트
1. DomainSimpleDto를 diagnostic/common 패키지에 별도 생성 (role/common에도 동일한 DTO 존재)
   - 패키지별 독립성 유지 vs 공통 DTO 재사용 여부 검토 필요
2. domainCode 필드가 @NotNull 필수값으로 설정됨 - 기존 API 호출에 영향 있음
3. DiagnosticDetailResponse와 DiagnosticListItemDto에는 DomainSimpleDto 구조 사용 (일관성)
4. DiagnosticCreateResponse에는 단순 필드(domainCode, domainName) 사용 - 생성 응답 특성상

## TODO / 질문
- [ ] Service 로직에서 domainCode로 Domain 엔티티 조회 및 Diagnostic에 연결하는 로직 필요 (별도 이슈)
- [ ] Validation 로직 추가 필요 (별도 이슈) - 유효하지 않은 domainCode 처리
- Q: DomainSimpleDto를 공통 패키지로 통합할지, 도메인별 패키지에 유지할지 결정 필요
- Q: 기존 API 클라이언트가 domainCode 없이 호출하는 경우 하위 호환성 처리 방안 필요