### PR TITLE
#38 [feat] AI 분석 결과 상세 파싱 및 조회 API 구현

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/ai/controller/AiAnalysisController.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/controller/AiAnalysisController.java
@@ -3,6 +3,7 @@ package com.smartchain.platform.domain.ai.controller;
 import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
 import com.smartchain.platform.domain.ai.service.AiAnalysisService;
 import com.smartchain.platform.dto.ai.AiAnalysisRequest;
+import com.smartchain.platform.dto.ai.AiAnalysisResultDetailResponse;
 import com.smartchain.platform.dto.ai.AiAnalysisResultResponse;
 import com.smartchain.platform.dto.ai.AiPreviewRequest;
 import com.smartchain.platform.dto.ai.run.RunPreviewResponse;
@@ -79,6 +80,19 @@ public class AiAnalysisController {
         AiAnalysisResultResponse response = AiAnalysisResultResponse.from(result);
 
         return ResponseEntity.ok(BaseResponse.success("분석 결과 조회 완료", response));
+    }
+
+    @Operation(summary = "AI Run 결과 상세 조회", description = "진단의 최신 AI Run 분석 결과를 슬롯별로 파싱하여 조회")
+    @GetMapping("/result/detail")
+    public ResponseEntity<BaseResponse<AiAnalysisResultDetailResponse>> getLatestResultDetail(
+        @PathVariable Long diagnosticId
+    ) {
+        log.info("AI 분석 결과 상세 조회 - diagnosticId: {}", diagnosticId);
+
+        AiAnalysisResult result = aiAnalysisService.getLatestResult(diagnosticId);
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result);
+
+        return ResponseEntity.ok(BaseResponse.success("분석 결과 상세 조회 완료", response));
     }
 
     @Operation(summary = "AI Run 이력 조회", description = "진단의 AI Run 분석 이력 전체 조회")

