### PR TITLE
#31 [feat] : AI 분석 완료 알림 구현

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/job/service/AiAnalysisJobService.java
+++ b/src/main/java/com/smartchain/platform/domain/job/service/AiAnalysisJobService.java
@@ -4,11 +4,13 @@ import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
 import com.smartchain.platform.domain.job.entity.AsyncJob;
 import com.smartchain.platform.domain.job.repository.AsyncJobRepository;
+import com.smartchain.platform.domain.notification.service.NotificationService;
 import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.domain.user.repository.UserRepository;
 import com.smartchain.platform.dto.job.JobStatusResponse;
 import com.smartchain.platform.global.enums.JobStatus;
 import com.smartchain.platform.global.enums.JobType;
+import com.smartchain.platform.global.enums.NotificationType;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class AiAnalysisJobService {
     private final AsyncJobRepository asyncJobRepository;
     private final DiagnosticRepository diagnosticRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     private static final int AI_ANALYSIS_ESTIMATED_SECONDS = 120;
 
@@ -102,10 +105,22 @@ public class AiAnalysisJobService {
 
             log.info("AI analysis completed: jobId={}, targetId={}", jobId, job.getTargetId());
 
+            // 성공 알림 전송
+            sendNotification(job, NotificationType.AI_ANALYSIS_COMPLETE,
+                    "AI 분석 완료",
+                    "ESG 진단 AI 분석이 완료되었습니다. 결과를 확인해주세요.",
+                    resultUrl);
+
         } catch (Exception e) {
             log.error("AI analysis failed: jobId={}, error={}", jobId, e.getMessage(), e);
             job.fail("AI_ERROR", e.getMessage(), true);
             asyncJobRepository.save(job);
+
+            // 실패 알림 전송
+            sendNotification(job, NotificationType.AI_ANALYSIS_FAILED,
+                    "AI 분석 실패",
+                    "ESG 진단 AI 분석이 실패했습니다. 다시 시도해주세요.",
+                    "/api/v1/jobs/" + jobId);
         }
 
         return CompletableFuture.completedFuture(null);
@@ -121,6 +136,17 @@ public class AiAnalysisJobService {
             case "SAFETY" -> JobType.AI_SAFETY_ANALYSIS;
             default -> JobType.AI_ESG_ANALYSIS;
         };
+    }
+
+    private void sendNotification(AsyncJob job, NotificationType type, String title, String message, String linkUrl) {
+        try {
+            User requester = userRepository.findById(job.getRequesterId()).orElse(null);
+            if (requester != null) {
+                notificationService.createNotification(requester, type, title, message, linkUrl);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to send notification for jobId={}: {}", job.getJobId(), e.getMessage());
+        }
     }
 
     private void validateAccess(User user, Diagnostic diagnostic) {

--- a/src/main/java/com/smartchain/platform/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/smartchain/platform/domain/notification/service/NotificationService.java
@@ -2,11 +2,13 @@ package com.smartchain.platform.domain.notification.service;
 
 import com.smartchain.platform.domain.notification.entity.Notification;
 import com.smartchain.platform.domain.notification.repository.NotificationRepository;
+import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.dto.notification.NotificationItemDto;
 import com.smartchain.platform.dto.notification.NotificationListResponse;
 import com.smartchain.platform.dto.notification.NotificationReadRequest;
 import com.smartchain.platform.dto.notification.NotificationReadResponse;
 import com.smartchain.platform.dto.review.common.PageDto;
+import com.smartchain.platform.global.enums.NotificationType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -76,6 +78,20 @@ public class NotificationService {
                 .markedCount(markedCount)
                 .remainingUnread(remainingUnread)
                 .build();
+    }
+
+    @Transactional
+    public Notification createNotification(User user, NotificationType type, String title, String message, String linkUrl) {
+        Notification notification = Notification.builder()
+                .user(user)
+                .type(type)
+                .title(title)
+                .message(message)
+                .linkUrl(linkUrl)
+                .build();
+        Notification saved = notificationRepository.save(notification);
+        log.info("Notification created: userId={}, type={}, title={}", user.getUserId(), type, title);
+        return saved;
     }
 
     private NotificationItemDto mapToItemDto(Notification notification) {

--- a/src/main/java/com/smartchain/platform/global/enums/NotificationType.java
+++ b/src/main/java/com/smartchain/platform/global/enums/NotificationType.java
@@ -4,8 +4,10 @@ package com.smartchain.platform.global.enums;
  * 알림 타입
  */
 public enum NotificationType {
-    APPROVAL_COMPLETE,    // 결재 완료
-    REVIEW_COMPLETE,      // 심사 완료
-    ROLE_APPROVED,        // 권한 승인
-    REVISION_REQUIRED     // 보완 요청
+    APPROVAL_COMPLETE,      // 결재 완료
+    REVIEW_COMPLETE,        // 심사 완료
+    ROLE_APPROVED,          // 권한 승인
+    REVISION_REQUIRED,      // 보완 요청
+    AI_ANALYSIS_COMPLETE,   // AI 분석 완료
+    AI_ANALYSIS_FAILED      // AI 분석 실패
 }

--- a/src/test/java/com/smartchain/platform/domain/job/service/AiAnalysisJobServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/job/service/AiAnalysisJobServiceTest.java
@@ -4,6 +4,7 @@ import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
 import com.smartchain.platform.domain.job.entity.AsyncJob;
 import com.smartchain.platform.domain.job.repository.AsyncJobRepository;
+import com.smartchain.platform.domain.notification.service.NotificationService;
 import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.entity.Role;
 import com.smartchain.platform.domain.user.entity.User;
@@ -11,6 +12,7 @@ import com.smartchain.platform.domain.user.entity.UserDomainRole;
 import com.smartchain.platform.domain.user.repository.UserRepository;
 import com.smartchain.platform.dto.job.JobStatusResponse;
 import com.smartchain.platform.global.enums.JobType;
+import com.smartchain.platform.global.enums.NotificationType;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +29,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -44,6 +47,9 @@ class AiAnalysisJobServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private NotificationService notificationService;
 
     private User testUser;
     private Diagnostic testDiagnostic;
@@ -193,8 +199,8 @@ class AiAnalysisJobServiceTest {
     class ExecuteAnalysisAsync {
 
         @Test
-        @DisplayName("비동기 실행 시 작업 상태가 SUCCEEDED로 변경된다")
-        void executeAsync_success() {
+        @DisplayName("비동기 실행 성공 시 AI_ANALYSIS_COMPLETE 알림이 생성된다")
+        void executeAsync_success_sendsCompleteNotification() {
             // given
             AsyncJob job = AsyncJob.builder()
                     .jobType(JobType.AI_ESG_ANALYSIS)
@@ -204,12 +210,49 @@ class AiAnalysisJobServiceTest {
 
             given(asyncJobRepository.findByJobId(job.getJobId())).willReturn(Optional.of(job));
             given(asyncJobRepository.save(any(AsyncJob.class))).willAnswer(inv -> inv.getArgument(0));
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
 
             // when
             aiAnalysisJobService.executeAnalysisAsync(job.getJobId());
 
             // then
             assertThat(job.getProgress()).isEqualTo(100);
+            verify(notificationService).createNotification(
+                    eq(testUser),
+                    eq(NotificationType.AI_ANALYSIS_COMPLETE),
+                    eq("AI 분석 완료"),
+                    eq("ESG 진단 AI 분석이 완료되었습니다. 결과를 확인해주세요."),
+                    eq("/api/v1/diagnostics/100/ai-analysis"));
+        }
+
+        @Test
+        @DisplayName("비동기 실행 실패 시 AI_ANALYSIS_FAILED 알림이 생성된다")
+        void executeAsync_failure_sendsFailedNotification() {
+            // given
+            AsyncJob job = AsyncJob.builder()
+                    .jobType(JobType.AI_ESG_ANALYSIS)
+                    .requesterId(1L)
+                    .targetId(100L)
+                    .build();
+
+            // start() save succeeds, then first progress update throws
+            given(asyncJobRepository.findByJobId(job.getJobId())).willReturn(Optional.of(job));
+            given(asyncJobRepository.save(any(AsyncJob.class)))
+                    .willAnswer(inv -> inv.getArgument(0))   // start()
+                    .willThrow(new RuntimeException("DB error"))  // progress 30% fails
+                    .willAnswer(inv -> inv.getArgument(0));  // fail() save
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+            // when
+            aiAnalysisJobService.executeAnalysisAsync(job.getJobId());
+
+            // then
+            verify(notificationService).createNotification(
+                    eq(testUser),
+                    eq(NotificationType.AI_ANALYSIS_FAILED),
+                    eq("AI 분석 실패"),
+                    eq("ESG 진단 AI 분석이 실패했습니다. 다시 시도해주세요."),
+                    any(String.class));
         }
     }
 }


### PR DESCRIPTION
## 변경요약
- `NotificationType` enum에 `AI_ANALYSIS_COMPLETE`, `AI_ANALYSIS_FAILED` 2개 타입 추가
- `NotificationService`에 `createNotification(User, NotificationType, title, message, linkUrl)` 메서드 추가
- `AiAnalysisJobService.executeAnalysisAsync()`에서:
  - 성공 시: `AI_ANALYSIS_COMPLETE` 알림 생성 (linkUrl: `/api/v1/diagnostics/{id}/ai-analysis`)
  - 실패 시: `AI_ANALYSIS_FAILED` 알림 생성 (linkUrl: `/api/v1/jobs/{jobId}`)
- 알림 전송 실패 시 예외를 catch하여 분석 작업 자체에는 영향 없도록 처리

## 관련이슈
- closes #31

## 테스트방법
1. `./gradlew test` 실행하여 전체 테스트 통과 확인
2. `AiAnalysisJobServiceTest` 알림 관련 테스트 2개:
   - 비동기 실행 성공 시 `AI_ANALYSIS_COMPLETE` 알림이 올바른 제목/메시지/linkUrl로 생성되는지 검증
   - 비동기 실행 실패 시 `AI_ANALYSIS_FAILED` 알림이 생성되는지 검증

## 명세준수 체크
- [x] NotificationType enum 업데이트됨 (AI_ANALYSIS_COMPLETE, AI_ANALYSIS_FAILED)
- [x] 분석 완료 시 알림 생성됨
- [x] 분석 실패 시 알림 생성됨
- [x] 알림에 링크 URL 포함됨
- [x] 단위 테스트 통과

## 리뷰포인트
- `sendNotification()` 메서드에서 예외를 catch하여 알림 전송 실패가 분석 작업 상태에 영향을 주지 않도록 함
- `NotificationService.createNotification()`은 범용 메서드로 설계하여 다른 도메인에서도 재사용 가능

## TODO 질문
- 알림 메시지에 진단 제목이나 분석 유형(ESG/Compliance/Safety)을 포함해야 하는지?
- 이메일 알림, WebSocket 실시간 알림은 별도 이슈로 처리 예정인지?