### PR TITLE
#39 [feat] AI Run API 공통 클라이언트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'  // WebClient for AI API
 	// Swagger (API 문서화)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 	// JWT (인증)

--- a/src/main/java/com/smartchain/platform/domain/ai/client/AiRunApiClient.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/client/AiRunApiClient.java
@@ -1,0 +1,114 @@
+package com.smartchain.platform.domain.ai.client;
+
+import com.smartchain.platform.dto.ai.run.RunPreviewRequest;
+import com.smartchain.platform.dto.ai.run.RunPreviewResponse;
+import com.smartchain.platform.dto.ai.run.RunSubmitRequest;
+import com.smartchain.platform.dto.ai.run.RunSubmitResponse;
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+
+/**
+ * AI Run API 클라이언트
+ * 공통 /run/preview, /run/submit 엔드포인트 호출
+ */
+@Component
+public class AiRunApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(AiRunApiClient.class);
+
+    private final WebClient webClient;
+    private final int maxRetry;
+
+    public AiRunApiClient(
+        @Qualifier("aiRunApiWebClient") WebClient webClient,
+        com.smartchain.platform.domain.ai.config.AiRunApiConfig config
+    ) {
+        this.webClient = webClient;
+        this.maxRetry = config.getMaxRetry();
+    }
+
+    /**
+     * Preview API 호출
+     * 파일 추가 시 슬롯 추정 및 필수 항목 현황 반환
+     */
+    public Mono<RunPreviewResponse> preview(RunPreviewRequest request) {
+        log.info("AI Run API preview 호출 - domain: {}, packageId: {}, files: {}",
+            request.domain(), request.packageId(),
+            request.addedFiles() != null ? request.addedFiles().size() : 0);
+
+        return webClient.post()
+            .uri("/run/preview")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(RunPreviewResponse.class)
+            .retryWhen(Retry.backoff(maxRetry, Duration.ofSeconds(1))
+                .filter(this::isRetryableError)
+                .onRetryExhaustedThrow((spec, signal) ->
+                    new CustomException(ErrorCode.AI_SERVICE_UNAVAILABLE)))
+            .doOnSuccess(response ->
+                log.info("AI Run API preview 성공 - packageId: {}", response.packageId()))
+            .doOnError(error ->
+                log.error("AI Run API preview 실패", error));
+    }
+
+    /**
+     * Submit API 호출
+     * 전체 파일 검증 및 최종 판정 결과 반환
+     */
+    public Mono<RunSubmitResponse> submit(RunSubmitRequest request) {
+        log.info("AI Run API submit 호출 - domain: {}, packageId: {}, files: {}",
+            request.domain(), request.packageId(),
+            request.files() != null ? request.files().size() : 0);
+
+        return webClient.post()
+            .uri("/run/submit")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(RunSubmitResponse.class)
+            .retryWhen(Retry.backoff(maxRetry, Duration.ofSeconds(2))
+                .filter(this::isRetryableError)
+                .onRetryExhaustedThrow((spec, signal) ->
+                    new CustomException(ErrorCode.AI_SERVICE_UNAVAILABLE)))
+            .doOnSuccess(response ->
+                log.info("AI Run API submit 성공 - packageId: {}, verdict: {}",
+                    response.packageId(), response.verdict()))
+            .doOnError(error ->
+                log.error("AI Run API submit 실패", error));
+    }
+
+    /**
+     * Preview API 동기 호출
+     */
+    public RunPreviewResponse previewSync(RunPreviewRequest request) {
+        return preview(request).block();
+    }
+
+    /**
+     * Submit API 동기 호출
+     */
+    public RunSubmitResponse submitSync(RunSubmitRequest request) {
+        return submit(request).block();
+    }
+
+    private boolean isRetryableError(Throwable throwable) {
+        if (throwable instanceof WebClientResponseException ex) {
+            // 5xx 에러만 재시도
+            return ex.getStatusCode().is5xxServerError();
+        }
+        // 네트워크 에러도 재시도
+        return throwable instanceof java.net.ConnectException;
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/ai/config/AiRunApiConfig.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/config/AiRunApiConfig.java
@@ -1,0 +1,58 @@
+package com.smartchain.platform.domain.ai.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+/**
+ * AI Run API 설정
+ */
+@Configuration
+@ConfigurationProperties(prefix = "ai.run-api")
+public class AiRunApiConfig {
+
+    private String url = "http://localhost:8000";
+    private int timeoutSeconds = 180;
+    private int maxRetry = 3;
+
+    @Bean
+    public WebClient aiRunApiWebClient() {
+        HttpClient httpClient = HttpClient.create()
+            .responseTimeout(Duration.ofSeconds(timeoutSeconds));
+
+        return WebClient.builder()
+            .baseUrl(url)
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .build();
+    }
+
+    // Getters and Setters
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public int getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public void setTimeoutSeconds(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    public int getMaxRetry() {
+        return maxRetry;
+    }
+
+    public void setMaxRetry(int maxRetry) {
+        this.maxRetry = maxRetry;
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/ai/controller/AiAnalysisController.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/controller/AiAnalysisController.java
@@ -1,0 +1,98 @@
+package com.smartchain.platform.domain.ai.controller;
+
+import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
+import com.smartchain.platform.domain.ai.service.AiAnalysisService;
+import com.smartchain.platform.dto.ai.AiAnalysisRequest;
+import com.smartchain.platform.dto.ai.AiAnalysisResultResponse;
+import com.smartchain.platform.dto.ai.AiPreviewRequest;
+import com.smartchain.platform.dto.ai.run.RunPreviewResponse;
+import com.smartchain.platform.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AI 분석 컨트롤러
+ */
+@Tag(name = "AI Run Analysis", description = "AI Run API 기반 분석")
+@RestController
+@RequestMapping("/api/v1/ai/run/diagnostics/{diagnosticId}")
+public class AiAnalysisController {
+
+    private static final Logger log = LoggerFactory.getLogger(AiAnalysisController.class);
+
+    private final AiAnalysisService aiAnalysisService;
+
+    public AiAnalysisController(AiAnalysisService aiAnalysisService) {
+        this.aiAnalysisService = aiAnalysisService;
+    }
+
+    @Operation(summary = "AI Run Preview", description = "파일 추가 시 슬롯 추정 및 필수 항목 현황 확인")
+    @PostMapping("/preview")
+    public ResponseEntity<BaseResponse<RunPreviewResponse>> preview(
+        @PathVariable Long diagnosticId,
+        @RequestBody AiPreviewRequest request
+    ) {
+        log.info("AI 분석 미리보기 요청 - diagnosticId: {}, fileIds: {}",
+            diagnosticId, request.fileIds());
+
+        RunPreviewResponse response = aiAnalysisService.preview(diagnosticId, request.fileIds());
+
+        return ResponseEntity.ok(BaseResponse.success("슬롯 추정 완료", response));
+    }
+
+    @Operation(summary = "AI Run Submit", description = "전체 파일에 대한 AI 검증 요청 (비동기)")
+    @PostMapping("/submit")
+    public ResponseEntity<BaseResponse<Map<String, Object>>> requestAnalysis(
+        @PathVariable Long diagnosticId,
+        @RequestBody(required = false) AiAnalysisRequest request
+    ) {
+        log.info("AI 분석 요청 - diagnosticId: {}", diagnosticId);
+
+        // 비동기로 분석 시작
+        aiAnalysisService.submitAsync(diagnosticId);
+
+        Map<String, Object> response = Map.of(
+            "diagnosticId", diagnosticId,
+            "status", "PENDING",
+            "message", "AI 분석이 시작되었습니다. 결과는 조회 API로 확인하세요."
+        );
+
+        return ResponseEntity.accepted()
+            .body(BaseResponse.success("AI 분석 요청이 접수되었습니다", response));
+    }
+
+    @Operation(summary = "AI Run 결과 조회", description = "진단의 최신 AI Run 분석 결과 조회")
+    @GetMapping("/result")
+    public ResponseEntity<BaseResponse<AiAnalysisResultResponse>> getLatestResult(
+        @PathVariable Long diagnosticId
+    ) {
+        log.info("AI 분석 결과 조회 - diagnosticId: {}", diagnosticId);
+
+        AiAnalysisResult result = aiAnalysisService.getLatestResult(diagnosticId);
+        AiAnalysisResultResponse response = AiAnalysisResultResponse.from(result);
+
+        return ResponseEntity.ok(BaseResponse.success("분석 결과 조회 완료", response));
+    }
+
+    @Operation(summary = "AI Run 이력 조회", description = "진단의 AI Run 분석 이력 전체 조회")
+    @GetMapping("/history")
+    public ResponseEntity<BaseResponse<List<AiAnalysisResultResponse>>> getAnalysisHistory(
+        @PathVariable Long diagnosticId
+    ) {
+        log.info("AI 분석 이력 조회 - diagnosticId: {}", diagnosticId);
+
+        List<AiAnalysisResult> results = aiAnalysisService.getAnalysisHistory(diagnosticId);
+        List<AiAnalysisResultResponse> response = results.stream()
+            .map(AiAnalysisResultResponse::from)
+            .toList();
+
+        return ResponseEntity.ok(BaseResponse.success("분석 이력 조회 완료", response));
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/ai/entity/AiAnalysisResult.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/entity/AiAnalysisResult.java
@@ -1,0 +1,64 @@
+package com.smartchain.platform.domain.ai.entity;
+
+import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * AI 분석 결과 엔티티
+ */
+@Entity
+@Table(name = "ai_analysis_result")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiAnalysisResult extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diagnostic_id", nullable = false)
+    private Diagnostic diagnostic;
+
+    @Column(name = "domain_code", nullable = false)
+    private String domainCode;  // ESG, COMPLIANCE, SAFETY
+
+    @Column(name = "package_id")
+    private String packageId;  // AI Run API의 package_id
+
+    @Column(name = "risk_level")
+    private String riskLevel;  // LOW, MEDIUM, HIGH
+
+    @Column(nullable = false)
+    private String verdict;  // PASS, WARN, NEED_CLARIFY, NEED_FIX
+
+    @Column(name = "why_summary", length = 500)
+    private String whySummary;
+
+    @Column(name = "result_json", columnDefinition = "TEXT")
+    private String resultJson;  // 전체 응답 JSON
+
+    @Column(name = "analyzed_at")
+    private LocalDateTime analyzedAt;
+
+    @Builder
+    public AiAnalysisResult(Diagnostic diagnostic, String domainCode, String packageId,
+                            String riskLevel, String verdict, String whySummary,
+                            String resultJson, LocalDateTime analyzedAt) {
+        this.diagnostic = diagnostic;
+        this.domainCode = domainCode;
+        this.packageId = packageId;
+        this.riskLevel = riskLevel;
+        this.verdict = verdict;
+        this.whySummary = whySummary;
+        this.resultJson = resultJson;
+        this.analyzedAt = analyzedAt != null ? analyzedAt : LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/ai/repository/AiAnalysisResultRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/repository/AiAnalysisResultRepository.java
@@ -1,0 +1,32 @@
+package com.smartchain.platform.domain.ai.repository;
+
+import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AiAnalysisResultRepository extends JpaRepository<AiAnalysisResult, Long> {
+
+    /**
+     * 진단의 최신 분석 결과 조회
+     */
+    Optional<AiAnalysisResult> findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(Long diagnosticId);
+
+    /**
+     * 진단의 분석 이력 조회
+     */
+    List<AiAnalysisResult> findByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(Long diagnosticId);
+
+    /**
+     * package_id로 조회
+     */
+    Optional<AiAnalysisResult> findByPackageId(String packageId);
+
+    /**
+     * 도메인별 분석 결과 조회
+     */
+    List<AiAnalysisResult> findByDomainCodeOrderByAnalyzedAtDesc(String domainCode);
+}

--- a/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
@@ -1,0 +1,255 @@
+package com.smartchain.platform.domain.ai.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartchain.platform.domain.ai.client.AiRunApiClient;
+import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
+import com.smartchain.platform.domain.ai.repository.AiAnalysisResultRepository;
+import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
+import com.smartchain.platform.domain.evidence.entity.EvidenceFile;
+import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository;
+import com.smartchain.platform.dto.ai.run.*;
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * AI 분석 서비스
+ * Diagnostic과 AI Run API를 연동
+ */
+@Service
+@Transactional(readOnly = true)
+public class AiAnalysisService {
+
+    private static final Logger log = LoggerFactory.getLogger(AiAnalysisService.class);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private final AiRunApiClient aiRunApiClient;
+    private final AiAnalysisResultRepository resultRepository;
+    private final DiagnosticRepository diagnosticRepository;
+    private final EvidenceFileRepository evidenceFileRepository;
+    private final ObjectMapper objectMapper;
+
+    public AiAnalysisService(
+        AiRunApiClient aiRunApiClient,
+        AiAnalysisResultRepository resultRepository,
+        DiagnosticRepository diagnosticRepository,
+        EvidenceFileRepository evidenceFileRepository,
+        ObjectMapper objectMapper
+    ) {
+        this.aiRunApiClient = aiRunApiClient;
+        this.resultRepository = resultRepository;
+        this.diagnosticRepository = diagnosticRepository;
+        this.evidenceFileRepository = evidenceFileRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Preview 호출 - 파일 추가 시 슬롯 추정
+     */
+    public RunPreviewResponse preview(Long diagnosticId, List<Long> fileIds) {
+        Diagnostic diagnostic = getDiagnostic(diagnosticId);
+        String domainCode = getDomainCode(diagnostic);
+
+        List<FileInfo> addedFiles = fileIds.stream()
+            .map(this::toFileInfo)
+            .toList();
+
+        // 기존 package_id 조회 (있으면 사용)
+        String existingPackageId = resultRepository
+            .findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(diagnosticId)
+            .map(AiAnalysisResult::getPackageId)
+            .orElse(null);
+
+        RunPreviewRequest request = new RunPreviewRequest(
+            domainCode.toLowerCase(),
+            diagnostic.getPeriodStartDate().format(DATE_FORMATTER),
+            diagnostic.getPeriodEndDate().format(DATE_FORMATTER),
+            existingPackageId,
+            addedFiles
+        );
+
+        return aiRunApiClient.previewSync(request);
+    }
+
+    /**
+     * Submit 호출 - 전체 검증 및 판정 (비동기)
+     */
+    @Async
+    @Transactional
+    public CompletableFuture<AiAnalysisResult> submitAsync(Long diagnosticId) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                return submit(diagnosticId);
+            } catch (Exception e) {
+                log.error("AI 분석 실패 - diagnosticId: {}", diagnosticId, e);
+                throw new CustomException(ErrorCode.AI_SERVICE_ERROR);
+            }
+        });
+    }
+
+    /**
+     * Submit 호출 - 전체 검증 및 판정 (동기)
+     */
+    @Transactional
+    public AiAnalysisResult submit(Long diagnosticId) {
+        Diagnostic diagnostic = getDiagnostic(diagnosticId);
+        String domainCode = getDomainCode(diagnostic);
+
+        // 증빙 파일 목록 조회
+        List<EvidenceFile> evidenceFiles = evidenceFileRepository.findByDiagnosticId(diagnosticId);
+        if (evidenceFiles.isEmpty()) {
+            throw new CustomException(ErrorCode.DIAGNOSTIC_MISSING_EVIDENCE);
+        }
+
+        // FileInfo 변환
+        List<FileInfo> files = evidenceFiles.stream()
+            .map(ef -> new FileInfo(
+                ef.getResultFileId().toString(),
+                ef.getFilePath(),
+                ef.getOriginalFileName()
+            ))
+            .toList();
+
+        // SlotHint 생성 (파일명 기반 자동 매핑)
+        List<SlotHint> slotHints = evidenceFiles.stream()
+            .map(ef -> new SlotHint(
+                ef.getResultFileId().toString(),
+                guessSlotName(ef.getOriginalFileName(), domainCode)
+            ))
+            .toList();
+
+        // 기존 package_id 조회
+        String packageId = resultRepository
+            .findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(diagnosticId)
+            .map(AiAnalysisResult::getPackageId)
+            .orElse(generatePackageId(diagnostic));
+
+        RunSubmitRequest request = new RunSubmitRequest(
+            packageId,
+            domainCode.toLowerCase(),
+            diagnostic.getPeriodStartDate().format(DATE_FORMATTER),
+            diagnostic.getPeriodEndDate().format(DATE_FORMATTER),
+            files,
+            slotHints
+        );
+
+        // AI API 호출
+        RunSubmitResponse response = aiRunApiClient.submitSync(request);
+
+        // 결과 저장
+        return saveAnalysisResult(diagnostic, domainCode, response);
+    }
+
+    /**
+     * 진단의 최신 분석 결과 조회
+     */
+    public AiAnalysisResult getLatestResult(Long diagnosticId) {
+        return resultRepository.findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(diagnosticId)
+            .orElseThrow(() -> new CustomException(ErrorCode.AI_ANALYSIS_NOT_FOUND));
+    }
+
+    /**
+     * 진단의 분석 이력 조회
+     */
+    public List<AiAnalysisResult> getAnalysisHistory(Long diagnosticId) {
+        return resultRepository.findByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(diagnosticId);
+    }
+
+    private Diagnostic getDiagnostic(Long diagnosticId) {
+        return diagnosticRepository.findById(diagnosticId)
+            .orElseThrow(() -> new CustomException(ErrorCode.DIAGNOSTIC_NOT_FOUND));
+    }
+
+    private String getDomainCode(Diagnostic diagnostic) {
+        if (diagnostic.getDomain() != null) {
+            return diagnostic.getDomain().getCode();
+        }
+        // 레거시 데이터는 ESG로 기본 설정
+        return "ESG";
+    }
+
+    private FileInfo toFileInfo(Long fileId) {
+        EvidenceFile ef = evidenceFileRepository.findById(fileId)
+            .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
+        return new FileInfo(
+            ef.getResultFileId().toString(),
+            ef.getFilePath(),
+            ef.getOriginalFileName()
+        );
+    }
+
+    private String guessSlotName(String fileName, String domainCode) {
+        String lowerName = fileName.toLowerCase();
+
+        return switch (domainCode.toUpperCase()) {
+            case "SAFETY" -> {
+                if (lowerName.contains("tbm") || lowerName.contains("작업전")) yield "safety.tbm";
+                if (lowerName.contains("교육") || lowerName.contains("education")) yield "safety.education.status";
+                if (lowerName.contains("소방") || lowerName.contains("fire")) yield "safety.fire.inspection";
+                if (lowerName.contains("사진") || lowerName.contains("photo")) yield "safety.site.photos";
+                yield "safety.other";
+            }
+            case "COMPLIANCE" -> {
+                if (lowerName.contains("계약") || lowerName.contains("contract")) yield "compliance.contract.sample";
+                if (lowerName.contains("개인정보") || lowerName.contains("privacy")) yield "compliance.privacy.policy";
+                if (lowerName.contains("교육") || lowerName.contains("education")) yield "compliance.education.status";
+                yield "compliance.other";
+            }
+            case "ESG" -> {
+                if (lowerName.contains("에너지") || lowerName.contains("energy")) yield "esg.energy.usage";
+                if (lowerName.contains("고지서") || lowerName.contains("bill")) yield "esg.energy.bill";
+                if (lowerName.contains("msds") || lowerName.contains("화학")) yield "esg.hazmat.msds";
+                if (lowerName.contains("윤리") || lowerName.contains("ethics")) yield "esg.ethics.code";
+                yield "esg.other";
+            }
+            default -> "other";
+        };
+    }
+
+    private String generatePackageId(Diagnostic diagnostic) {
+        String companyCode = diagnostic.getCompany() != null
+            ? diagnostic.getCompany().getCompanyId().toString()
+            : "UNKNOWN";
+        String date = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMM"));
+        return String.format("PKG_%s_%s_%d", companyCode, date, diagnostic.getDiagnosticId());
+    }
+
+    @Transactional
+    protected AiAnalysisResult saveAnalysisResult(
+        Diagnostic diagnostic,
+        String domainCode,
+        RunSubmitResponse response
+    ) {
+        String resultJson;
+        try {
+            resultJson = objectMapper.writeValueAsString(response);
+        } catch (JsonProcessingException e) {
+            log.warn("AI 응답 JSON 변환 실패", e);
+            resultJson = "{}";
+        }
+
+        AiAnalysisResult result = AiAnalysisResult.builder()
+            .diagnostic(diagnostic)
+            .domainCode(domainCode)
+            .packageId(response.packageId())
+            .riskLevel(response.riskLevel())
+            .verdict(response.verdict())
+            .whySummary(response.why())
+            .resultJson(resultJson)
+            .analyzedAt(LocalDateTime.now())
+            .build();
+
+        return resultRepository.save(result);
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisRequest.java
@@ -1,0 +1,12 @@
+package com.smartchain.platform.dto.ai;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AI 분석 요청 DTO
+ */
+public record AiAnalysisRequest(
+    List<Long> fileIds,
+    Map<String, Object> options
+) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisResultResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisResultResponse.java
@@ -1,0 +1,48 @@
+package com.smartchain.platform.dto.ai;
+
+import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
+
+import java.time.LocalDateTime;
+
+/**
+ * AI 분석 결과 응답 DTO
+ */
+public record AiAnalysisResultResponse(
+    Long id,
+    Long diagnosticId,
+    String domainCode,
+    String packageId,
+    String riskLevel,
+    String verdict,
+    String whySummary,
+    Object details,
+    LocalDateTime analyzedAt
+) {
+    public static AiAnalysisResultResponse from(AiAnalysisResult result) {
+        Object details = null;
+        if (result.getResultJson() != null && !result.getResultJson().isEmpty()) {
+            try {
+                var mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+                details = mapper.readValue(result.getResultJson(), Object.class);
+            } catch (Exception e) {
+                details = result.getResultJson();
+            }
+        }
+
+        Long diagId = result.getDiagnostic() != null
+            ? result.getDiagnostic().getDiagnosticId()
+            : null;
+
+        return new AiAnalysisResultResponse(
+            result.getId(),
+            diagId,
+            result.getDomainCode(),
+            result.getPackageId(),
+            result.getRiskLevel(),
+            result.getVerdict(),
+            result.getWhySummary(),
+            details,
+            result.getAnalyzedAt()
+        );
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/ai/AiPreviewRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/AiPreviewRequest.java
@@ -1,0 +1,10 @@
+package com.smartchain.platform.dto.ai;
+
+import java.util.List;
+
+/**
+ * AI Preview 요청 DTO
+ */
+public record AiPreviewRequest(
+    List<Long> fileIds
+) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/Clarification.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/Clarification.java
@@ -1,0 +1,17 @@
+package com.smartchain.platform.dto.ai.run;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * AI Run API 보완요청 메시지 DTO
+ */
+public record Clarification(
+    @JsonProperty("slot_name")
+    String slotName,
+
+    String message,
+
+    @JsonProperty("file_ids")
+    List<String> fileIds
+) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/FileInfo.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/FileInfo.java
@@ -1,0 +1,21 @@
+package com.smartchain.platform.dto.ai.run;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * AI Run API 파일 정보 DTO
+ */
+public record FileInfo(
+    @JsonProperty("file_id")
+    String fileId,
+
+    @JsonProperty("storage_uri")
+    String storageUri,
+
+    @JsonProperty("file_name")
+    String fileName
+) {
+    public FileInfo(String fileId, String storageUri) {
+        this(fileId, storageUri, null);
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/RunPreviewRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/RunPreviewRequest.java
@@ -1,0 +1,24 @@
+package com.smartchain.platform.dto.ai.run;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * AI Run API Preview 요청 DTO
+ * POST /run/preview
+ */
+public record RunPreviewRequest(
+    String domain,  // safety, compliance, esg
+
+    @JsonProperty("period_start")
+    String periodStart,
+
+    @JsonProperty("period_end")
+    String periodEnd,
+
+    @JsonProperty("package_id")
+    String packageId,  // 첫 호출 시 null
+
+    @JsonProperty("added_files")
+    List<FileInfo> addedFiles
+) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/RunPreviewResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/RunPreviewResponse.java
@@ -1,0 +1,21 @@
+package com.smartchain.platform.dto.ai.run;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * AI Run API Preview 응답 DTO
+ */
+public record RunPreviewResponse(
+    @JsonProperty("package_id")
+    String packageId,
+
+    @JsonProperty("slot_hint")
+    List<SlotHint> slotHint,
+
+    @JsonProperty("required_slot_status")
+    List<SlotStatus> requiredSlotStatus,
+
+    @JsonProperty("missing_required_slots")
+    List<String> missingRequiredSlots
+) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/RunSubmitRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/RunSubmitRequest.java
@@ -1,0 +1,26 @@
+package com.smartchain.platform.dto.ai.run;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * AI Run API Submit 요청 DTO
+ * POST /run/submit
+ */
+public record RunSubmitRequest(
+    @JsonProperty("package_id")
+    String packageId,
+
+    String domain,  // safety, compliance, esg
+
+    @JsonProperty("period_start")
+    String periodStart,
+
+    @JsonProperty("period_end")
+    String periodEnd,
+
+    List<FileInfo> files,
+
+    @JsonProperty("slot_hint")
+    List<SlotHint> slotHint
+) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/RunSubmitResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/RunSubmitResponse.java
@@ -1,0 +1,28 @@
+package com.smartchain.platform.dto.ai.run;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AI Run API Submit 응답 DTO
+ * 고정 Output 스키마
+ */
+public record RunSubmitResponse(
+    @JsonProperty("package_id")
+    String packageId,
+
+    @JsonProperty("risk_level")
+    String riskLevel,  // LOW, MEDIUM, HIGH
+
+    String verdict,  // PASS, WARN, NEED_CLARIFY, NEED_FIX
+
+    String why,  // 한 줄 요약
+
+    @JsonProperty("slot_results")
+    List<SlotResult> slotResults,
+
+    List<Clarification> clarifications,
+
+    Map<String, Object> extras  // 도메인별 추가 정보
+) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/SlotHint.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/SlotHint.java
@@ -1,0 +1,24 @@
+package com.smartchain.platform.dto.ai.run;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * AI Run API 슬롯 힌트 DTO
+ * 파일과 슬롯 매핑 정보
+ */
+public record SlotHint(
+    @JsonProperty("file_id")
+    String fileId,
+
+    @JsonProperty("slot_name")
+    String slotName,
+
+    Double confidence,
+
+    @JsonProperty("match_reason")
+    String matchReason
+) {
+    public SlotHint(String fileId, String slotName) {
+        this(fileId, slotName, null, null);
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/SlotResult.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/SlotResult.java
@@ -1,0 +1,22 @@
+package com.smartchain.platform.dto.ai.run;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * AI Run API 슬롯 검증 결과 DTO
+ */
+public record SlotResult(
+    @JsonProperty("slot_name")
+    String slotName,
+
+    String verdict,  // PASS, WARN, NEED_CLARIFY, NEED_FIX
+
+    List<String> reasons,
+
+    @JsonProperty("file_ids")
+    List<String> fileIds,
+
+    @JsonProperty("file_names")
+    List<String> fileNames
+) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/SlotStatus.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/SlotStatus.java
@@ -1,0 +1,13 @@
+package com.smartchain.platform.dto.ai.run;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * AI Run API 슬롯 상태 DTO
+ */
+public record SlotStatus(
+    @JsonProperty("slot_name")
+    String slotName,
+
+    String status  // SUBMITTED, MISSING
+) {}

--- a/src/main/java/com/smartchain/platform/global/config/AsyncConfig.java
+++ b/src/main/java/com/smartchain/platform/global/config/AsyncConfig.java
@@ -1,0 +1,12 @@
+package com.smartchain.platform.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ * 비동기 처리 설정
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -75,7 +75,12 @@ public enum ErrorCode {
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 오류가 발생했습니다"),
     FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S002", "파일 업로드에 실패했습니다"),
     AI_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S003", "AI 서비스 연동에 실패했습니다"),
-    FILE_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYS_003", "파일 파싱에 실패했습니다");
+    FILE_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYS_003", "파일 파싱에 실패했습니다"),
+
+    // 503 Service Unavailable - AI Service
+    AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI001", "AI 서비스에 연결할 수 없습니다"),
+    AI_ANALYSIS_IN_PROGRESS(HttpStatus.CONFLICT, "AI002", "이미 분석이 진행 중입니다"),
+    AI_ANALYSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "AI003", "AI 분석 결과를 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,6 +56,13 @@ logging:
     com.smartchain.platform: DEBUG
     org.hibernate.SQL: DEBUG
 
+# AI Run API 설정
+ai:
+  run-api:
+    url: http://localhost:8000
+    timeout-seconds: 180
+    max-retry: 3
+
 ---
 # ========================================
 # 개발 서버 환경 (Azure)


### PR DESCRIPTION
## Summary
- 기획서(AI_RunAPI_기획서) 기반 공통 AI Run API 클라이언트 구현
- 도메인별 분리된 클라이언트 대신 공통 `/run/preview`, `/run/submit` API 사용
- `domain` 필드로 도메인(esg/safety/compliance) 분기

## 변경 내용

### 새 파일 (19개)
**설정 및 클라이언트**
- `domain/ai/config/AiRunApiConfig.java` - WebClient 설정
- `domain/ai/client/AiRunApiClient.java` - AI API 클라이언트

**서비스 및 엔티티**
- `domain/ai/entity/AiAnalysisResult.java` - 분석 결과 엔티티
- `domain/ai/repository/AiAnalysisResultRepository.java`
- `domain/ai/service/AiAnalysisService.java` - 비동기 지원
- `domain/ai/controller/AiAnalysisController.java`

**DTO (기획서 스키마 준수)**
- `dto/ai/run/` - RunPreviewRequest/Response, RunSubmitRequest/Response
- `dto/ai/` - AiAnalysisRequest, AiPreviewRequest, AiAnalysisResultResponse

### 수정 파일
- `build.gradle` - webflux 의존성 추가
- `ErrorCode.java` - AI 에러코드 추가
- `application.yaml` - AI Run API 설정 추가

## API 엔드포인트
| Method | Path | 설명 |
|--------|------|------|
| POST | `/api/v1/ai/run/diagnostics/{id}/preview` | 슬롯 추정 |
| POST | `/api/v1/ai/run/diagnostics/{id}/submit` | 전체 검증 (비동기) |
| GET | `/api/v1/ai/run/diagnostics/{id}/result` | 최신 결과 조회 |
| GET | `/api/v1/ai/run/diagnostics/{id}/history` | 분석 이력 조회 |

## 설정 예시
```yaml
ai:
  run-api:
    url: http://localhost:8000
    timeout-seconds: 180
    max-retry: 3
```

## Test plan
- [x] `./gradlew build` 성공
- [x] `./gradlew test` 123 tests passed
- [ ] AI 서버 연동 테스트 (AI 서버 배포 후)

## 관련 이슈
- Closes #39
- Closes #22, #27, #28 (완료)
- Closes #23, #24, #25, #29 (설계 변경으로 종료)