### PR TITLE
#9 [feat] : ReviewService 도메인별 권한 검증 로직 추가

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/review/repository/ReviewRepository.java
@@ -63,4 +63,38 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Page<Review> findByAssignedReviewerAndDomainOrderByCreatedAtDesc(User assignedReviewer, Domain domain, Pageable pageable);
 
     List<Review> findByAssignedReviewerAndDomain(User assignedReviewer, Domain domain);
+
+    // 도메인 목록(IN)으로 필터링
+    Page<Review> findByDomainInOrderByCreatedAtDesc(List<Domain> domains, Pageable pageable);
+
+    Page<Review> findByDomainInAndStatusOrderByCreatedAtDesc(List<Domain> domains, ReviewStatus status, Pageable pageable);
+
+    Page<Review> findByDomainInAndRiskLevelOrderByCreatedAtDesc(List<Domain> domains, RiskLevel riskLevel, Pageable pageable);
+
+    Page<Review> findByDomainInAndStatusAndRiskLevelOrderByCreatedAtDesc(
+            List<Domain> domains, ReviewStatus status, RiskLevel riskLevel, Pageable pageable);
+
+    Page<Review> findByDomainInAndStatusAndRiskLevelAndCompanyOrderByCreatedAtDesc(
+            List<Domain> domains, ReviewStatus status, RiskLevel riskLevel, Company company, Pageable pageable);
+
+    Page<Review> findByDomainInAndStatusAndCompanyOrderByCreatedAtDesc(
+            List<Domain> domains, ReviewStatus status, Company company, Pageable pageable);
+
+    Page<Review> findByDomainInAndRiskLevelAndCompanyOrderByCreatedAtDesc(
+            List<Domain> domains, RiskLevel riskLevel, Company company, Pageable pageable);
+
+    Page<Review> findByDomainInAndCompanyOrderByCreatedAtDesc(List<Domain> domains, Company company, Pageable pageable);
+
+    // 도메인 목록 기반 통계
+    long countByDomainIn(List<Domain> domains);
+
+    long countByDomainInAndStatus(List<Domain> domains, ReviewStatus status);
+
+    long countByDomainInAndRiskLevel(List<Domain> domains, RiskLevel riskLevel);
+
+    @Query("SELECT COUNT(DISTINCT r.company) FROM Review r WHERE r.domain IN :domains")
+    long countDistinctCompaniesByDomainIn(@Param("domains") List<Domain> domains);
+
+    @Query("SELECT r FROM Review r WHERE r.domain IN :domains ORDER BY r.submittedAt DESC")
+    List<Review> findByDomainInOrderBySubmittedAtDesc(@Param("domains") List<Domain> domains, Pageable pageable);
 }

--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.smartchain.platform.domain.review.service;
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
+import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.domain.user.repository.CompanyRepository;
 import com.smartchain.platform.domain.user.repository.UserRepository;
@@ -12,7 +13,6 @@ import com.smartchain.platform.dto.review.decision.ReviewDecisionRequest;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionResponse;
 import com.smartchain.platform.dto.review.detail.*;
 import com.smartchain.platform.dto.review.list.*;
-import com.smartchain.platform.global.enums.DiagnosticStatus;
 import com.smartchain.platform.global.enums.ReviewStatus;
 import com.smartchain.platform.global.enums.RiskLevel;
 import com.smartchain.platform.global.error.CustomException;
