### PR TITLE
#10 [feat] : @DomainAuthorization 커스텀 어노테이션 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
 	// Spring Boot
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/smartchain/platform/domain/user/entity/Domain.java
+++ b/src/main/java/com/smartchain/platform/domain/user/entity/Domain.java
@@ -25,10 +25,14 @@ public class Domain extends BaseTimeEntity {
 
     private String description;
 
+    @Column(nullable = false)
+    private Boolean isActive = true;
+
     @Builder
-    public Domain(String code, String name, String description) {
+    public Domain(String code, String name, String description, Boolean isActive) {
         this.code = code;
         this.name = name;
         this.description = description;
+        this.isActive = isActive != null ? isActive : true;
     }
 }

--- a/src/main/java/com/smartchain/platform/domain/user/repository/DomainRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/user/repository/DomainRepository.java
@@ -4,10 +4,13 @@ import com.smartchain.platform.domain.user.entity.Domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface DomainRepository extends JpaRepository<Domain, Long> {
 
     Optional<Domain> findByCode(String code);
+
+    List<Domain> findByIsActiveTrue();
 }

--- a/src/main/java/com/smartchain/platform/global/security/DomainAuthorization.java
+++ b/src/main/java/com/smartchain/platform/global/security/DomainAuthorization.java
@@ -1,0 +1,40 @@
+package com.smartchain.platform.global.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 도메인별 권한 검증 어노테이션.
+ *
+ * <p>Controller 메서드에 선언하면 AOP가 요청 파라미터/바디에서
+ * domainCode를 추출하여 현재 사용자의 해당 도메인 역할을 검증합니다.</p>
+ *
+ * <h3>사용 예시</h3>
+ * <pre>{@code
+ * @DomainAuthorization(roles = {"DRAFTER", "APPROVER"})
+ * @PostMapping("/diagnostics")
+ * public ResponseEntity<?> create(HttpServletRequest request, @RequestBody CreateRequest body) { ... }
+ *
+ * @DomainAuthorization(roles = {"REVIEWER"}, domainCodeParam = "domainCode")
+ * @GetMapping("/reviews")
+ * public ResponseEntity<?> list(HttpServletRequest request, @RequestParam String domainCode) { ... }
+ * }</pre>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DomainAuthorization {
+
+    /**
+     * 허용되는 도메인 역할 코드 목록.
+     * 사용자가 해당 도메인에서 이 역할들 중 하나라도 가지고 있어야 합니다.
+     */
+    String[] roles();
+
+    /**
+     * domainCode를 추출할 요청 파라미터/필드 이름.
+     * 기본값은 "domainCode"이며, 요청 파라미터 → 요청 바디 순서로 탐색합니다.
+     */
+    String domainCodeParam() default "domainCode";
+}

--- a/src/main/java/com/smartchain/platform/global/security/DomainAuthorizationAspect.java
+++ b/src/main/java/com/smartchain/platform/global/security/DomainAuthorizationAspect.java
@@ -1,0 +1,113 @@
+package com.smartchain.platform.global.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartchain.platform.domain.user.entity.User;
+import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Arrays;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DomainAuthorizationAspect {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    @Before("@annotation(domainAuthorization)")
+    public void checkDomainAuthorization(JoinPoint joinPoint, DomainAuthorization domainAuthorization) {
+        String[] requiredRoles = domainAuthorization.roles();
+        String domainCodeParam = domainAuthorization.domainCodeParam();
+
+        // 1. HttpServletRequest에서 userId 추출
+        HttpServletRequest request = getCurrentRequest();
+        Long userId = extractUserId(request);
+
+        // 2. domainCode 추출 (파라미터 → 바디)
+        String domainCode = extractDomainCode(request, joinPoint.getArgs(), domainCodeParam);
+        if (!StringUtils.hasText(domainCode)) {
+            log.warn("domainCode not found in request for param '{}'", domainCodeParam);
+            throw new CustomException(ErrorCode.INVALID_INPUT, "domainCode가 요청에 포함되어 있지 않습니다");
+        }
+
+        // 3. 사용자 조회 및 도메인 권한 검증
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        boolean hasPermission = user.hasAnyRoleInDomain(domainCode, requiredRoles);
+        if (!hasPermission) {
+            log.warn("Domain authorization failed: userId={}, domainCode={}, requiredRoles={}",
+                    userId, domainCode, Arrays.toString(requiredRoles));
+            throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);
+        }
+
+        log.debug("Domain authorization passed: userId={}, domainCode={}, roles={}",
+                userId, domainCode, Arrays.toString(requiredRoles));
+    }
+
+    private HttpServletRequest getCurrentRequest() {
+        ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attrs == null) {
+            throw new CustomException(ErrorCode.INTERNAL_ERROR, "요청 컨텍스트를 찾을 수 없습니다");
+        }
+        return attrs.getRequest();
+    }
+
+    private Long extractUserId(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7);
+            return jwtTokenProvider.getUserIdFromToken(token);
+        }
+        throw new CustomException(ErrorCode.INVALID_TOKEN);
+    }
+
+    private String extractDomainCode(HttpServletRequest request, Object[] args, String paramName) {
+        // 1. 요청 파라미터에서 추출
+        String domainCode = request.getParameter(paramName);
+        if (StringUtils.hasText(domainCode)) {
+            return domainCode;
+        }
+
+        // 2. 메서드 인자(RequestBody)에서 추출
+        for (Object arg : args) {
+            if (arg == null || arg instanceof HttpServletRequest) {
+                continue;
+            }
+            domainCode = extractFromObject(arg, paramName);
+            if (StringUtils.hasText(domainCode)) {
+                return domainCode;
+            }
+        }
+
+        return null;
+    }
+
+    private String extractFromObject(Object obj, String fieldName) {
+        try {
+            JsonNode node = objectMapper.valueToTree(obj);
+            JsonNode fieldNode = node.get(fieldName);
+            if (fieldNode != null && !fieldNode.isNull()) {
+                return fieldNode.asText();
+            }
+        } catch (Exception e) {
+            log.debug("Failed to extract '{}' from object of type {}: {}", fieldName, obj.getClass().getSimpleName(), e.getMessage());
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/smartchain/platform/global/security/DomainAuthorizationAspectTest.java
+++ b/src/test/java/com/smartchain/platform/global/security/DomainAuthorizationAspectTest.java
@@ -1,0 +1,208 @@
+package com.smartchain.platform.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartchain.platform.domain.user.entity.User;
+import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.JoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DomainAuthorizationAspectTest {
+
+    @InjectMocks
+    private DomainAuthorizationAspect aspect;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JoinPoint joinPoint;
+
+    @Mock
+    private DomainAuthorization domainAuthorization;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private User user;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        // Replace ObjectMapper mock with real instance via reflection
+        try {
+            var field = DomainAuthorizationAspect.class.getDeclaredField("objectMapper");
+            field.setAccessible(true);
+            field.set(aspect, objectMapper);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+
+    @Nested
+    @DisplayName("도메인 권한 검증 테스트")
+    class CheckDomainAuthorizationTest {
+
+        @Test
+        @DisplayName("요청 파라미터에서 domainCode 추출 후 권한 검증 성공")
+        void checkAuth_WithRequestParam_Success() {
+            // given
+            when(domainAuthorization.roles()).thenReturn(new String[]{"DRAFTER", "APPROVER"});
+            when(domainAuthorization.domainCodeParam()).thenReturn("domainCode");
+            when(request.getHeader("Authorization")).thenReturn("Bearer test-token");
+            when(jwtTokenProvider.getUserIdFromToken("test-token")).thenReturn(1L);
+            when(request.getParameter("domainCode")).thenReturn("ENV");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(user.hasAnyRoleInDomain("ENV", new String[]{"DRAFTER", "APPROVER"})).thenReturn(true);
+            when(joinPoint.getArgs()).thenReturn(new Object[]{request});
+
+            // when & then
+            assertThatCode(() -> aspect.checkDomainAuthorization(joinPoint, domainAuthorization))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("도메인 권한이 없으면 PERMISSION_DENIED_ACTION 에러")
+        void checkAuth_WithoutPermission_ThrowsException() {
+            // given
+            when(domainAuthorization.roles()).thenReturn(new String[]{"REVIEWER"});
+            when(domainAuthorization.domainCodeParam()).thenReturn("domainCode");
+            when(request.getHeader("Authorization")).thenReturn("Bearer test-token");
+            when(jwtTokenProvider.getUserIdFromToken("test-token")).thenReturn(1L);
+            when(request.getParameter("domainCode")).thenReturn("ENV");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(user.hasAnyRoleInDomain("ENV", new String[]{"REVIEWER"})).thenReturn(false);
+            when(joinPoint.getArgs()).thenReturn(new Object[]{request});
+
+            // when & then
+            assertThatThrownBy(() -> aspect.checkDomainAuthorization(joinPoint, domainAuthorization))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assert ce.getErrorCode() == ErrorCode.PERMISSION_DENIED_ACTION;
+                    });
+        }
+
+        @Test
+        @DisplayName("domainCode가 요청에 없으면 INVALID_INPUT 에러")
+        void checkAuth_MissingDomainCode_ThrowsException() {
+            // given
+            when(domainAuthorization.roles()).thenReturn(new String[]{"DRAFTER"});
+            when(domainAuthorization.domainCodeParam()).thenReturn("domainCode");
+            when(request.getHeader("Authorization")).thenReturn("Bearer test-token");
+            when(jwtTokenProvider.getUserIdFromToken("test-token")).thenReturn(1L);
+            when(request.getParameter("domainCode")).thenReturn(null);
+            when(joinPoint.getArgs()).thenReturn(new Object[]{request});
+
+            // when & then
+            assertThatThrownBy(() -> aspect.checkDomainAuthorization(joinPoint, domainAuthorization))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assert ce.getErrorCode() == ErrorCode.INVALID_INPUT;
+                    });
+        }
+
+        @Test
+        @DisplayName("Authorization 헤더가 없으면 INVALID_TOKEN 에러")
+        void checkAuth_MissingToken_ThrowsException() {
+            // given
+            when(domainAuthorization.roles()).thenReturn(new String[]{"DRAFTER"});
+            when(domainAuthorization.domainCodeParam()).thenReturn("domainCode");
+            when(request.getHeader("Authorization")).thenReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> aspect.checkDomainAuthorization(joinPoint, domainAuthorization))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assert ce.getErrorCode() == ErrorCode.INVALID_TOKEN;
+                    });
+        }
+
+        @Test
+        @DisplayName("RequestBody에서 domainCode 추출 후 권한 검증 성공")
+        void checkAuth_WithRequestBody_Success() {
+            // given
+            when(domainAuthorization.roles()).thenReturn(new String[]{"DRAFTER"});
+            when(domainAuthorization.domainCodeParam()).thenReturn("domainCode");
+            when(request.getHeader("Authorization")).thenReturn("Bearer test-token");
+            when(jwtTokenProvider.getUserIdFromToken("test-token")).thenReturn(1L);
+            when(request.getParameter("domainCode")).thenReturn(null); // 파라미터에 없음
+
+            // RequestBody 객체 시뮬레이션
+            TestRequestBody body = new TestRequestBody("ENV", "test");
+            when(joinPoint.getArgs()).thenReturn(new Object[]{request, body});
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(user.hasAnyRoleInDomain("ENV", new String[]{"DRAFTER"})).thenReturn(true);
+
+            // when & then
+            assertThatCode(() -> aspect.checkDomainAuthorization(joinPoint, domainAuthorization))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 USER_NOT_FOUND 에러")
+        void checkAuth_UserNotFound_ThrowsException() {
+            // given
+            when(domainAuthorization.roles()).thenReturn(new String[]{"DRAFTER"});
+            when(domainAuthorization.domainCodeParam()).thenReturn("domainCode");
+            when(request.getHeader("Authorization")).thenReturn("Bearer test-token");
+            when(jwtTokenProvider.getUserIdFromToken("test-token")).thenReturn(999L);
+            when(request.getParameter("domainCode")).thenReturn("ENV");
+            when(userRepository.findById(999L)).thenReturn(Optional.empty());
+            when(joinPoint.getArgs()).thenReturn(new Object[]{request});
+
+            // when & then
+            assertThatThrownBy(() -> aspect.checkDomainAuthorization(joinPoint, domainAuthorization))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assert ce.getErrorCode() == ErrorCode.USER_NOT_FOUND;
+                    });
+        }
+    }
+
+    // RequestBody 시뮬레이션용 inner class
+    static class TestRequestBody {
+        private String domainCode;
+        private String title;
+
+        public TestRequestBody() {}
+
+        public TestRequestBody(String domainCode, String title) {
+            this.domainCode = domainCode;
+            this.title = title;
+        }
+
+        public String getDomainCode() { return domainCode; }
+        public void setDomainCode(String domainCode) { this.domainCode = domainCode; }
+        public String getTitle() { return title; }
+        public void setTitle(String title) { this.title = title; }
+    }
+}


