### PR TITLE
#37 [feat] : 도메인별 슬롯 설정 외부화 (SlotConfigProperties)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/ai/config/SlotConfigProperties.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/config/SlotConfigProperties.java
@@ -1,0 +1,53 @@
+package com.smartchain.platform.domain.ai.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "ai.slots")
+public class SlotConfigProperties {
+
+    private Map<String, List<SlotDefinition>> domains = new HashMap<>();
+
+    @Getter
+    @Setter
+    public static class SlotDefinition {
+        private String name;
+        private List<String> keywords = new ArrayList<>();
+        private boolean required;
+    }
+
+    public List<SlotDefinition> getSlotsForDomain(String domainCode) {
+        return domains.getOrDefault(domainCode.toLowerCase(), List.of());
+    }
+
+    public List<SlotDefinition> getRequiredSlots(String domainCode) {
+        return getSlotsForDomain(domainCode).stream()
+                .filter(SlotDefinition::isRequired)
+                .toList();
+    }
+
+    public String matchSlotName(String fileName, String domainCode) {
+        String lowerName = fileName.toLowerCase();
+        List<SlotDefinition> slots = getSlotsForDomain(domainCode);
+
+        for (SlotDefinition slot : slots) {
+            for (String keyword : slot.getKeywords()) {
+                if (lowerName.contains(keyword.toLowerCase())) {
+                    return slot.getName();
+                }
+            }
+        }
+
+        return domainCode.toLowerCase() + ".other";
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
@@ -3,6 +3,7 @@ package com.smartchain.platform.domain.ai.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartchain.platform.domain.ai.client.AiRunApiClient;
+import com.smartchain.platform.domain.ai.config.SlotConfigProperties;
 import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
 import com.smartchain.platform.domain.ai.repository.AiAnalysisResultRepository;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
@@ -39,19 +40,22 @@ public class AiAnalysisService {
     private final DiagnosticRepository diagnosticRepository;
     private final EvidenceFileRepository evidenceFileRepository;
     private final ObjectMapper objectMapper;
+    private final SlotConfigProperties slotConfigProperties;
 
     public AiAnalysisService(
         AiRunApiClient aiRunApiClient,
         AiAnalysisResultRepository resultRepository,
         DiagnosticRepository diagnosticRepository,
         EvidenceFileRepository evidenceFileRepository,
-        ObjectMapper objectMapper
+        ObjectMapper objectMapper,
+        SlotConfigProperties slotConfigProperties
     ) {
         this.aiRunApiClient = aiRunApiClient;
         this.resultRepository = resultRepository;
         this.diagnosticRepository = diagnosticRepository;
         this.evidenceFileRepository = evidenceFileRepository;
         this.objectMapper = objectMapper;
+        this.slotConfigProperties = slotConfigProperties;
     }
 
     /**
@@ -198,31 +202,7 @@ public class AiAnalysisService {
     }
 
     private String guessSlotName(String fileName, String domainCode) {
-        String lowerName = fileName.toLowerCase();
-
-        return switch (domainCode.toUpperCase()) {
-            case "SAFETY" -> {
-                if (lowerName.contains("tbm") || lowerName.contains("작업전")) yield "safety.tbm";
-                if (lowerName.contains("교육") || lowerName.contains("education")) yield "safety.education.status";
-                if (lowerName.contains("소방") || lowerName.contains("fire")) yield "safety.fire.inspection";
-                if (lowerName.contains("사진") || lowerName.contains("photo")) yield "safety.site.photos";
-                yield "safety.other";
-            }
-            case "COMPLIANCE" -> {
-                if (lowerName.contains("계약") || lowerName.contains("contract")) yield "compliance.contract.sample";
-                if (lowerName.contains("개인정보") || lowerName.contains("privacy")) yield "compliance.privacy.policy";
-                if (lowerName.contains("교육") || lowerName.contains("education")) yield "compliance.education.status";
-                yield "compliance.other";
-            }
-            case "ESG" -> {
-                if (lowerName.contains("에너지") || lowerName.contains("energy")) yield "esg.energy.usage";
-                if (lowerName.contains("고지서") || lowerName.contains("bill")) yield "esg.energy.bill";
-                if (lowerName.contains("msds") || lowerName.contains("화학")) yield "esg.hazmat.msds";
-                if (lowerName.contains("윤리") || lowerName.contains("ethics")) yield "esg.ethics.code";
-                yield "esg.other";
-            }
-            default -> "other";
-        };
+        return slotConfigProperties.matchSlotName(fileName, domainCode);
     }
 
     private String generatePackageId(Diagnostic diagnostic) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,6 +68,47 @@ ai:
     url: http://localhost:8000
     timeout-seconds: 180
     max-retry: 3
+  slots:
+    domains:
+      safety:
+        - name: safety.tbm
+          keywords: [tbm, 작업전, 안전점검, 안전회의, toolbox, 작업전회의]
+          required: true
+        - name: safety.education.status
+          keywords: [교육, education, 이수, 안전교육, 교육이수, 수료]
+          required: true
+        - name: safety.fire.inspection
+          keywords: [소방, fire, 점검, 소방점검, 소화기, 방화]
+          required: true
+        - name: safety.site.photos
+          keywords: [사진, photo, 현장, 현장사진, site, image]
+          required: true
+      compliance:
+        - name: compliance.contract.sample
+          keywords: [계약, contract, 계약서, 샘플, 표준계약, 도급계약]
+          required: true
+        - name: compliance.contract.status
+          keywords: [계약현황, 현황, status, 계약목록]
+          required: true
+        - name: compliance.privacy.policy
+          keywords: [개인정보, privacy, 정책, 보호, 개인정보처리]
+          required: true
+        - name: compliance.education.status
+          keywords: [교육, education, 이수, 법정교육, 컴플라이언스교육]
+          required: true
+      esg:
+        - name: esg.energy.usage
+          keywords: [에너지, energy, 사용량, 전력, 가스, 에너지사용]
+          required: true
+        - name: esg.energy.bill
+          keywords: [고지서, bill, 근거, 요금, 청구서, 납부]
+          required: true
+        - name: esg.hazmat.msds
+          keywords: [msds, 화학, 물질안전, 유해물질, 화학물질, hazmat]
+          required: true
+        - name: esg.ethics.code
+          keywords: [윤리, ethics, 강령, 윤리강령, 행동강령, code of conduct]
+          required: true
 
 ---
 # ========================================

--- a/src/test/java/com/smartchain/platform/domain/ai/config/SlotConfigPropertiesTest.java
+++ b/src/test/java/com/smartchain/platform/domain/ai/config/SlotConfigPropertiesTest.java
@@ -1,0 +1,89 @@
+package com.smartchain.platform.domain.ai.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SlotConfigPropertiesTest {
+
+    private SlotConfigProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new SlotConfigProperties();
+
+        // safety 도메인 슬롯 설정
+        SlotConfigProperties.SlotDefinition safetyTbm = new SlotConfigProperties.SlotDefinition();
+        safetyTbm.setName("safety.tbm");
+        safetyTbm.setKeywords(List.of("tbm", "작업전", "안전점검"));
+        safetyTbm.setRequired(true);
+
+        SlotConfigProperties.SlotDefinition safetyEducation = new SlotConfigProperties.SlotDefinition();
+        safetyEducation.setName("safety.education.status");
+        safetyEducation.setKeywords(List.of("교육", "education", "이수"));
+        safetyEducation.setRequired(true);
+
+        // esg 도메인 슬롯 설정
+        SlotConfigProperties.SlotDefinition esgEnergy = new SlotConfigProperties.SlotDefinition();
+        esgEnergy.setName("esg.energy.usage");
+        esgEnergy.setKeywords(List.of("에너지", "energy", "전력"));
+        esgEnergy.setRequired(true);
+
+        SlotConfigProperties.SlotDefinition esgEthics = new SlotConfigProperties.SlotDefinition();
+        esgEthics.setName("esg.ethics.code");
+        esgEthics.setKeywords(List.of("윤리", "ethics"));
+        esgEthics.setRequired(false);
+
+        properties.setDomains(Map.of(
+                "safety", List.of(safetyTbm, safetyEducation),
+                "esg", List.of(esgEnergy, esgEthics)
+        ));
+    }
+
+    @Test
+    @DisplayName("키워드가 포함된 파일명으로 슬롯을 매칭한다")
+    void matchSlotName_matchesKeyword() {
+        assertThat(properties.matchSlotName("TBM_점검표.pdf", "SAFETY"))
+                .isEqualTo("safety.tbm");
+        assertThat(properties.matchSlotName("안전교육_이수현황.xlsx", "SAFETY"))
+                .isEqualTo("safety.education.status");
+        assertThat(properties.matchSlotName("energy_usage_2024.csv", "ESG"))
+                .isEqualTo("esg.energy.usage");
+    }
+
+    @Test
+    @DisplayName("매칭되는 키워드가 없으면 domain.other를 반환한다")
+    void matchSlotName_fallbackToOther() {
+        assertThat(properties.matchSlotName("unknown_file.pdf", "SAFETY"))
+                .isEqualTo("safety.other");
+        assertThat(properties.matchSlotName("random.doc", "ESG"))
+                .isEqualTo("esg.other");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 도메인이면 domain.other를 반환한다")
+    void matchSlotName_unknownDomain() {
+        assertThat(properties.matchSlotName("test.pdf", "UNKNOWN"))
+                .isEqualTo("unknown.other");
+    }
+
+    @Test
+    @DisplayName("getSlotsForDomain은 해당 도메인의 슬롯 목록을 반환한다")
+    void getSlotsForDomain_returnsList() {
+        assertThat(properties.getSlotsForDomain("safety")).hasSize(2);
+        assertThat(properties.getSlotsForDomain("nonexistent")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getRequiredSlots는 required=true인 슬롯만 반환한다")
+    void getRequiredSlots_filtersRequired() {
+        List<SlotConfigProperties.SlotDefinition> required = properties.getRequiredSlots("esg");
+        assertThat(required).hasSize(1);
+        assertThat(required.get(0).getName()).isEqualTo("esg.energy.usage");
+    }
+}


### PR DESCRIPTION
## 변경요약
- `SlotConfigProperties` 클래스 신규 생성 (`@ConfigurationProperties(prefix = "ai.slots")`)
- `application.yaml`에 safety/compliance/esg 도메인별 슬롯 설정 추가 (12개 슬롯, 키워드 포함)
- `AiAnalysisService.guessSlotName()` 하드코딩 제거 → `SlotConfigProperties.matchSlotName()` 위임
- `SlotConfigPropertiesTest` 단위 테스트 5건 추가

## 관련 이슈
- closes #37

## 테스트 방법
- `./gradlew test` 전체 통과 확인
- `SlotConfigPropertiesTest`: 키워드 매칭, fallback(other), 미존재 도메인, 슬롯 목록 조회, required 필터링

## 명세 준수 체크
- [x] `@ConfigurationProperties`로 YAML 바인딩
- [x] 도메인별 슬롯 정의 (name, keywords, required)
- [x] `matchSlotName()` 키워드 기반 슬롯 매칭
- [x] `getRequiredSlots()` 필수 슬롯 필터링
- [x] 기존 하드코딩 로직 제거

## 리뷰 포인트
- YAML 슬롯 키워드 목록의 적절성
- `matchSlotName()` 첫 번째 매칭 반환 전략

## TODO / 질문
- 슬롯 키워드 추가/변경 시 YAML만 수정하면 됨 (코드 변경 불필요)