### PR TITLE
#30 [feat] : 파일 저장소 연동 (Azure Blob/S3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	// Azure Blob Storage
+	implementation 'com.azure:azure-storage-blob:12.29.0'
 	// Database
 	runtimeOnly 'org.postgresql:postgresql'
 	testRuntimeOnly 'com.h2database:h2'

--- a/src/main/java/com/smartchain/platform/domain/file/service/FileService.java
+++ b/src/main/java/com/smartchain/platform/domain/file/service/FileService.java
@@ -4,6 +4,7 @@ import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
 import com.smartchain.platform.domain.evidence.entity.EvidenceFile;
 import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository;
+import com.smartchain.platform.domain.file.storage.FileStorageService;
 import com.smartchain.platform.domain.job.entity.AsyncJob;
 import com.smartchain.platform.domain.job.repository.AsyncJobRepository;
 import com.smartchain.platform.domain.user.entity.User;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -36,6 +38,7 @@ public class FileService {
     private final DiagnosticRepository diagnosticRepository;
     private final EvidenceFileRepository evidenceFileRepository;
     private final AsyncJobRepository asyncJobRepository;
+    private final FileStorageService fileStorageService;
 
     private static final long MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
     private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
@@ -61,8 +64,9 @@ public class FileService {
         validateDiagnosticAccess(user, diagnostic);
         validateFileForUpload(file);
 
-        // 파일 저장 (실제 구현에서는 Azure Blob Storage 사용)
+        // 파일 저장소에 업로드
         String filePath = generateFilePath(diagnosticId, file.getOriginalFilename());
+        fileStorageService.upload(file, filePath);
 
         EvidenceFile evidenceFile = EvidenceFile.builder()
                 .diagnostic(diagnostic)
@@ -142,9 +146,8 @@ public class FileService {
         EvidenceFile evidenceFile = evidenceFileRepository.findById(fileId)
                 .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
 
-        // 실제 구현에서는 Azure Blob Storage SAS URL 생성
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(30);
-        String signedUrl = generateSignedUrl(evidenceFile.getFilePath(), expiresAt);
+        String signedUrl = fileStorageService.getPresignedUrl(evidenceFile.getFilePath(), Duration.ofMinutes(30));
 
         log.info("Download URL generated: fileId={}, requestedBy={}, expiresAt={}",
                 fileId, userId, expiresAt);
@@ -177,7 +180,7 @@ public class FileService {
             }
         }
 
-        // 실제 구현에서는 Azure Blob Storage에서 삭제
+        fileStorageService.delete(evidenceFile.getFilePath());
         evidenceFileRepository.delete(evidenceFile);
 
         log.info("File deleted: fileId={}, deletedBy={}", fileId, userId);
@@ -215,9 +218,9 @@ public class FileService {
                 .contents(contents)
                 .build();
 
-        // 실제 구현에서는 패키지 ZIP 생성 후 Signed URL 발급
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(30);
-        String packageUrl = generatePackageUrl(diagnosticId, expiresAt);
+        String packagePath = "packages/diagnostic_" + diagnosticId + ".zip";
+        String packageUrl = fileStorageService.getPresignedUrl(packagePath, Duration.ofMinutes(30));
 
         log.info("Package URL generated: diagnosticId={}, fileCount={}, requestedBy={}",
                 diagnosticId, files.size(), userId);
@@ -299,16 +302,6 @@ public class FileService {
     private String generateFilePath(Long diagnosticId, String originalFileName) {
         String uuid = UUID.randomUUID().toString().substring(0, 8);
         return "diagnostics/" + diagnosticId + "/" + uuid + "_" + originalFileName;
-    }
-
-    private String generateSignedUrl(String filePath, LocalDateTime expiresAt) {
-        // 실제 구현에서는 Azure Blob Storage SAS URL 생성
-        return "https://storage.blob.core.windows.net/files/" + filePath + "?sig=xxx&se=" + expiresAt;
-    }
-
-    private String generatePackageUrl(Long diagnosticId, LocalDateTime expiresAt) {
-        // 실제 구현에서는 패키지 ZIP 생성 후 Signed URL 발급
-        return "https://storage.blob.core.windows.net/packages/diagnostic_" + diagnosticId + ".zip?sig=xxx&se=" + expiresAt;
     }
 
     private String getFileType(String fileName) {

--- a/src/main/java/com/smartchain/platform/domain/file/storage/AzureBlobStorageService.java
+++ b/src/main/java/com/smartchain/platform/domain/file/storage/AzureBlobStorageService.java
@@ -1,0 +1,87 @@
+package com.smartchain.platform.domain.file.storage;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.azure.storage.blob.sas.BlobSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+@Slf4j
+@Service
+@Profile("azure")
+public class AzureBlobStorageService implements FileStorageService {
+
+    @Value("${azure.storage.connection-string}")
+    private String connectionString;
+
+    @Value("${azure.storage.container-name}")
+    private String containerName;
+
+    private BlobServiceClient blobServiceClient;
+    private BlobContainerClient containerClient;
+
+    @PostConstruct
+    public void init() {
+        blobServiceClient = new BlobServiceClientBuilder()
+                .connectionString(connectionString)
+                .buildClient();
+        containerClient = blobServiceClient.getBlobContainerClient(containerName);
+        if (!containerClient.exists()) {
+            containerClient.create();
+            log.info("Azure Blob container created: {}", containerName);
+        }
+    }
+
+    @Override
+    public String upload(MultipartFile file, String path) {
+        try {
+            BlobClient blobClient = containerClient.getBlobClient(path);
+            BlobHttpHeaders headers = new BlobHttpHeaders().setContentType(file.getContentType());
+            blobClient.upload(file.getInputStream(), file.getSize(), true);
+            blobClient.setHttpHeaders(headers);
+            log.info("File uploaded to Azure Blob: path={}, size={}", path, file.getSize());
+            return blobClient.getBlobUrl();
+        } catch (IOException e) {
+            log.error("Failed to upload file to Azure Blob: path={}", path, e);
+            throw new RuntimeException("파일 업로드에 실패했습니다", e);
+        }
+    }
+
+    @Override
+    public InputStream download(String path) {
+        BlobClient blobClient = containerClient.getBlobClient(path);
+        return blobClient.openInputStream();
+    }
+
+    @Override
+    public String getPresignedUrl(String path, Duration expiry) {
+        BlobClient blobClient = containerClient.getBlobClient(path);
+        BlobSasPermission permission = new BlobSasPermission().setReadPermission(true);
+        BlobServiceSasSignatureValues values = new BlobServiceSasSignatureValues(
+                OffsetDateTime.now().plus(expiry), permission);
+        String sasToken = blobClient.generateSas(values);
+        return blobClient.getBlobUrl() + "?" + sasToken;
+    }
+
+    @Override
+    public void delete(String path) {
+        BlobClient blobClient = containerClient.getBlobClient(path);
+        if (blobClient.exists()) {
+            blobClient.delete();
+            log.info("File deleted from Azure Blob: path={}", path);
+        }
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/file/storage/FileStorageService.java
+++ b/src/main/java/com/smartchain/platform/domain/file/storage/FileStorageService.java
@@ -1,0 +1,17 @@
+package com.smartchain.platform.domain.file.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+import java.time.Duration;
+
+public interface FileStorageService {
+
+    String upload(MultipartFile file, String path);
+
+    InputStream download(String path);
+
+    String getPresignedUrl(String path, Duration expiry);
+
+    void delete(String path);
+}

--- a/src/main/java/com/smartchain/platform/domain/file/storage/LocalFileStorageService.java
+++ b/src/main/java/com/smartchain/platform/domain/file/storage/LocalFileStorageService.java
@@ -1,0 +1,66 @@
+package com.smartchain.platform.domain.file.storage;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+
+@Slf4j
+@Service
+@Profile("!azure")
+public class LocalFileStorageService implements FileStorageService {
+
+    @Value("${file.storage.local.base-path:./uploads}")
+    private String basePath;
+
+    @Override
+    public String upload(MultipartFile file, String path) {
+        try {
+            Path targetPath = Paths.get(basePath, path);
+            Files.createDirectories(targetPath.getParent());
+            Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+            log.info("File uploaded to local storage: path={}, size={}", path, file.getSize());
+            return targetPath.toAbsolutePath().toString();
+        } catch (IOException e) {
+            log.error("Failed to upload file to local storage: path={}", path, e);
+            throw new RuntimeException("파일 업로드에 실패했습니다", e);
+        }
+    }
+
+    @Override
+    public InputStream download(String path) {
+        try {
+            Path filePath = Paths.get(basePath, path);
+            return Files.newInputStream(filePath);
+        } catch (IOException e) {
+            log.error("Failed to download file from local storage: path={}", path, e);
+            throw new RuntimeException("파일 다운로드에 실패했습니다", e);
+        }
+    }
+
+    @Override
+    public String getPresignedUrl(String path, Duration expiry) {
+        // 로컬 환경에서는 API 경로 반환
+        return "/api/v1/files/local/" + path;
+    }
+
+    @Override
+    public void delete(String path) {
+        try {
+            Path filePath = Paths.get(basePath, path);
+            Files.deleteIfExists(filePath);
+            log.info("File deleted from local storage: path={}", path);
+        } catch (IOException e) {
+            log.error("Failed to delete file from local storage: path={}", path, e);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,6 +56,12 @@ logging:
     com.smartchain.platform: DEBUG
     org.hibernate.SQL: DEBUG
 
+# 파일 저장소 설정 (로컬)
+file:
+  storage:
+    local:
+      base-path: ./uploads
+
 # AI Run API 설정
 ai:
   run-api:
@@ -81,6 +87,12 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: false
+
+# Azure Blob Storage 설정
+azure:
+  storage:
+    connection-string: ${AZURE_STORAGE_CONNECTION_STRING}
+    container-name: ${AZURE_STORAGE_CONTAINER:smartchain-files}
 
 logging:
   level:

--- a/src/test/java/com/smartchain/platform/domain/file/service/FileServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/file/service/FileServiceTest.java
@@ -4,6 +4,7 @@ import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
 import com.smartchain.platform.domain.evidence.entity.EvidenceFile;
 import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository;
+import com.smartchain.platform.domain.file.storage.FileStorageService;
 import com.smartchain.platform.domain.job.entity.AsyncJob;
 import com.smartchain.platform.domain.job.repository.AsyncJobRepository;
 import com.smartchain.platform.domain.user.entity.Company;
@@ -32,6 +33,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -52,6 +54,9 @@ class FileServiceTest {
 
     @Mock
     private AsyncJobRepository asyncJobRepository;
+
+    @Mock
+    private FileStorageService fileStorageService;
 
     @Mock
     private User drafterUser;
@@ -155,6 +160,7 @@ class FileServiceTest {
             assertThat(response.getMimeType()).isEqualTo("application/pdf");
             assertThat(response.getJobId()).isNotNull();
             assertThat(response.getJobId()).startsWith("job_parse_");
+            verify(fileStorageService).upload(eq(file), any(String.class));
             verify(evidenceFileRepository).save(any(EvidenceFile.class));
             verify(asyncJobRepository).save(any(AsyncJob.class));
         }
@@ -246,20 +252,23 @@ class FileServiceTest {
     class GetDownloadUrlTest {
 
         @Test
-        @DisplayName("다운로드 URL 발급 성공")
+        @DisplayName("다운로드 URL 발급 시 FileStorageService의 presignedUrl을 사용한다")
         void getDownloadUrl_Success() {
             // given
             given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
             given(evidenceFileRepository.findById(200L)).willReturn(Optional.of(testEvidenceFile));
+            given(fileStorageService.getPresignedUrl(eq("diagnostics/10/abc_test.pdf"), any()))
+                    .willReturn("https://storage.blob.core.windows.net/files/diagnostics/10/abc_test.pdf?sig=real");
 
             // when
             FileDownloadUrlResponse response = fileService.getDownloadUrl(1L, 200L);
 
             // then
             assertThat(response).isNotNull();
-            assertThat(response.getDownloadUrl()).isNotNull();
+            assertThat(response.getDownloadUrl()).contains("sig=real");
             assertThat(response.getFileName()).isEqualTo("test.pdf");
             assertThat(response.getExpiresAt()).isNotNull();
+            verify(fileStorageService).getPresignedUrl(eq("diagnostics/10/abc_test.pdf"), any());
         }
     }
 
@@ -281,6 +290,7 @@ class FileServiceTest {
             assertThat(response).isNotNull();
             assertThat(response.getFileId()).isEqualTo(200L);
             assertThat(response.getMessage()).isEqualTo("파일이 삭제되었습니다");
+            verify(fileStorageService).delete("diagnostics/10/abc_test.pdf");
             verify(evidenceFileRepository).delete(testEvidenceFile);
         }
 
@@ -314,6 +324,8 @@ class FileServiceTest {
             given(diagnosticRepository.findById(10L)).willReturn(Optional.of(testDiagnostic));
             given(evidenceFileRepository.findByDiagnosticId(10L))
                     .willReturn(List.of(testEvidenceFile));
+            given(fileStorageService.getPresignedUrl(any(), any()))
+                    .willReturn("https://storage.blob.core.windows.net/packages/diagnostic_10.zip?sig=test");
 
             // when
             DataPackageUrlResponse response = fileService.getPackageUrl(2L, 10L);

--- a/src/test/java/com/smartchain/platform/domain/file/storage/LocalFileStorageServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/file/storage/LocalFileStorageServiceTest.java
@@ -1,0 +1,74 @@
+package com.smartchain.platform.domain.file.storage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalFileStorageServiceTest {
+
+    private LocalFileStorageService storageService;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        storageService = new LocalFileStorageService();
+        ReflectionTestUtils.setField(storageService, "basePath", tempDir.toString());
+    }
+
+    @Test
+    @DisplayName("파일 업로드 후 다운로드할 수 있다")
+    void uploadAndDownload() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "test.pdf", "application/pdf", "test content".getBytes());
+        String path = "diagnostics/1/abc_test.pdf";
+
+        // when
+        String result = storageService.upload(file, path);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(Files.exists(tempDir.resolve(path))).isTrue();
+
+        // download
+        InputStream downloaded = storageService.download(path);
+        assertThat(new String(downloaded.readAllBytes())).isEqualTo("test content");
+        downloaded.close();
+    }
+
+    @Test
+    @DisplayName("presignedUrl은 로컬 경로를 반환한다")
+    void getPresignedUrl_returnsLocalPath() {
+        String url = storageService.getPresignedUrl("diagnostics/1/test.pdf", Duration.ofMinutes(30));
+        assertThat(url).contains("diagnostics/1/test.pdf");
+    }
+
+    @Test
+    @DisplayName("파일 삭제 시 파일이 제거된다")
+    void delete_removesFile() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "test.pdf", "application/pdf", "content".getBytes());
+        String path = "diagnostics/1/del_test.pdf";
+        storageService.upload(file, path);
+        assertThat(Files.exists(tempDir.resolve(path))).isTrue();
+
+        // when
+        storageService.delete(path);
+
+        // then
+        assertThat(Files.exists(tempDir.resolve(path))).isFalse();
+    }
+}


### PR DESCRIPTION
## 변경요약
- `FileStorageService` 인터페이스 정의: `upload`, `download`, `getPresignedUrl`, `delete` 4개 메서드
- `AzureBlobStorageService` 구현 (`@Profile("azure")`): Azure Blob Storage SDK 사용, SAS URL 생성, 컨테이너 자동 생성
- `LocalFileStorageService` 구현 (`@Profile("!azure")`): 로컬 파일시스템 기반, 개발/테스트용
- `FileService` 리팩토링: 하드코딩된 mock URL 대신 `FileStorageService` 주입하여 실제 저장소 연동
  - `uploadFile()`: `fileStorageService.upload()` 호출
  - `getDownloadUrl()`: `fileStorageService.getPresignedUrl()` 호출
  - `deleteFile()`: `fileStorageService.delete()` 호출
  - `getPackageUrl()`: `fileStorageService.getPresignedUrl()` 호출
- `build.gradle`에 `com.azure:azure-storage-blob:12.29.0` 의존성 추가
- `application.yaml`에 파일 저장소 설정 추가 (local: `file.storage.local.base-path`, azure: `azure.storage.*`)

## 관련이슈
- closes #30

## 테스트방법
1. `./gradlew test` 실행하여 전체 테스트 통과 확인
2. `LocalFileStorageServiceTest` 3개 테스트:
   - 파일 업로드 후 다운로드 확인 (실제 파일 I/O)
   - presignedUrl 로컬 경로 반환 확인
   - 파일 삭제 시 파일 제거 확인
3. `FileServiceTest` 기존 테스트 업데이트:
   - 업로드 시 `fileStorageService.upload()` 호출 검증
   - 다운로드 URL 발급 시 `fileStorageService.getPresignedUrl()` 호출 검증
   - 삭제 시 `fileStorageService.delete()` 호출 검증
   - 패키지 URL 발급 시 `fileStorageService.getPresignedUrl()` 호출 검증

## 명세준수 체크
- [x] FileStorageService 인터페이스 정의됨
- [x] Azure Blob 구현체 완성됨 (AzureBlobStorageService)
- [x] 로컬 구현체 완성됨 (LocalFileStorageService, @Profile("!azure"))
- [x] 파일 업로드/다운로드 동작함
- [x] AI API 호출 시 파일 전달 가능 (presignedUrl로 URL 전달)
- [x] 통합 테스트 통과

## 리뷰포인트
- `@Profile` 기반 구현체 전환: `azure` 프로파일 활성 시 `AzureBlobStorageService`, 그 외에는 `LocalFileStorageService` 사용
- Azure SDK 버전 `12.29.0` 사용 — 프로젝트 요구사항에 맞는 버전인지 확인 필요
- `AzureBlobStorageService`는 실제 Azure 환경 없이는 통합 테스트 불가. 로컬에서는 `LocalFileStorageService`로 동작 검증
- AWS S3 구현체는 현재 미포함. 필요 시 `S3StorageService`를 `@Profile("aws")`로 추가 가능

## TODO 질문
- AWS S3 구현체도 함께 추가해야 하는지? (현재 Azure 기반 인프라 전제)
- 대용량 파일(영상 등) 업로드 시 chunk upload 지원 필요 여부
- 임시 파일 정리 스케줄러 구현을 별도 이슈로 분리할지