### PR DESCRIPTION
## 변경 요약
- `@DomainAuthorization(roles = {"DRAFTER", "APPROVER"})` 커스텀 어노테이션 생성
- `DomainAuthorizationAspect` AOP 구현: Controller 메서드 실행 전 도메인별 권한을 자동 검증
- JWT Authorization 헤더에서 userId 추출 → 요청 파라미터/바디에서 domainCode 추출 → `User.hasAnyRoleInDomain()` 검증
- `spring-boot-starter-aop` 의존성 추가
- Domain 엔티티에 `isActive` 필드 추가 (기존 빌드 오류 수정)

### 사용 예시
```java
// 요청 파라미터에서 domainCode 추출
@DomainAuthorization(roles = {"REVIEWER"}, domainCodeParam = "domainCode")
@GetMapping("/reviews")
public ResponseEntity<?> list(HttpServletRequest request, @RequestParam String domainCode) { ... }

// RequestBody에서 domainCode 추출
@DomainAuthorization(roles = {"DRAFTER", "APPROVER"})
@PostMapping("/diagnostics")
public ResponseEntity<?> create(HttpServletRequest request, @RequestBody CreateRequest body) { ... }
```

## 관련 이슈
- Closes #10

## 테스트 방법
```bash
./gradlew test --tests "DomainAuthorizationAspectTest"
```
- 6개 테스트 케이스:
  - 요청 파라미터에서 domainCode 추출 후 권한 검증 성공
  - RequestBody에서 domainCode 추출 후 권한 검증 성공
  - 도메인 권한 없으면 PERMISSION_DENIED_ACTION (403)
  - domainCode 누락 시 INVALID_INPUT (400)
  - Authorization 헤더 없으면 INVALID_TOKEN (401)
  - 사용자 없으면 USER_NOT_FOUND (404)

## 명세 준수 체크
- [x] @DomainAuthorization 어노테이션 생성됨
- [x] DomainAuthorizationAspect 구현됨
- [x] domainCode 파라미터/바디 자동 추출됨
- [x] 권한 실패 시 CustomException(PERMISSION_DENIED_ACTION) 발생
- [x] 사용 예시 Javadoc 문서화
- [x] `./gradlew test && ./gradlew build` 통과

## 리뷰 포인트
1. `extractFromObject()`에서 Jackson `valueToTree`로 RequestBody 필드 추출 — 성능 영향 검토 필요 (매 요청마다 직렬화)
2. 기존 Service 레이어 권한 로직과 병행 운영 방침 — 점진적 마이그레이션 전략
3. `@Before` 어드바이스에서 `RequestContextHolder`로 HttpServletRequest 획득하는 방식의 적절성

## TODO / 질문
- [ ] 클래스 레벨 적용은 범위(Out)이므로 추후 필요시 별도 이슈로 처리
- [ ] PathVariable에서 domainCode를 추출하는 케이스 추가 고려 (현재 미지원)
- [ ] 기존 Service 레이어의 validateReviewerRole/validateDomainAccess 로직을 어노테이션으로 대체할 마이그레이션 계획 수립 필요