--- a/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
@@ -160,6 +160,14 @@ public class AiAnalysisService {
     }
 
     /**
+     * 특정 분석 결과 조회 (ID로)
+     */
+    public AiAnalysisResult getResultById(Long resultId) {
+        return resultRepository.findById(resultId)
+            .orElseThrow(() -> new CustomException(ErrorCode.AI_ANALYSIS_NOT_FOUND));
+    }
+
+    /**
      * 진단의 분석 이력 조회
      */
     public List<AiAnalysisResult> getAnalysisHistory(Long diagnosticId) {

--- a/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponse.java
@@ -1,0 +1,177 @@
+package com.smartchain.platform.dto.ai;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
+import com.smartchain.platform.dto.ai.run.Clarification;
+import com.smartchain.platform.dto.ai.run.SlotResult;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AI 분석 결과 상세 응답 DTO
+ * resultJson을 파싱하여 슬롯별 결과와 보완요청 메시지를 구조화하여 제공
+ */
+public record AiAnalysisResultDetailResponse(
+    Long id,
+    Long diagnosticId,
+    String domainCode,
+    String packageId,
+    String riskLevel,
+    String verdict,
+    String whySummary,
+    List<SlotResult> slotResults,
+    List<Clarification> clarifications,
+    Map<String, Object> extras,
+    LocalDateTime analyzedAt
+) {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /**
+     * AiAnalysisResult 엔티티를 상세 응답 DTO로 변환
+     * resultJson을 파싱하여 슬롯 결과와 보완요청을 추출
+     */
+    public static AiAnalysisResultDetailResponse from(AiAnalysisResult result) {
+        Long diagId = result.getDiagnostic() != null
+            ? result.getDiagnostic().getDiagnosticId()
+            : null;
+
+        ParsedResult parsed = parseResultJson(result.getResultJson());
+
+        return new AiAnalysisResultDetailResponse(
+            result.getId(),
+            diagId,
+            result.getDomainCode(),
+            result.getPackageId(),
+            result.getRiskLevel(),
+            result.getVerdict(),
+            result.getWhySummary(),
+            parsed.slotResults(),
+            parsed.clarifications(),
+            parsed.extras(),
+            result.getAnalyzedAt()
+        );
+    }
+
+    /**
+     * resultJson을 파싱하여 구조화된 데이터 추출
+     */
+    private static ParsedResult parseResultJson(String resultJson) {
+        if (resultJson == null || resultJson.isBlank()) {
+            return new ParsedResult(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyMap()
+            );
+        }
+
+        try {
+            Map<String, Object> jsonMap = OBJECT_MAPPER.readValue(
+                resultJson,
+                new TypeReference<Map<String, Object>>() {}
+            );
+
+            List<SlotResult> slotResults = parseSlotResults(jsonMap);
+            List<Clarification> clarifications = parseClarifications(jsonMap);
+            Map<String, Object> extras = parseExtras(jsonMap);
+
+            return new ParsedResult(slotResults, clarifications, extras);
+        } catch (Exception e) {
+            return new ParsedResult(
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyMap()
+            );
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<SlotResult> parseSlotResults(Map<String, Object> jsonMap) {
+        Object slotResultsObj = jsonMap.get("slot_results");
+        if (slotResultsObj == null) {
+            slotResultsObj = jsonMap.get("slotResults");
+        }
+
+        if (slotResultsObj instanceof List<?> list) {
+            return list.stream()
+                .filter(item -> item instanceof Map)
+                .map(item -> {
+                    Map<String, Object> map = (Map<String, Object>) item;
+                    return new SlotResult(
+                        getStringValue(map, "slot_name", "slotName"),
+                        (String) map.get("verdict"),
+                        getListValue(map, "reasons"),
+                        getListValue(map, "file_ids", "fileIds"),
+                        getListValue(map, "file_names", "fileNames")
+                    );
+                })
+                .toList();
+        }
+        return Collections.emptyList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Clarification> parseClarifications(Map<String, Object> jsonMap) {
+        Object clarificationsObj = jsonMap.get("clarifications");
+
+        if (clarificationsObj instanceof List<?> list) {
+            return list.stream()
+                .filter(item -> item instanceof Map)
+                .map(item -> {
+                    Map<String, Object> map = (Map<String, Object>) item;
+                    return new Clarification(
+                        getStringValue(map, "slot_name", "slotName"),
+                        (String) map.get("message"),
+                        getListValue(map, "file_ids", "fileIds")
+                    );
+                })
+                .toList();
+        }
+        return Collections.emptyList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> parseExtras(Map<String, Object> jsonMap) {
+        Object extrasObj = jsonMap.get("extras");
+        if (extrasObj instanceof Map) {
+            return (Map<String, Object>) extrasObj;
+        }
+        return Collections.emptyMap();
+    }
+
+    private static String getStringValue(Map<String, Object> map, String... keys) {
+        for (String key : keys) {
+            Object value = map.get(key);
+            if (value instanceof String) {
+                return (String) value;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> getListValue(Map<String, Object> map, String... keys) {
+        for (String key : keys) {
+            Object value = map.get(key);
+            if (value instanceof List<?> list) {
+                return list.stream()
+                    .filter(item -> item instanceof String)
+                    .map(item -> (String) item)
+                    .toList();
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * 파싱 결과 내부 레코드
+     */
+    private record ParsedResult(
+        List<SlotResult> slotResults,
+        List<Clarification> clarifications,
+        Map<String, Object> extras
+    ) {}
+}

--- a/src/test/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponseTest.java
+++ b/src/test/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponseTest.java
@@ -1,0 +1,241 @@
+package com.smartchain.platform.dto.ai;
+
+import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
+import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * AI 분석 결과 상세 응답 DTO 테스트
+ */
+class AiAnalysisResultDetailResponseTest {
+
+    @Test
+    @DisplayName("resultJson 파싱 - slot_results와 clarifications 추출 성공")
+    void from_withValidResultJson_parsesSlotResultsAndClarifications() {
+        // given
+        String resultJson = """
+            {
+                "package_id": "PKG_1_202601_1",
+                "risk_level": "MEDIUM",
+                "verdict": "PASS",
+                "why": "에너지 사용량 증빙 확인 완료",
+                "slot_results": [
+                    {
+                        "slot_name": "esg.energy.usage",
+                        "verdict": "PASS",
+                        "reasons": ["데이터 형식 적합", "기간 일치"],
+                        "file_ids": ["1", "2"],
+                        "file_names": ["energy_2026.xlsx", "usage_report.pdf"]
+                    },
+                    {
+                        "slot_name": "esg.hazmat.msds",
+                        "verdict": "NEED_FIX",
+                        "reasons": ["MSDS 문서 누락"],
+                        "file_ids": [],
+                        "file_names": []
+                    }
+                ],
+                "clarifications": [
+                    {
+                        "slot_name": "esg.hazmat.msds",
+                        "message": "화학물질 MSDS 문서를 업로드해주세요",
+                        "file_ids": []
+                    }
+                ],
+                "extras": {
+                    "totalScore": 85,
+                    "category": "환경"
+                }
+            }
+            """;
+
+        Diagnostic diagnostic = mock(Diagnostic.class);
+        when(diagnostic.getDiagnosticId()).thenReturn(100L);
+
+        AiAnalysisResult result = AiAnalysisResult.builder()
+            .diagnostic(diagnostic)
+            .domainCode("ESG")
+            .packageId("PKG_1_202601_1")
+            .riskLevel("MEDIUM")
+            .verdict("PASS")
+            .whySummary("에너지 사용량 증빙 확인 완료")
+            .resultJson(resultJson)
+            .analyzedAt(LocalDateTime.now())
+            .build();
+
+        // Reflection으로 ID 설정
+        try {
+            var idField = AiAnalysisResult.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(result, 1L);
+        } catch (Exception e) {
+            // 테스트 환경에서 ID 설정 실패 시 무시
+        }
+
+        // when
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result);
+
+        // then
+        assertThat(response.diagnosticId()).isEqualTo(100L);
+        assertThat(response.domainCode()).isEqualTo("ESG");
+        assertThat(response.verdict()).isEqualTo("PASS");
+        assertThat(response.riskLevel()).isEqualTo("MEDIUM");
+
+        // slot_results 검증
+        assertThat(response.slotResults()).hasSize(2);
+        assertThat(response.slotResults().get(0).slotName()).isEqualTo("esg.energy.usage");
+        assertThat(response.slotResults().get(0).verdict()).isEqualTo("PASS");
+        assertThat(response.slotResults().get(0).reasons()).containsExactly("데이터 형식 적합", "기간 일치");
+        assertThat(response.slotResults().get(0).fileNames()).containsExactly("energy_2026.xlsx", "usage_report.pdf");
+
+        assertThat(response.slotResults().get(1).slotName()).isEqualTo("esg.hazmat.msds");
+        assertThat(response.slotResults().get(1).verdict()).isEqualTo("NEED_FIX");
+
+        // clarifications 검증
+        assertThat(response.clarifications()).hasSize(1);
+        assertThat(response.clarifications().get(0).slotName()).isEqualTo("esg.hazmat.msds");
+        assertThat(response.clarifications().get(0).message()).isEqualTo("화학물질 MSDS 문서를 업로드해주세요");
+
+        // extras 검증
+        assertThat(response.extras()).containsEntry("totalScore", 85);
+        assertThat(response.extras()).containsEntry("category", "환경");
+    }
+
+    @Test
+    @DisplayName("resultJson이 null인 경우 빈 리스트 반환")
+    void from_withNullResultJson_returnsEmptyLists() {
+        // given
+        Diagnostic diagnostic = mock(Diagnostic.class);
+        when(diagnostic.getDiagnosticId()).thenReturn(100L);
+
+        AiAnalysisResult result = AiAnalysisResult.builder()
+            .diagnostic(diagnostic)
+            .domainCode("ESG")
+            .packageId("PKG_1_202601_1")
+            .riskLevel("LOW")
+            .verdict("PASS")
+            .whySummary("테스트")
+            .resultJson(null)
+            .analyzedAt(LocalDateTime.now())
+            .build();
+
+        // when
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result);
+
+        // then
+        assertThat(response.slotResults()).isEmpty();
+        assertThat(response.clarifications()).isEmpty();
+        assertThat(response.extras()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("resultJson이 빈 문자열인 경우 빈 리스트 반환")
+    void from_withEmptyResultJson_returnsEmptyLists() {
+        // given
+        Diagnostic diagnostic = mock(Diagnostic.class);
+        when(diagnostic.getDiagnosticId()).thenReturn(100L);
+
+        AiAnalysisResult result = AiAnalysisResult.builder()
+            .diagnostic(diagnostic)
+            .domainCode("SAFETY")
+            .packageId("PKG_2_202601_1")
+            .riskLevel("HIGH")
+            .verdict("WARN")
+            .whySummary("테스트")
+            .resultJson("")
+            .analyzedAt(LocalDateTime.now())
+            .build();
+
+        // when
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result);
+
+        // then
+        assertThat(response.slotResults()).isEmpty();
+        assertThat(response.clarifications()).isEmpty();
+        assertThat(response.extras()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("잘못된 JSON 형식인 경우 빈 리스트 반환")
+    void from_withInvalidJson_returnsEmptyLists() {
+        // given
+        Diagnostic diagnostic = mock(Diagnostic.class);
+        when(diagnostic.getDiagnosticId()).thenReturn(100L);
+
+        AiAnalysisResult result = AiAnalysisResult.builder()
+            .diagnostic(diagnostic)
+            .domainCode("COMPLIANCE")
+            .packageId("PKG_3_202601_1")
+            .riskLevel("MEDIUM")
+            .verdict("PASS")
+            .whySummary("테스트")
+            .resultJson("{ invalid json }")
+            .analyzedAt(LocalDateTime.now())
+            .build();
+
+        // when
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result);
+
+        // then
+        assertThat(response.slotResults()).isEmpty();
+        assertThat(response.clarifications()).isEmpty();
+        assertThat(response.extras()).isEmpty();
+        // 기본 필드는 정상적으로 설정
+        assertThat(response.domainCode()).isEqualTo("COMPLIANCE");
+        assertThat(response.verdict()).isEqualTo("PASS");
+    }
+
+    @Test
+    @DisplayName("camelCase 키 형식도 파싱 성공")
+    void from_withCamelCaseKeys_parsesSuccessfully() {
+        // given
+        String resultJson = """
+            {
+                "packageId": "PKG_1_202601_1",
+                "riskLevel": "LOW",
+                "verdict": "PASS",
+                "why": "테스트",
+                "slotResults": [
+                    {
+                        "slotName": "esg.energy.usage",
+                        "verdict": "PASS",
+                        "reasons": ["OK"],
+                        "fileIds": ["1"],
+                        "fileNames": ["test.xlsx"]
+                    }
+                ],
+                "clarifications": [],
+                "extras": {}
+            }
+            """;
+
+        Diagnostic diagnostic = mock(Diagnostic.class);
+        when(diagnostic.getDiagnosticId()).thenReturn(100L);
+
+        AiAnalysisResult result = AiAnalysisResult.builder()
+            .diagnostic(diagnostic)
+            .domainCode("ESG")
+            .packageId("PKG_1_202601_1")
+            .riskLevel("LOW")
+            .verdict("PASS")
+            .whySummary("테스트")
+            .resultJson(resultJson)
+            .analyzedAt(LocalDateTime.now())
+            .build();
+
+        // when
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result);
+
+        // then
+        assertThat(response.slotResults()).hasSize(1);
+        assertThat(response.slotResults().get(0).slotName()).isEqualTo("esg.energy.usage");
+        assertThat(response.slotResults().get(0).fileNames()).containsExactly("test.xlsx");
+    }
+}


### PR DESCRIPTION
## 변경 요약
AI Run API 응답의 `slot_results`, `clarifications`, `extras`를 파싱하여 프론트엔드에 구조화된 데이터를 제공하는 API 구현

### 주요 변경사항
- `AiAnalysisResultDetailResponse` DTO 생성 (JSON 파싱 로직 포함)
- `GET /api/v1/ai/run/diagnostics/{id}/result/detail` 엔드포인트 추가
- snake_case, camelCase 키 모두 지원하는 파싱 로직
- 단위 테스트 5개 추가

### 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `dto/ai/AiAnalysisResultDetailResponse.java` | 신규 - 상세 응답 DTO |
| `controller/AiAnalysisController.java` | 수정 - 상세 조회 엔드포인트 추가 |
| `service/AiAnalysisService.java` | 수정 - getResultById 메서드 추가 |
| `AiAnalysisResultDetailResponseTest.java` | 신규 - 단위 테스트 |

## 관련 이슈
- Closes #38

## 테스트 방법
```bash
# 단위 테스트 실행
./gradlew test --tests "AiAnalysisResultDetailResponseTest"

# 전체 테스트
./gradlew test

# API 테스트 (서버 실행 후)
curl -X GET http://localhost:8080/api/v1/ai/run/diagnostics/1/result/detail \
  -H "Authorization: Bearer {token}"
```

## 명세 준수 체크
- [x] Issue #38 응답 DTO 설계 준수
- [x] `SlotResultDto` 형식: slotName, verdict, reasons, fileNames
- [x] `ClarificationDto` 형식: slotName, message
- [x] extras Map 포함
- [x] 기존 DTO (SlotResult, Clarification) 재사용

## 리뷰 포인트
1. **JSON 파싱 로직**: `parseResultJson()` 메서드에서 snake_case/camelCase 둘 다 지원하는 방식이 적절한지
2. **에러 처리**: 잘못된 JSON 형식일 때 빈 리스트 반환 vs 예외 발생 - 현재는 빈 리스트 반환
3. **ObjectMapper 재사용**: static final로 선언하여 재사용 - 성능상 문제 없는지

## TODO / 질문
- [ ] 특정 resultId로 조회하는 API도 필요한가? (현재는 최신 결과만 조회)
- [ ] 파싱 실패 시 로깅 추가 필요한가?
- [ ] extras에 특정 도메인별 필드 검증 필요한가?