### PR TITLE
#11 [feat] : DiagnosticController 도메인 파라미터 추가

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/diagnostic/controller/DiagnosticController.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/controller/DiagnosticController.java
@@ -34,10 +34,12 @@ public class DiagnosticController {
     private final DiagnosticService diagnosticService;
     private final JwtTokenProvider jwtTokenProvider;
 
-    @Operation(summary = "기안 목록 조회", description = "기안 목록을 조회합니다. DRAFTER는 본인 기안만, APPROVER는 소속 회사 전체 기안을 조회합니다.")
+    @Operation(summary = "기안 목록 조회", description = "기안 목록을 조회합니다. DRAFTER는 본인 기안만, APPROVER는 소속 회사 전체 기안을 조회합니다. domainCode로 특정 도메인 필터링 가능합니다.")
     @GetMapping
     public ResponseEntity<BaseResponse<DiagnosticListResponse>> getDiagnosticList(
             HttpServletRequest request,
+            @Parameter(description = "도메인 코드 필터 (예: ENV, SOC, GOV)")
+            @RequestParam(required = false) String domainCode,
             @Parameter(description = "상태 필터 (쉼표로 구분, 예: WRITING,SUBMITTED)")
             @RequestParam(required = false) String statuses,
             @Parameter(description = "마감일 시작")
@@ -47,7 +49,7 @@ public class DiagnosticController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         Long userId = extractUserIdFromRequest(request);
-        DiagnosticListResponse response = diagnosticService.getDiagnosticList(userId, statuses, deadlineFrom, deadlineTo, page, size);
+        DiagnosticListResponse response = diagnosticService.getDiagnosticList(userId, domainCode, statuses, deadlineFrom, deadlineTo, page, size);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -73,7 +73,7 @@ public class DiagnosticService {
             "COMPLETED", "완료"
     );
 
-    public DiagnosticListResponse getDiagnosticList(Long userId, String statuses, LocalDate deadlineFrom,
+    public DiagnosticListResponse getDiagnosticList(Long userId, String domainCode, String statuses, LocalDate deadlineFrom,
                                                      LocalDate deadlineTo, int page, int size) {
         User currentUser = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -98,7 +98,14 @@ public class DiagnosticService {
         // 도메인 역할이 없으면 레거시 로직 사용
         boolean hasDomainRoles = !reviewerDomains.isEmpty() || !approverDomains.isEmpty() || !drafterDomains.isEmpty();
         if (!hasDomainRoles) {
-            return getDiagnosticListLegacy(currentUser, userCompany, statuses, deadlineFrom, deadlineTo, page, size);
+            return getDiagnosticListLegacy(currentUser, userCompany, domainCode, statuses, deadlineFrom, deadlineTo, page, size);
+        }
+
+        // domainCode 파라미터가 있으면 해당 도메인으로 필터링
+        if (domainCode != null && !domainCode.isEmpty()) {
+            reviewerDomains = reviewerDomains.stream().filter(d -> d.getCode().equals(domainCode)).toList();
+            approverDomains = approverDomains.stream().filter(d -> d.getCode().equals(domainCode)).toList();
+            drafterDomains = drafterDomains.stream().filter(d -> d.getCode().equals(domainCode)).toList();
         }
 
         // 빈 리스트를 placeholder 도메인으로 대체 (JPQL IN 절 처리)
@@ -154,7 +161,7 @@ public class DiagnosticService {
      * 레거시: 도메인 역할이 없는 사용자용 기안 목록 조회
      */
     private DiagnosticListResponse getDiagnosticListLegacy(User currentUser, Company userCompany,
-                                                            String statuses, LocalDate deadlineFrom,
+                                                            String domainCode, String statuses, LocalDate deadlineFrom,
                                                             LocalDate deadlineTo, int page, int size) {
         validateAccessRole(currentUser);
 
@@ -165,7 +172,12 @@ public class DiagnosticService {
         Pageable pageable = PageRequest.of(page, size);
         Page<Diagnostic> diagnosticPage;
 
-        if (statuses != null && !statuses.isEmpty()) {
+        // domainCode 필터가 있으면 도메인별 조회
+        if (domainCode != null && !domainCode.isEmpty()) {
+            Domain domain = domainRepository.findByCode(domainCode)
+                    .orElseThrow(() -> new CustomException(ErrorCode.DOMAIN_NOT_FOUND));
+            diagnosticPage = diagnosticRepository.findByDomainOrderByCreatedAtDesc(domain, pageable);
+        } else if (statuses != null && !statuses.isEmpty()) {
             List<DiagnosticStatus> statusList = parseStatuses(statuses);
             diagnosticPage = diagnosticRepository.findByCompanyAndStatusInOrderByCreatedAtDesc(
                     userCompany, statusList, pageable);
@@ -241,9 +253,20 @@ public class DiagnosticService {
                     .build();
         }
 
+        DomainSimpleDto domainDto = null;
+        if (diagnostic.getDomain() != null) {
+            Domain domain = diagnostic.getDomain();
+            domainDto = DomainSimpleDto.builder()
+                    .domainId(domain.getDomainId())
+                    .code(domain.getCode())
+                    .name(domain.getName())
+                    .build();
+        }
+
         return DiagnosticDetailResponse.builder()
                 .diagnosticId(diagnostic.getDiagnosticId())
                 .diagnosticCode(diagnostic.getDiagnosticCode())
+                .domain(domainDto)
                 .campaign(campaignDto)
                 .company(companyDto)
                 .period(periodDto)
@@ -578,9 +601,20 @@ public class DiagnosticService {
                 .overall(diagnostic.getOverallProgress())
                 .build();
 
+        DomainSimpleDto domainDto = null;
+        if (diagnostic.getDomain() != null) {
+            Domain domain = diagnostic.getDomain();
+            domainDto = DomainSimpleDto.builder()
+                    .domainId(domain.getDomainId())
+                    .code(domain.getCode())
+                    .name(domain.getName())
+                    .build();
+        }
+
         return DiagnosticListItemDto.builder()
                 .diagnosticId(diagnostic.getDiagnosticId())
                 .diagnosticCode(diagnostic.getDiagnosticCode())
+                .domain(domainDto)
                 .campaign(campaignDto)
                 .summary(diagnostic.getTitle())
                 .period(periodDto)

--- a/src/main/java/com/smartchain/platform/domain/user/entity/Domain.java
+++ b/src/main/java/com/smartchain/platform/domain/user/entity/Domain.java
@@ -25,10 +25,14 @@ public class Domain extends BaseTimeEntity {
 
     private String description;
 
+    @Column(nullable = false)
+    private Boolean isActive = true;
+
     @Builder
-    public Domain(String code, String name, String description) {
+    public Domain(String code, String name, String description, Boolean isActive) {
         this.code = code;
         this.name = name;
         this.description = description;
+        this.isActive = isActive != null ? isActive : true;
     }
 }

--- a/src/main/java/com/smartchain/platform/domain/user/repository/DomainRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/user/repository/DomainRepository.java
@@ -4,10 +4,13 @@ import com.smartchain.platform.domain.user.entity.Domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface DomainRepository extends JpaRepository<Domain, Long> {
 
     Optional<Domain> findByCode(String code);
+
+    List<Domain> findByIsActiveTrue();
 }

--- a/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
@@ -9,6 +9,7 @@ import com.smartchain.platform.domain.diagnostic.repository.CampaignRepository;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticHistoryRepository;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
 import com.smartchain.platform.domain.user.entity.Company;
+import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.entity.Role;
 import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.domain.user.entity.UserDomainRole;
@@ -154,7 +155,7 @@ class DiagnosticServiceTest {
                     .willReturn(diagnosticPage);
 
             // when
-            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, null, null, null, 0, 10);
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, null, null, null, null, 0, 10);
 
             // then
             assertThat(response).isNotNull();
@@ -190,7 +191,7 @@ class DiagnosticServiceTest {
                     .willReturn(diagnosticPage);
 
             // when
-            DiagnosticListResponse response = diagnosticService.getDiagnosticList(2L, null, null, null, 0, 10);
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(2L, null, null, null, null, 0, 10);
 
             // then
             assertThat(response).isNotNull();
@@ -208,7 +209,7 @@ class DiagnosticServiceTest {
             given(userRepository.findById(99L)).willReturn(Optional.of(guestUser));
 
             // when & then
-            assertThatThrownBy(() -> diagnosticService.getDiagnosticList(99L, null, null, null, 0, 10))
+            assertThatThrownBy(() -> diagnosticService.getDiagnosticList(99L, null, null, null, null, 0, 10))
                     .isInstanceOf(CustomException.class)
                     .satisfies(ex -> {
                         CustomException ce = (CustomException) ex;
@@ -580,6 +581,114 @@ class DiagnosticServiceTest {
             assertThat(response.getHistory()).hasSize(1);
             assertThat(response.getHistory().get(0).getAction()).isEqualTo("CREATED");
             assertThat(response.getHistory().get(0).getNewStatus()).isEqualTo("WRITING");
+        }
+    }
+
+    @Nested
+    @DisplayName("도메인 파라미터 관련 테스트")
+    class DomainParameterTest {
+
+        @Test
+        @DisplayName("domainCode 필터로 기안 목록 조회 성공 (레거시)")
+        void getDiagnosticList_WithDomainCodeFilter_Legacy_Success() {
+            // given
+            Domain envDomain = mock(Domain.class);
+            when(envDomain.getDomainId()).thenReturn(1L);
+            when(envDomain.getCode()).thenReturn("ENV");
+            when(envDomain.getName()).thenReturn("환경");
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            lenient().when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            lenient().when(diagnostic.getDiagnosticCode()).thenReturn("DG-2026-00001");
+            lenient().when(diagnostic.getTitle()).thenReturn("2026년 ESG 자가진단");
+            lenient().when(diagnostic.getCampaign()).thenReturn(testCampaign);
+            lenient().when(diagnostic.getCompany()).thenReturn(testCompany);
+            lenient().when(diagnostic.getDomain()).thenReturn(envDomain);
+            lenient().when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.WRITING);
+            lenient().when(diagnostic.getPeriodStartDate()).thenReturn(LocalDate.of(2026, 1, 1));
+            lenient().when(diagnostic.getPeriodEndDate()).thenReturn(LocalDate.of(2026, 12, 31));
+            lenient().when(diagnostic.getDeadline()).thenReturn(LocalDate.of(2026, 3, 31));
+            lenient().when(diagnostic.getQualitativeProgress()).thenReturn(0);
+            lenient().when(diagnostic.getQuantitativeProgress()).thenReturn(0);
+            lenient().when(diagnostic.getOverallProgress()).thenReturn(0);
+            lenient().when(diagnostic.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            Page<Diagnostic> diagnosticPage = new PageImpl<>(List.of(diagnostic), PageRequest.of(0, 10), 1);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(domainRepository.findByCode("ENV")).willReturn(Optional.of(envDomain));
+            given(diagnosticRepository.findByDomainOrderByCreatedAtDesc(eq(envDomain), any()))
+                    .willReturn(diagnosticPage);
+
+            // when
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, "ENV", null, null, null, 0, 10);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).hasSize(1);
+            assertThat(response.getContent().get(0).getDomain()).isNotNull();
+            assertThat(response.getContent().get(0).getDomain().getCode()).isEqualTo("ENV");
+            assertThat(response.getContent().get(0).getDomain().getName()).isEqualTo("환경");
+            verify(diagnosticRepository).findByDomainOrderByCreatedAtDesc(eq(envDomain), any());
+        }
+
+        @Test
+        @DisplayName("상세 조회 시 도메인 정보가 응답에 포함됨")
+        void getDiagnosticDetail_IncludesDomainInfo() {
+            // given
+            Domain envDomain = mock(Domain.class);
+            when(envDomain.getDomainId()).thenReturn(1L);
+            when(envDomain.getCode()).thenReturn("ENV");
+            when(envDomain.getName()).thenReturn("환경");
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            when(diagnostic.getDiagnosticCode()).thenReturn("DG-2026-00001");
+            when(diagnostic.getCampaign()).thenReturn(testCampaign);
+            when(diagnostic.getCompany()).thenReturn(testCompany);
+            when(diagnostic.getDomain()).thenReturn(envDomain);
+            when(diagnostic.getDrafterId()).thenReturn(1L);
+            when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.WRITING);
+            when(diagnostic.getPeriodStartDate()).thenReturn(LocalDate.of(2026, 1, 1));
+            when(diagnostic.getPeriodEndDate()).thenReturn(LocalDate.of(2026, 12, 31));
+            when(diagnostic.getDeadline()).thenReturn(LocalDate.of(2026, 3, 31));
+            when(diagnostic.getQualitativeProgress()).thenReturn(50);
+            when(diagnostic.getQuantitativeProgress()).thenReturn(30);
+            when(diagnostic.getOverallProgress()).thenReturn(40);
+            when(diagnostic.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            // 도메인 기반 접근 검증을 통과하도록 설정
+            when(drafterUser.hasAnyRoleInDomain("ENV", "DRAFTER", "APPROVER", "REVIEWER")).thenReturn(true);
+            when(drafterUser.hasRoleInDomain("ENV", "DRAFTER")).thenReturn(true);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(1L)).willReturn(Optional.of(diagnostic));
+
+            // when
+            DiagnosticDetailResponse response = diagnosticService.getDiagnosticDetail(1L, 1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getDomain()).isNotNull();
+            assertThat(response.getDomain().getDomainId()).isEqualTo(1L);
+            assertThat(response.getDomain().getCode()).isEqualTo("ENV");
+            assertThat(response.getDomain().getName()).isEqualTo("환경");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 domainCode 필터 시 DOMAIN_NOT_FOUND")
+        void getDiagnosticList_InvalidDomainCode_ThrowsException() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(domainRepository.findByCode("INVALID")).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> diagnosticService.getDiagnosticList(1L, "INVALID", null, null, null, 0, 10))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.DOMAIN_NOT_FOUND);
+                    });
         }
     }
 }


### PR DESCRIPTION
## 변경 요약
- **GET `/api/v1/diagnostics`**: `domainCode` 쿼리 파라미터 추가 (선택) — 특정 도메인의 기안만 필터링
- **POST `/api/v1/diagnostics`**: RequestBody에 `domainCode` 필수 검증 (기존 `@NotNull` 유지)
- **GET `/api/v1/diagnostics/{id}`**: Response에 `DomainSimpleDto` (domainId, code, name) 포함
- 목록 아이템(`DiagnosticListItemDto`)에도 도메인 정보 포함
- Swagger UI에 domainCode 파라미터 설명 추가
- Domain 엔티티에 `isActive` 필드 추가 (기존 빌드 오류 수정)

## 관련 이슈
- Closes #11

## 테스트 방법
```bash
./gradlew test --tests "DiagnosticServiceTest"
```
- 기존 테스트 + 신규 3개:
  - `domainCode` 필터로 기안 목록 조회 성공 (레거시 경로)
  - 상세 조회 시 도메인 정보가 응답에 포함됨
  - 존재하지 않는 domainCode 필터 시 DOMAIN_NOT_FOUND

### 수동 테스트 (Swagger)
```
GET /api/v1/diagnostics?domainCode=ENV
GET /api/v1/diagnostics/1  → response.domain 확인
POST /api/v1/diagnostics   → body에 domainCode 필수
```

## 명세 준수 체크
- [x] 목록 조회 API에 domainCode 필터 동작함
- [x] 생성 API에서 domainCode 필수 검증됨 (`@NotNull`)
- [x] 상세 조회 응답에 도메인 정보 포함됨
- [x] Swagger UI에서 파라미터 확인 가능
- [x] `./gradlew test && ./gradlew build` 통과

## 리뷰 포인트
1. 레거시 경로에서 `domainCode` 필터 시 `findByDomainOrderByCreatedAtDesc`로 조회 — 회사 필터와의 조합 필요 여부
2. 도메인 기반 경로에서 `domainCode` 필터 시 각 역할 도메인 리스트를 stream filter하는 방식의 적절성
3. `mapToListItemDto`에 domain 매핑 추가 — 기존 API 응답 형식 호환성

## TODO / 질문
- [ ] API 문서(API_SPECIFICATION.md) 업데이트는 별도 커밋/이슈로 분리할지?
- [ ] 레거시 경로에서 domainCode + statuses 조합 필터 지원 필요 시 repository 메서드 추가 필요
- [ ] domainCode 필터와 deadlineFrom/To 조합 지원 여부