@@ -59,15 +59,17 @@ public class ReviewService {
 
     /**
      * 진단 현황 대시보드 조회
+     * - 사용자가 REVIEWER 권한을 가진 도메인의 심사만 통계에 포함
      */
     public ReviewDashboardResponse getDashboard(Long userId, Long campaignId, String fromDate, String toDate) {
         User currentUser = validateReviewerRole(userId);
+        List<Domain> permittedDomains = getPermittedReviewerDomains(currentUser);
 
-        // Overview 통계
-        long totalCompanies = reviewRepository.countDistinctCompanies();
-        long inReviewCount = reviewRepository.countByStatus(ReviewStatus.REVIEWING);
-        long completedCount = reviewRepository.countByStatus(ReviewStatus.APPROVED);
-        long revisionCount = reviewRepository.countByStatus(ReviewStatus.REVISION_REQUIRED);
+        // Overview 통계 (도메인 필터링 적용)
+        long totalCompanies = reviewRepository.countDistinctCompaniesByDomainIn(permittedDomains);
+        long inReviewCount = reviewRepository.countByDomainInAndStatus(permittedDomains, ReviewStatus.REVIEWING);
+        long completedCount = reviewRepository.countByDomainInAndStatus(permittedDomains, ReviewStatus.APPROVED);
+        long revisionCount = reviewRepository.countByDomainInAndStatus(permittedDomains, ReviewStatus.REVISION_REQUIRED);
         long submittedCount = inReviewCount + completedCount + revisionCount;
 
         OverviewDto overview = OverviewDto.builder()
@@ -75,14 +77,14 @@ public class ReviewService {
                 .submittedCount((int) submittedCount)
                 .inReviewCount((int) inReviewCount)
                 .completedCount((int) completedCount)
-                .notStartedCount(0) // 계산 로직 필요시 추가
+                .notStartedCount(0)
                 .build();
 
-        // Risk Distribution
+        // Risk Distribution (도메인 필터링 적용)
         RiskDistributionDto riskDistribution = RiskDistributionDto.builder()
-                .high((int) reviewRepository.countByRiskLevel(RiskLevel.HIGH))
-                .medium((int) reviewRepository.countByRiskLevel(RiskLevel.MEDIUM))
-                .low((int) reviewRepository.countByRiskLevel(RiskLevel.LOW))
+                .high((int) reviewRepository.countByDomainInAndRiskLevel(permittedDomains, RiskLevel.HIGH))
+                .medium((int) reviewRepository.countByDomainInAndRiskLevel(permittedDomains, RiskLevel.MEDIUM))
+                .low((int) reviewRepository.countByDomainInAndRiskLevel(permittedDomains, RiskLevel.LOW))
                 .build();
 
         // Category Averages (현재 단순 고정값, 추후 실제 계산 로직 추가)
@@ -92,8 +94,9 @@ public class ReviewService {
                 .G(68.0)
                 .build();
 
-        // Recent Activities
-        List<Review> recentReviews = reviewRepository.findTopNByOrderBySubmittedAtDesc(PageRequest.of(0, 5));
+        // Recent Activities (도메인 필터링 적용)
+        List<Review> recentReviews = reviewRepository.findByDomainInOrderBySubmittedAtDesc(
+                permittedDomains, PageRequest.of(0, 5));
         List<RecentActivityDto> recentActivities = recentReviews.stream()
                 .map(review -> RecentActivityDto.builder()
                         .type(review.getStatus().name())
@@ -113,22 +116,24 @@ public class ReviewService {
 
     /**
      * 심사 대상 목록 조회
+     * - 사용자가 REVIEWER 권한을 가진 도메인의 심사만 조회
      */
     public ReviewListResponse getReviewList(Long userId, String status, String riskLevel, Long companyId, int page, int size) {
         User currentUser = validateReviewerRole(userId);
+        List<Domain> permittedDomains = getPermittedReviewerDomains(currentUser);
         Pageable pageable = PageRequest.of(page, size);
 
-        Page<Review> reviewPage = findReviewsWithFilters(status, riskLevel, companyId, pageable);
+        Page<Review> reviewPage = findReviewsWithDomainFilters(permittedDomains, status, riskLevel, companyId, pageable);
 
-        // Summary 생성
+        // Summary 생성 (도메인 필터링 적용)
         ReviewSummaryDto summary = ReviewSummaryDto.builder()
-                .totalCompanies((int) reviewRepository.countDistinctCompanies())
-                .completedCount((int) reviewRepository.countByStatus(ReviewStatus.APPROVED))
-                .inProgressCount((int) reviewRepository.countByStatus(ReviewStatus.REVIEWING))
+                .totalCompanies((int) reviewRepository.countDistinctCompaniesByDomainIn(permittedDomains))
+                .completedCount((int) reviewRepository.countByDomainInAndStatus(permittedDomains, ReviewStatus.APPROVED))
+                .inProgressCount((int) reviewRepository.countByDomainInAndStatus(permittedDomains, ReviewStatus.REVIEWING))
                 .pendingCount(0)
-                .highRiskCount((int) reviewRepository.countByRiskLevel(RiskLevel.HIGH))
-                .mediumRiskCount((int) reviewRepository.countByRiskLevel(RiskLevel.MEDIUM))
-                .lowRiskCount((int) reviewRepository.countByRiskLevel(RiskLevel.LOW))
+                .highRiskCount((int) reviewRepository.countByDomainInAndRiskLevel(permittedDomains, RiskLevel.HIGH))
+                .mediumRiskCount((int) reviewRepository.countByDomainInAndRiskLevel(permittedDomains, RiskLevel.MEDIUM))
+                .lowRiskCount((int) reviewRepository.countByDomainInAndRiskLevel(permittedDomains, RiskLevel.LOW))
                 .build();
 
         // Content 변환
@@ -153,12 +158,15 @@ public class ReviewService {
 
     /**
      * 심사 상세 조회
+     * - 해당 심사의 도메인에 REVIEWER 권한이 있는지 검증
      */
     public ReviewDetailResponse getReviewDetail(Long userId, Long reviewId) {
         User currentUser = validateReviewerRole(userId);
 
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+
+        validateDomainReviewerAccess(currentUser, review);
 
         // Diagnostic Info
         DiagnosticDetailInfoDto diagnosticDto = DiagnosticDetailInfoDto.builder()
@@ -204,6 +212,7 @@ public class ReviewService {
 
     /**
      * 심사 결과 입력 (승인/보완요청)
+     * - 해당 심사의 도메인에 REVIEWER 권한이 있는지 검증
      */
     @Transactional
     public ReviewDecisionResponse processReview(Long userId, Long reviewId, ReviewDecisionRequest request) {
@@ -211,6 +220,8 @@ public class ReviewService {
 
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+
+        validateDomainReviewerAccess(currentUser, review);
 
         if (!review.isReviewing()) {
             throw new CustomException(ErrorCode.ALREADY_PROCESSED_REVIEW);
@@ -271,32 +282,49 @@ public class ReviewService {
         return user;
     }
 
-    private Page<Review> findReviewsWithFilters(String status, String riskLevel, Long companyId, Pageable pageable) {
+    private List<Domain> getPermittedReviewerDomains(User user) {
+        List<Domain> domains = user.getDomainsWithRole("REVIEWER");
+        if (domains.isEmpty()) {
+            throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);
+        }
+        return domains;
+    }
+
+    private void validateDomainReviewerAccess(User user, Review review) {
+        if (review.getDomain() == null) {
+            throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);
+        }
+        String domainCode = review.getDomain().getCode();
+        if (!user.hasRoleInDomain(domainCode, "REVIEWER")) {
+            throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);
+        }
+    }
+
+    private Page<Review> findReviewsWithDomainFilters(List<Domain> domains, String status, String riskLevel, Long companyId, Pageable pageable) {
         ReviewStatus reviewStatus = parseReviewStatus(status);
         RiskLevel riskLevelEnum = parseRiskLevel(riskLevel);
         Company company = companyId != null ? companyRepository.findById(companyId).orElse(null) : null;
 
-        // 필터 조합에 따른 쿼리 선택
         if (reviewStatus != null && riskLevelEnum != null && company != null) {
-            return reviewRepository.findByStatusAndRiskLevelAndCompanyOrderByCreatedAtDesc(
-                    reviewStatus, riskLevelEnum, company, pageable);
+            return reviewRepository.findByDomainInAndStatusAndRiskLevelAndCompanyOrderByCreatedAtDesc(
+                    domains, reviewStatus, riskLevelEnum, company, pageable);
         } else if (reviewStatus != null && riskLevelEnum != null) {
-            return reviewRepository.findByStatusAndRiskLevelOrderByCreatedAtDesc(
-                    reviewStatus, riskLevelEnum, pageable);
+            return reviewRepository.findByDomainInAndStatusAndRiskLevelOrderByCreatedAtDesc(
+                    domains, reviewStatus, riskLevelEnum, pageable);
         } else if (reviewStatus != null && company != null) {
-            return reviewRepository.findByStatusAndCompanyOrderByCreatedAtDesc(
-                    reviewStatus, company, pageable);
+            return reviewRepository.findByDomainInAndStatusAndCompanyOrderByCreatedAtDesc(
+                    domains, reviewStatus, company, pageable);
         } else if (riskLevelEnum != null && company != null) {
-            return reviewRepository.findByRiskLevelAndCompanyOrderByCreatedAtDesc(
-                    riskLevelEnum, company, pageable);
+            return reviewRepository.findByDomainInAndRiskLevelAndCompanyOrderByCreatedAtDesc(
+                    domains, riskLevelEnum, company, pageable);
         } else if (reviewStatus != null) {
-            return reviewRepository.findByStatusOrderByCreatedAtDesc(reviewStatus, pageable);
+            return reviewRepository.findByDomainInAndStatusOrderByCreatedAtDesc(domains, reviewStatus, pageable);
         } else if (riskLevelEnum != null) {
-            return reviewRepository.findByRiskLevelOrderByCreatedAtDesc(riskLevelEnum, pageable);
+            return reviewRepository.findByDomainInAndRiskLevelOrderByCreatedAtDesc(domains, riskLevelEnum, pageable);
         } else if (company != null) {
-            return reviewRepository.findByCompanyOrderByCreatedAtDesc(company, pageable);
+            return reviewRepository.findByDomainInAndCompanyOrderByCreatedAtDesc(domains, company, pageable);
         } else {
-            return reviewRepository.findAllByOrderByCreatedAtDesc(pageable);
+            return reviewRepository.findByDomainInOrderByCreatedAtDesc(domains, pageable);
         }
     }
 

--- a/src/main/java/com/smartchain/platform/domain/user/entity/Domain.java
+++ b/src/main/java/com/smartchain/platform/domain/user/entity/Domain.java
@@ -25,10 +25,14 @@ public class Domain extends BaseTimeEntity {
 
     private String description;
 
+    @Column(nullable = false)
+    private Boolean isActive = true;
+
     @Builder
-    public Domain(String code, String name, String description) {
+    public Domain(String code, String name, String description, Boolean isActive) {
         this.code = code;
         this.name = name;
         this.description = description;
+        this.isActive = isActive != null ? isActive : true;
     }
 }

--- a/src/main/java/com/smartchain/platform/domain/user/repository/DomainRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/user/repository/DomainRepository.java
@@ -4,10 +4,13 @@ import com.smartchain.platform.domain.user.entity.Domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface DomainRepository extends JpaRepository<Domain, Long> {
 
     Optional<Domain> findByCode(String code);
+
+    List<Domain> findByIsActiveTrue();
 }

--- a/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
@@ -4,6 +4,7 @@ import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
+import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.entity.Industry;
 import com.smartchain.platform.domain.user.entity.Role;
 import com.smartchain.platform.domain.user.entity.User;
@@ -37,6 +38,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -62,6 +64,9 @@ class ReviewServiceTest {
     private User guestUser;
 
     @Mock
+    private User reviewerWithoutDomain;
+
+    @Mock
     private Company testCompany;
 
     @Mock
@@ -79,19 +84,41 @@ class ReviewServiceTest {
     @Mock
     private Review testReview;
 
+    @Mock
+    private Domain envDomain;
+
+    @Mock
+    private Domain socDomain;
+
     @BeforeEach
     void setUp() {
         lenient().when(reviewerRole.getCode()).thenReturn("REVIEWER");
         lenient().when(guestRole.getCode()).thenReturn("GUEST");
 
+        lenient().when(envDomain.getCode()).thenReturn("ENV");
+        lenient().when(envDomain.getName()).thenReturn("환경");
+        lenient().when(envDomain.getDomainId()).thenReturn(1L);
+
+        lenient().when(socDomain.getCode()).thenReturn("SOC");
+        lenient().when(socDomain.getName()).thenReturn("사회");
+        lenient().when(socDomain.getDomainId()).thenReturn(2L);
+
         lenient().when(reviewerUser.getUserId()).thenReturn(1L);
         lenient().when(reviewerUser.getName()).thenReturn("심사자");
         lenient().when(reviewerUser.getEmail()).thenReturn("reviewer@test.com");
         lenient().when(reviewerUser.getRole()).thenReturn(reviewerRole);
+        lenient().when(reviewerUser.getDomainsWithRole("REVIEWER")).thenReturn(List.of(envDomain));
+        lenient().when(reviewerUser.hasRoleInDomain("ENV", "REVIEWER")).thenReturn(true);
+        lenient().when(reviewerUser.hasRoleInDomain("SOC", "REVIEWER")).thenReturn(false);
 
         lenient().when(guestUser.getUserId()).thenReturn(2L);
         lenient().when(guestUser.getName()).thenReturn("게스트");
         lenient().when(guestUser.getRole()).thenReturn(guestRole);
+
+        lenient().when(reviewerWithoutDomain.getUserId()).thenReturn(3L);
+        lenient().when(reviewerWithoutDomain.getName()).thenReturn("도메인없는심사자");
+        lenient().when(reviewerWithoutDomain.getRole()).thenReturn(reviewerRole);
+        lenient().when(reviewerWithoutDomain.getDomainsWithRole("REVIEWER")).thenReturn(List.of());
 
         lenient().when(testIndustry.getName()).thenReturn("제조업");
 
@@ -112,6 +139,7 @@ class ReviewServiceTest {
         lenient().when(testReview.getScore()).thenReturn(72);
         lenient().when(testReview.getRiskLevel()).thenReturn(RiskLevel.MEDIUM);
         lenient().when(testReview.getSubmittedAt()).thenReturn(LocalDateTime.now());
+        lenient().when(testReview.getDomain()).thenReturn(envDomain);
     }
 
     @Nested
@@ -119,30 +147,29 @@ class ReviewServiceTest {
     class GetDashboardTest {
 
         @Test
-        @DisplayName("REVIEWER가 대시보드 조회 성공")
-        void getDashboard_AsReviewer_Success() {
+        @DisplayName("REVIEWER가 도메인 필터링된 대시보드 조회 성공")
+        void getDashboard_AsReviewer_WithDomainFilter_Success() {
             // given
+            List<Domain> domains = List.of(envDomain);
             given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
-            given(reviewRepository.countDistinctCompanies()).willReturn(50L);
-            given(reviewRepository.countByStatus(ReviewStatus.REVIEWING)).willReturn(10L);
-            given(reviewRepository.countByStatus(ReviewStatus.APPROVED)).willReturn(30L);
-            given(reviewRepository.countByStatus(ReviewStatus.REVISION_REQUIRED)).willReturn(5L);
-            given(reviewRepository.countByRiskLevel(RiskLevel.HIGH)).willReturn(5L);
-            given(reviewRepository.countByRiskLevel(RiskLevel.MEDIUM)).willReturn(25L);
-            given(reviewRepository.countByRiskLevel(RiskLevel.LOW)).willReturn(15L);
-            given(reviewRepository.findTopNByOrderBySubmittedAtDesc(any())).willReturn(List.of(testReview));
+            given(reviewRepository.countDistinctCompaniesByDomainIn(domains)).willReturn(30L);
+            given(reviewRepository.countByDomainInAndStatus(domains, ReviewStatus.REVIEWING)).willReturn(5L);
+            given(reviewRepository.countByDomainInAndStatus(domains, ReviewStatus.APPROVED)).willReturn(20L);
+            given(reviewRepository.countByDomainInAndStatus(domains, ReviewStatus.REVISION_REQUIRED)).willReturn(3L);
+            given(reviewRepository.countByDomainInAndRiskLevel(domains, RiskLevel.HIGH)).willReturn(3L);
+            given(reviewRepository.countByDomainInAndRiskLevel(domains, RiskLevel.MEDIUM)).willReturn(15L);
+            given(reviewRepository.countByDomainInAndRiskLevel(domains, RiskLevel.LOW)).willReturn(10L);
+            given(reviewRepository.findByDomainInOrderBySubmittedAtDesc(eq(domains), any())).willReturn(List.of(testReview));
 
             // when
             ReviewDashboardResponse response = reviewService.getDashboard(1L, null, null, null);
 
             // then
             assertThat(response).isNotNull();
-            assertThat(response.getOverview().getTotalCompanies()).isEqualTo(50);
-            assertThat(response.getOverview().getInReviewCount()).isEqualTo(10);
-            assertThat(response.getOverview().getCompletedCount()).isEqualTo(30);
-            assertThat(response.getRiskDistribution().getHigh()).isEqualTo(5);
-            assertThat(response.getRiskDistribution().getMedium()).isEqualTo(25);
-            assertThat(response.getRiskDistribution().getLow()).isEqualTo(15);
+            assertThat(response.getOverview().getTotalCompanies()).isEqualTo(30);
+            assertThat(response.getOverview().getInReviewCount()).isEqualTo(5);
+            assertThat(response.getOverview().getCompletedCount()).isEqualTo(20);
+            assertThat(response.getRiskDistribution().getHigh()).isEqualTo(3);
             assertThat(response.getRecentActivities()).hasSize(1);
         }
 
@@ -160,6 +187,21 @@ class ReviewServiceTest {
                         assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_ACTION);
                     });
         }
+
+        @Test
+        @DisplayName("REVIEWER 역할이지만 도메인 권한이 없으면 실패")
+        void getDashboard_ReviewerWithoutDomain_ThrowsException() {
+            // given
+            given(userRepository.findById(3L)).willReturn(Optional.of(reviewerWithoutDomain));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.getDashboard(3L, null, null, null))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_ACTION);
+                    });
+        }
     }
 
     @Nested
@@ -167,19 +209,20 @@ class ReviewServiceTest {
     class GetReviewListTest {
 
         @Test
-        @DisplayName("REVIEWER가 심사 목록 조회 성공")
-        void getReviewList_AsReviewer_Success() {
+        @DisplayName("REVIEWER가 도메인 필터링된 심사 목록 조회 성공")
+        void getReviewList_AsReviewer_WithDomainFilter_Success() {
             // given
+            List<Domain> domains = List.of(envDomain);
             Page<Review> reviewPage = new PageImpl<>(List.of(testReview), PageRequest.of(0, 20), 1);
 
             given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
-            given(reviewRepository.findAllByOrderByCreatedAtDesc(any())).willReturn(reviewPage);
-            given(reviewRepository.countDistinctCompanies()).willReturn(50L);
-            given(reviewRepository.countByStatus(ReviewStatus.REVIEWING)).willReturn(10L);
-            given(reviewRepository.countByStatus(ReviewStatus.APPROVED)).willReturn(30L);
-            given(reviewRepository.countByRiskLevel(RiskLevel.HIGH)).willReturn(5L);
-            given(reviewRepository.countByRiskLevel(RiskLevel.MEDIUM)).willReturn(25L);
-            given(reviewRepository.countByRiskLevel(RiskLevel.LOW)).willReturn(15L);
+            given(reviewRepository.findByDomainInOrderByCreatedAtDesc(eq(domains), any())).willReturn(reviewPage);
+            given(reviewRepository.countDistinctCompaniesByDomainIn(domains)).willReturn(30L);
+            given(reviewRepository.countByDomainInAndStatus(domains, ReviewStatus.APPROVED)).willReturn(20L);
+            given(reviewRepository.countByDomainInAndStatus(domains, ReviewStatus.REVIEWING)).willReturn(5L);
+            given(reviewRepository.countByDomainInAndRiskLevel(domains, RiskLevel.HIGH)).willReturn(3L);
+            given(reviewRepository.countByDomainInAndRiskLevel(domains, RiskLevel.MEDIUM)).willReturn(15L);
+            given(reviewRepository.countByDomainInAndRiskLevel(domains, RiskLevel.LOW)).willReturn(10L);
 
             // when
             ReviewListResponse response = reviewService.getReviewList(1L, null, null, null, 0, 20);
@@ -188,41 +231,38 @@ class ReviewServiceTest {
             assertThat(response).isNotNull();
             assertThat(response.getContent()).hasSize(1);
             assertThat(response.getContent().get(0).getReviewId()).isEqualTo(1L);
-            assertThat(response.getContent().get(0).getScore()).isEqualTo(72);
-            assertThat(response.getContent().get(0).getRiskLevel()).isEqualTo("MEDIUM");
-            assertThat(response.getPage().getNumber()).isEqualTo(0);
-            assertThat(response.getPage().getTotalElements()).isEqualTo(1);
+            verify(reviewRepository).findByDomainInOrderByCreatedAtDesc(eq(domains), any());
         }
 
         @Test
-        @DisplayName("상태 필터로 심사 목록 조회 성공")
-        void getReviewList_WithStatusFilter_Success() {
+        @DisplayName("상태 필터 + 도메인 필터 조합 조회 성공")
+        void getReviewList_WithStatusAndDomainFilter_Success() {
             // given
+            List<Domain> domains = List.of(envDomain);
             Page<Review> reviewPage = new PageImpl<>(List.of(testReview), PageRequest.of(0, 20), 1);
 
             given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
-            given(reviewRepository.findByStatusOrderByCreatedAtDesc(eq(ReviewStatus.REVIEWING), any())).willReturn(reviewPage);
-            given(reviewRepository.countDistinctCompanies()).willReturn(50L);
-            given(reviewRepository.countByStatus(any())).willReturn(10L);
-            given(reviewRepository.countByRiskLevel(any())).willReturn(15L);
+            given(reviewRepository.findByDomainInAndStatusOrderByCreatedAtDesc(eq(domains), eq(ReviewStatus.REVIEWING), any())).willReturn(reviewPage);
+            given(reviewRepository.countDistinctCompaniesByDomainIn(domains)).willReturn(30L);
+            given(reviewRepository.countByDomainInAndStatus(eq(domains), any())).willReturn(10L);
+            given(reviewRepository.countByDomainInAndRiskLevel(eq(domains), any())).willReturn(10L);
 
             // when
             ReviewListResponse response = reviewService.getReviewList(1L, "REVIEWING", null, null, 0, 20);
 
             // then
             assertThat(response).isNotNull();
-            assertThat(response.getContent()).hasSize(1);
-            verify(reviewRepository).findByStatusOrderByCreatedAtDesc(eq(ReviewStatus.REVIEWING), any());
+            verify(reviewRepository).findByDomainInAndStatusOrderByCreatedAtDesc(eq(domains), eq(ReviewStatus.REVIEWING), any());
         }
     }
 
     @Nested
-    @DisplayName("심사 상세 조회 테스트")
-    class GetReviewDetailTest {
+    @DisplayName("심사 상세 조회 - 도메인 권한 검증 테스트")
+    class GetReviewDetailDomainTest {
 
         @Test
-        @DisplayName("심사 상세 조회 성공")
-        void getReviewDetail_Success() {
+        @DisplayName("해당 도메인 REVIEWER 권한이 있으면 상세 조회 성공")
+        void getReviewDetail_WithDomainPermission_Success() {
             // given
             given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
             given(reviewRepository.findById(1L)).willReturn(Optional.of(testReview));
@@ -234,11 +274,44 @@ class ReviewServiceTest {
             assertThat(response).isNotNull();
             assertThat(response.getReviewId()).isEqualTo(1L);
             assertThat(response.getDiagnostic().getDiagnosticId()).isEqualTo(100L);
-            assertThat(response.getDiagnostic().getDiagnosticCode()).isEqualTo("DG-2026-00001");
-            assertThat(response.getCompany().getCompanyId()).isEqualTo(10L);
-            assertThat(response.getScore()).isEqualTo(72);
-            assertThat(response.getRiskLevel()).isEqualTo("MEDIUM");
-            assertThat(response.getStatus()).isEqualTo("REVIEWING");
+        }
+
+        @Test
+        @DisplayName("다른 도메인의 심사 상세 조회 시 403 에러")
+        void getReviewDetail_WithoutDomainPermission_ThrowsException() {
+            // given
+            Review socReview = mock(Review.class);
+            when(socReview.getDomain()).thenReturn(socDomain);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(2L)).willReturn(Optional.of(socReview));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.getReviewDetail(1L, 2L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_ACTION);
+                    });
+        }
+
+        @Test
+        @DisplayName("도메인이 null인 심사 상세 조회 시 403 에러")
+        void getReviewDetail_NullDomain_ThrowsException() {
+            // given
+            Review noDomainReview = mock(Review.class);
+            when(noDomainReview.getDomain()).thenReturn(null);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(3L)).willReturn(Optional.of(noDomainReview));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.getReviewDetail(1L, 3L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_ACTION);
+                    });
         }
 
         @Test
@@ -259,12 +332,12 @@ class ReviewServiceTest {
     }
 
     @Nested
-    @DisplayName("심사 결과 입력 테스트")
-    class ProcessReviewTest {
+    @DisplayName("심사 결과 입력 - 도메인 권한 검증 테스트")
+    class ProcessReviewDomainTest {
 
         @Test
-        @DisplayName("심사 승인 성공")
-        void processReview_Approve_Success() {
+        @DisplayName("해당 도메인 REVIEWER 권한으로 심사 승인 성공")
+        void processReview_WithDomainPermission_Approve_Success() {
             // given
             when(testReview.isReviewing()).thenReturn(true);
             when(testReview.getStatus()).thenReturn(ReviewStatus.APPROVED);
@@ -287,6 +360,29 @@ class ReviewServiceTest {
             assertThat(response.getMessage()).isEqualTo("심사가 승인되었습니다");
             verify(testReview).approve(eq(reviewerUser), eq("ESG 관리 체계가 양호합니다"), any(), any(), any());
             verify(testDiagnostic).complete();
+        }
+
+        @Test
+        @DisplayName("다른 도메인 심사 결과 입력 시 403 에러")
+        void processReview_WithoutDomainPermission_ThrowsException() {
+            // given
+            Review socReview = mock(Review.class);
+            when(socReview.getDomain()).thenReturn(socDomain);
+
+            ReviewDecisionRequest request = ReviewDecisionRequest.builder()
+                    .decision("APPROVED")
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(2L)).willReturn(Optional.of(socReview));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.processReview(1L, 2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_ACTION);
+                    });
         }
 
         @Test


### PR DESCRIPTION
## 변경 요약
- ReviewService의 모든 메서드(`getReviewList`, `getReviewDetail`, `processReview`, `getDashboard`)에 도메인별 REVIEWER 권한 검증 추가
- 심사 목록/대시보드: `User.getDomainsWithRole("REVIEWER")`로 허용 도메인 목록을 조회하여 해당 도메인 심사만 필터링
- 심사 상세/결과 입력: `Review.domain` 필드 기반으로 사용자의 도메인별 REVIEWER 권한 검증
- ReviewRepository에 `domainIn` 기반 조회/통계 쿼리 메서드 추가
- Domain 엔티티에 `isActive` 필드 추가 (기존 빌드 오류 수정)

## 관련 이슈
- Closes #9

## 테스트 방법
```bash
./gradlew test --tests "ReviewServiceTest"
```
- 15개 테스트 케이스 (기존 + 신규 도메인 권한 검증 테스트)
  - 도메인 필터링된 대시보드 조회 성공
  - REVIEWER 역할이지만 도메인 권한 없으면 실패 (403)
  - 다른 도메인 심사 상세 조회 시 403
  - 도메인 null인 심사 접근 시 403
  - 다른 도메인 심사 결과 입력 시 403
  - 상태 필터 + 도메인 필터 조합 조회 성공

## 명세 준수 체크
- [x] 심사 목록 조회 시 도메인별 필터링 적용됨
- [x] 심사 결과 입력 시 해당 도메인 REVIEWER 권한 검증됨
- [x] 대시보드에서 도메인별 통계 확인 가능
- [x] 권한 없는 도메인 심사 시도 시 403 에러 반환됨
- [x] 단위 테스트 통과
- [x] `./gradlew test && ./gradlew build` 통과

## 리뷰 포인트
1. `getPermittedReviewerDomains()`에서 도메인이 비어있으면 즉시 403을 반환하는 방식이 적절한지
2. `findReviewsWithDomainFilters()`의 조합 분기 방식 — Specification 패턴으로 리팩터링 고려 여부
3. Domain 엔티티에 `isActive` 필드 추가는 기존 빌드 오류 수정 목적 (별도 이슈 분리 필요 시 의견)

## TODO / 질문
- [ ] `getDashboard`의 `categoryAverages`는 현재 고정값 — 도메인별 실제 카테고리 평균 계산 로직 필요 (별도 이슈)
- [ ] `getDomainsWithRole("REVIEWER")`는 User 엔티티의 `domainRoles` 컬렉션을 lazy load — N+1 이슈 확인 필요
- [ ] Specification 패턴 도입으로 필터 조합 분기 개선 검토 필요