### PR TITLE
feat(ai): 슬롯 정의 확장 - docs §8.6 기준 (#61)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -69,46 +69,104 @@ ai:
     timeout-seconds: 180
     max-retry: 3
   slots:
+    # 슬롯 정의: docs/API_CONTRACT_SSOT.md §8.6 기준
     domains:
-      safety:
-        - name: safety.tbm
-          keywords: [tbm, 작업전, 안전점검, 안전회의, toolbox, 작업전회의]
+      # ESG 도메인 (15개 슬롯, 필수 4개)
+      esg:
+        - name: esg.energy.electricity.usage
+          keywords: [전기, electricity, 전력사용, 전기사용, 전력량, kwh]
           required: true
+        - name: esg.energy.electricity.bill
+          keywords: [전기고지서, 전기요금, electricity bill, 전기청구]
+          required: false
+        - name: esg.energy.gas.usage
+          keywords: [가스, gas, 도시가스, 가스사용, 가스량]
+          required: true
+        - name: esg.energy.gas.bill
+          keywords: [가스고지서, 가스요금, gas bill, 가스청구]
+          required: false
+        - name: esg.energy.water.usage
+          keywords: [수도, water, 용수, 수도사용, 용수량]
+          required: false
+        - name: esg.energy.water.bill
+          keywords: [수도고지서, 수도요금, water bill, 수도청구]
+          required: false
+        - name: esg.energy.ghg.evidence
+          keywords: [ghg, 온실가스, greenhouse, 탄소, carbon, 배출량]
+          required: false
+        - name: esg.hazmat.msds
+          keywords: [msds, sds, 물질안전, 유해물질, 화학물질, hazmat]
+          required: true
+        - name: esg.hazmat.inventory
+          keywords: [유해물질목록, 화학물질목록, hazmat inventory, 물질목록]
+          required: false
+        - name: esg.hazmat.disposal.list
+          keywords: [폐기목록, 처리목록, disposal list, 폐기물]
+          required: false
+        - name: esg.hazmat.disposal.evidence
+          keywords: [폐기증빙, 처리증빙, disposal evidence, 폐기확인]
+          required: false
+        - name: esg.ethics.code
+          keywords: [윤리강령, 행동강령, ethics, code of conduct, 윤리규정]
+          required: true
+        - name: esg.ethics.distribution.log
+          keywords: [배포확인, 수신확인, distribution, 서명명단]
+          required: false
+        - name: esg.ethics.pledge
+          keywords: [서약서, pledge, 서약, 윤리서약]
+          required: false
+        - name: esg.ethics.poster.image
+          keywords: [포스터, poster, 윤리포스터, 게시물]
+          required: false
+      # Safety 도메인 (8개 슬롯, 필수 4개)
+      safety:
         - name: safety.education.status
-          keywords: [교육, education, 이수, 안전교육, 교육이수, 수료]
+          keywords: [교육이수, 안전교육, education status, 교육현황, 수료]
           required: true
         - name: safety.fire.inspection
-          keywords: [소방, fire, 점검, 소방점검, 소화기, 방화]
+          keywords: [소방점검, fire inspection, 소화기, 방화, 소방]
+          required: true
+        - name: safety.risk.assessment
+          keywords: [위험성평가, risk assessment, 위험평가, 리스크]
+          required: true
+        - name: safety.management.system
+          keywords: [안전보건관리, management system, 안전매뉴얼, 관리체계]
           required: true
         - name: safety.site.photos
-          keywords: [사진, photo, 현장, 현장사진, site, image]
-          required: true
+          keywords: [현장사진, site photo, 현장, 사진, image]
+          required: false
+        - name: safety.education.attendance
+          keywords: [출석부, attendance, 교육출석, 참석명단]
+          required: false
+        - name: safety.education.photo
+          keywords: [교육사진, education photo, 교육일사진]
+          required: false
+        - name: safety.tbm
+          keywords: [tbm, toolbox, 작업전회의, 안전회의, 작업전미팅]
+          required: false
+      # Compliance 도메인 (7개 슬롯, 필수 3개)
       compliance:
         - name: compliance.contract.sample
-          keywords: [계약, contract, 계약서, 샘플, 표준계약, 도급계약]
+          keywords: [표준계약, 하도급계약, contract sample, 근로계약, 계약서]
           required: true
-        - name: compliance.contract.status
-          keywords: [계약현황, 현황, status, 계약목록]
+        - name: compliance.education.privacy
+          keywords: [개인정보교육, privacy education, 개인정보보호, 정보보호교육]
           required: true
-        - name: compliance.privacy.policy
-          keywords: [개인정보, privacy, 정책, 보호, 개인정보처리]
+        - name: compliance.fair.trade
+          keywords: [공정거래, fair trade, 자율점검, 공정거래점검]
           required: true
-        - name: compliance.education.status
-          keywords: [교육, education, 이수, 법정교육, 컴플라이언스교육]
-          required: true
-      esg:
-        - name: esg.energy.usage
-          keywords: [에너지, energy, 사용량, 전력, 가스, 에너지사용]
-          required: true
-        - name: esg.energy.bill
-          keywords: [고지서, bill, 근거, 요금, 청구서, 납부]
-          required: true
-        - name: esg.hazmat.msds
-          keywords: [msds, 화학, 물질안전, 유해물질, 화학물질, hazmat]
-          required: true
-        - name: esg.ethics.code
-          keywords: [윤리, ethics, 강령, 윤리강령, 행동강령, code of conduct]
-          required: true
+        - name: compliance.ethics.report
+          keywords: [내부신고, ethics report, 윤리신고, 신고현황]
+          required: false
+        - name: compliance.education.plan
+          keywords: [교육계획, education plan, 법정교육, 교육일정]
+          required: false
+        - name: compliance.education.attendance
+          keywords: [출석부, attendance, 교육출석, 참석명단]
+          required: false
+        - name: compliance.education.photo
+          keywords: [교육사진, education photo, 교육일사진]
+          required: false
 
 ---
 # ========================================

--- a/src/test/java/com/smartchain/platform/domain/ai/config/SlotConfigPropertiesTest.java
+++ b/src/test/java/com/smartchain/platform/domain/ai/config/SlotConfigPropertiesTest.java
@@ -2,7 +2,11 @@ package com.smartchain.platform.domain.ai.config;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.Map;
@@ -17,73 +21,249 @@ class SlotConfigPropertiesTest {
     void setUp() {
         properties = new SlotConfigProperties();
 
-        // safety 도메인 슬롯 설정
-        SlotConfigProperties.SlotDefinition safetyTbm = new SlotConfigProperties.SlotDefinition();
-        safetyTbm.setName("safety.tbm");
-        safetyTbm.setKeywords(List.of("tbm", "작업전", "안전점검"));
-        safetyTbm.setRequired(true);
+        // ESG 도메인 슬롯 설정 (docs/API_CONTRACT_SSOT.md §8.6 기준)
+        SlotConfigProperties.SlotDefinition esgElectricityUsage = createSlot(
+            "esg.energy.electricity.usage", List.of("전기", "electricity", "전력사용"), true);
+        SlotConfigProperties.SlotDefinition esgGasUsage = createSlot(
+            "esg.energy.gas.usage", List.of("가스", "gas", "도시가스"), true);
+        SlotConfigProperties.SlotDefinition esgMsds = createSlot(
+            "esg.hazmat.msds", List.of("msds", "sds", "물질안전"), true);
+        SlotConfigProperties.SlotDefinition esgEthics = createSlot(
+            "esg.ethics.code", List.of("윤리강령", "ethics", "행동강령"), true);
+        SlotConfigProperties.SlotDefinition esgWaterUsage = createSlot(
+            "esg.energy.water.usage", List.of("수도", "water", "용수"), false);
 
-        SlotConfigProperties.SlotDefinition safetyEducation = new SlotConfigProperties.SlotDefinition();
-        safetyEducation.setName("safety.education.status");
-        safetyEducation.setKeywords(List.of("교육", "education", "이수"));
-        safetyEducation.setRequired(true);
+        // Safety 도메인 슬롯 설정
+        SlotConfigProperties.SlotDefinition safetyEducation = createSlot(
+            "safety.education.status", List.of("교육이수", "안전교육", "education status"), true);
+        SlotConfigProperties.SlotDefinition safetyFire = createSlot(
+            "safety.fire.inspection", List.of("소방점검", "fire inspection"), true);
+        SlotConfigProperties.SlotDefinition safetyRisk = createSlot(
+            "safety.risk.assessment", List.of("위험성평가", "risk assessment"), true);
+        SlotConfigProperties.SlotDefinition safetyManagement = createSlot(
+            "safety.management.system", List.of("안전보건관리", "management system"), true);
+        SlotConfigProperties.SlotDefinition safetyTbm = createSlot(
+            "safety.tbm", List.of("tbm", "toolbox", "작업전회의"), false);
 
-        // esg 도메인 슬롯 설정
-        SlotConfigProperties.SlotDefinition esgEnergy = new SlotConfigProperties.SlotDefinition();
-        esgEnergy.setName("esg.energy.usage");
-        esgEnergy.setKeywords(List.of("에너지", "energy", "전력"));
-        esgEnergy.setRequired(true);
-
-        SlotConfigProperties.SlotDefinition esgEthics = new SlotConfigProperties.SlotDefinition();
-        esgEthics.setName("esg.ethics.code");
-        esgEthics.setKeywords(List.of("윤리", "ethics"));
-        esgEthics.setRequired(false);
+        // Compliance 도메인 슬롯 설정
+        SlotConfigProperties.SlotDefinition complianceContract = createSlot(
+            "compliance.contract.sample", List.of("표준계약", "하도급계약", "contract sample"), true);
+        SlotConfigProperties.SlotDefinition compliancePrivacy = createSlot(
+            "compliance.education.privacy", List.of("개인정보교육", "privacy education"), true);
+        SlotConfigProperties.SlotDefinition complianceFairTrade = createSlot(
+            "compliance.fair.trade", List.of("공정거래", "fair trade", "자율점검"), true);
+        SlotConfigProperties.SlotDefinition complianceEthicsReport = createSlot(
+            "compliance.ethics.report", List.of("내부신고", "ethics report"), false);
 
         properties.setDomains(Map.of(
-                "safety", List.of(safetyTbm, safetyEducation),
-                "esg", List.of(esgEnergy, esgEthics)
+            "esg", List.of(esgElectricityUsage, esgGasUsage, esgMsds, esgEthics, esgWaterUsage),
+            "safety", List.of(safetyEducation, safetyFire, safetyRisk, safetyManagement, safetyTbm),
+            "compliance", List.of(complianceContract, compliancePrivacy, complianceFairTrade, complianceEthicsReport)
         ));
     }
 
-    @Test
-    @DisplayName("키워드가 포함된 파일명으로 슬롯을 매칭한다")
-    void matchSlotName_matchesKeyword() {
-        assertThat(properties.matchSlotName("TBM_점검표.pdf", "SAFETY"))
+    private SlotConfigProperties.SlotDefinition createSlot(String name, List<String> keywords, boolean required) {
+        SlotConfigProperties.SlotDefinition slot = new SlotConfigProperties.SlotDefinition();
+        slot.setName(name);
+        slot.setKeywords(keywords);
+        slot.setRequired(required);
+        return slot;
+    }
+
+    @Nested
+    @DisplayName("matchSlotName")
+    class MatchSlotNameTest {
+
+        @Test
+        @DisplayName("ESG 전기사용량 파일명을 esg.energy.electricity.usage로 매칭한다")
+        void matchSlotName_esgElectricity() {
+            assertThat(properties.matchSlotName("전기사용량_2024.xlsx", "ESG"))
+                .isEqualTo("esg.energy.electricity.usage");
+            assertThat(properties.matchSlotName("electricity_usage.csv", "ESG"))
+                .isEqualTo("esg.energy.electricity.usage");
+        }
+
+        @Test
+        @DisplayName("ESG 가스사용량 파일명을 esg.energy.gas.usage로 매칭한다")
+        void matchSlotName_esgGas() {
+            assertThat(properties.matchSlotName("도시가스_사용량.xlsx", "ESG"))
+                .isEqualTo("esg.energy.gas.usage");
+            assertThat(properties.matchSlotName("gas_usage_report.pdf", "ESG"))
+                .isEqualTo("esg.energy.gas.usage");
+        }
+
+        @Test
+        @DisplayName("Safety TBM 파일명을 safety.tbm으로 매칭한다 (필수 아님)")
+        void matchSlotName_safetyTbm() {
+            assertThat(properties.matchSlotName("TBM_점검표.pdf", "SAFETY"))
                 .isEqualTo("safety.tbm");
-        assertThat(properties.matchSlotName("안전교육_이수현황.xlsx", "SAFETY"))
-                .isEqualTo("safety.education.status");
-        assertThat(properties.matchSlotName("energy_usage_2024.csv", "ESG"))
-                .isEqualTo("esg.energy.usage");
-    }
+            assertThat(properties.matchSlotName("toolbox_meeting.xlsx", "SAFETY"))
+                .isEqualTo("safety.tbm");
+        }
 
-    @Test
-    @DisplayName("매칭되는 키워드가 없으면 domain.other를 반환한다")
-    void matchSlotName_fallbackToOther() {
-        assertThat(properties.matchSlotName("unknown_file.pdf", "SAFETY"))
+        @Test
+        @DisplayName("Safety 위험성평가 파일명을 safety.risk.assessment로 매칭한다")
+        void matchSlotName_safetyRisk() {
+            assertThat(properties.matchSlotName("위험성평가서_2024.xlsx", "SAFETY"))
+                .isEqualTo("safety.risk.assessment");
+            assertThat(properties.matchSlotName("risk assessment report.pdf", "SAFETY"))
+                .isEqualTo("safety.risk.assessment");
+        }
+
+        @Test
+        @DisplayName("Compliance 공정거래 파일명을 compliance.fair.trade로 매칭한다")
+        void matchSlotName_complianceFairTrade() {
+            assertThat(properties.matchSlotName("공정거래_자율점검표.xlsx", "COMPLIANCE"))
+                .isEqualTo("compliance.fair.trade");
+            assertThat(properties.matchSlotName("fair trade checklist.pdf", "COMPLIANCE"))
+                .isEqualTo("compliance.fair.trade");
+        }
+
+        @Test
+        @DisplayName("매칭되는 키워드가 없으면 domain.other를 반환한다")
+        void matchSlotName_fallbackToOther() {
+            assertThat(properties.matchSlotName("unknown_file.pdf", "SAFETY"))
                 .isEqualTo("safety.other");
-        assertThat(properties.matchSlotName("random.doc", "ESG"))
+            assertThat(properties.matchSlotName("random.doc", "ESG"))
                 .isEqualTo("esg.other");
-    }
+            assertThat(properties.matchSlotName("misc.xlsx", "COMPLIANCE"))
+                .isEqualTo("compliance.other");
+        }
 
-    @Test
-    @DisplayName("존재하지 않는 도메인이면 domain.other를 반환한다")
-    void matchSlotName_unknownDomain() {
-        assertThat(properties.matchSlotName("test.pdf", "UNKNOWN"))
+        @Test
+        @DisplayName("존재하지 않는 도메인이면 domain.other를 반환한다")
+        void matchSlotName_unknownDomain() {
+            assertThat(properties.matchSlotName("test.pdf", "UNKNOWN"))
                 .isEqualTo("unknown.other");
+        }
+
+        @Test
+        @DisplayName("대소문자 구분 없이 매칭한다")
+        void matchSlotName_caseInsensitive() {
+            assertThat(properties.matchSlotName("MSDS_문서.pdf", "esg"))
+                .isEqualTo("esg.hazmat.msds");
+            assertThat(properties.matchSlotName("TBM_meeting.pdf", "safety"))
+                .isEqualTo("safety.tbm");
+        }
     }
 
-    @Test
-    @DisplayName("getSlotsForDomain은 해당 도메인의 슬롯 목록을 반환한다")
-    void getSlotsForDomain_returnsList() {
-        assertThat(properties.getSlotsForDomain("safety")).hasSize(2);
-        assertThat(properties.getSlotsForDomain("nonexistent")).isEmpty();
+    @Nested
+    @DisplayName("getSlotsForDomain")
+    class GetSlotsForDomainTest {
+
+        @Test
+        @DisplayName("해당 도메인의 슬롯 목록을 반환한다")
+        void getSlotsForDomain_returnsList() {
+            assertThat(properties.getSlotsForDomain("esg")).hasSize(5);
+            assertThat(properties.getSlotsForDomain("safety")).hasSize(5);
+            assertThat(properties.getSlotsForDomain("compliance")).hasSize(4);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 도메인은 빈 목록을 반환한다")
+        void getSlotsForDomain_unknownReturnsEmpty() {
+            assertThat(properties.getSlotsForDomain("nonexistent")).isEmpty();
+        }
     }
 
-    @Test
-    @DisplayName("getRequiredSlots는 required=true인 슬롯만 반환한다")
-    void getRequiredSlots_filtersRequired() {
-        List<SlotConfigProperties.SlotDefinition> required = properties.getRequiredSlots("esg");
-        assertThat(required).hasSize(1);
-        assertThat(required.get(0).getName()).isEqualTo("esg.energy.usage");
+    @Nested
+    @DisplayName("getRequiredSlots")
+    class GetRequiredSlotsTest {
+
+        @Test
+        @DisplayName("ESG 도메인의 필수 슬롯은 4개다")
+        void getRequiredSlots_esg() {
+            List<SlotConfigProperties.SlotDefinition> required = properties.getRequiredSlots("esg");
+            assertThat(required).hasSize(4);
+            assertThat(required).extracting("name")
+                .containsExactlyInAnyOrder(
+                    "esg.energy.electricity.usage",
+                    "esg.energy.gas.usage",
+                    "esg.hazmat.msds",
+                    "esg.ethics.code"
+                );
+        }
+
+        @Test
+        @DisplayName("Safety 도메인의 필수 슬롯은 4개다 (TBM은 필수 아님)")
+        void getRequiredSlots_safety() {
+            List<SlotConfigProperties.SlotDefinition> required = properties.getRequiredSlots("safety");
+            assertThat(required).hasSize(4);
+            assertThat(required).extracting("name")
+                .containsExactlyInAnyOrder(
+                    "safety.education.status",
+                    "safety.fire.inspection",
+                    "safety.risk.assessment",
+                    "safety.management.system"
+                );
+            // TBM은 필수가 아님을 명시적으로 검증
+            assertThat(required).extracting("name")
+                .doesNotContain("safety.tbm");
+        }
+
+        @Test
+        @DisplayName("Compliance 도메인의 필수 슬롯은 3개다")
+        void getRequiredSlots_compliance() {
+            List<SlotConfigProperties.SlotDefinition> required = properties.getRequiredSlots("compliance");
+            assertThat(required).hasSize(3);
+            assertThat(required).extracting("name")
+                .containsExactlyInAnyOrder(
+                    "compliance.contract.sample",
+                    "compliance.education.privacy",
+                    "compliance.fair.trade"
+                );
+        }
+    }
+
+    /**
+     * application.yaml에서 로드된 슬롯 정의를 검증하는 통합 테스트
+     */
+    @Nested
+    @SpringBootTest
+    @ActiveProfiles("test")
+    @DisplayName("YAML 로딩 통합 테스트")
+    class YamlLoadingIntegrationTest {
+
+        @Autowired
+        private SlotConfigProperties yamlProperties;
+
+        @Test
+        @DisplayName("ESG 도메인은 15개 슬롯, 4개 필수로 정의되어야 한다")
+        void yamlLoading_esgSlotCount() {
+            List<SlotConfigProperties.SlotDefinition> esgSlots = yamlProperties.getSlotsForDomain("esg");
+            List<SlotConfigProperties.SlotDefinition> esgRequired = yamlProperties.getRequiredSlots("esg");
+
+            assertThat(esgSlots).hasSize(15);
+            assertThat(esgRequired).hasSize(4);
+        }
+
+        @Test
+        @DisplayName("Safety 도메인은 8개 슬롯, 4개 필수로 정의되어야 한다")
+        void yamlLoading_safetySlotCount() {
+            List<SlotConfigProperties.SlotDefinition> safetySlots = yamlProperties.getSlotsForDomain("safety");
+            List<SlotConfigProperties.SlotDefinition> safetyRequired = yamlProperties.getRequiredSlots("safety");
+
+            assertThat(safetySlots).hasSize(8);
+            assertThat(safetyRequired).hasSize(4);
+        }
+
+        @Test
+        @DisplayName("Compliance 도메인은 7개 슬롯, 3개 필수로 정의되어야 한다")
+        void yamlLoading_complianceSlotCount() {
+            List<SlotConfigProperties.SlotDefinition> complianceSlots = yamlProperties.getSlotsForDomain("compliance");
+            List<SlotConfigProperties.SlotDefinition> complianceRequired = yamlProperties.getRequiredSlots("compliance");
+
+            assertThat(complianceSlots).hasSize(7);
+            assertThat(complianceRequired).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("Safety TBM 슬롯은 필수가 아니어야 한다")
+        void yamlLoading_safetyTbmNotRequired() {
+            List<SlotConfigProperties.SlotDefinition> safetyRequired = yamlProperties.getRequiredSlots("safety");
+
+            assertThat(safetyRequired).extracting("name")
+                .doesNotContain("safety.tbm");
+        }
     }
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -28,3 +28,109 @@ jwt:
 logging:
   level:
     com.smartchain.platform: DEBUG
+
+# AI Run API 설정 (테스트용)
+ai:
+  run-api:
+    url: http://localhost:8000
+    timeout-seconds: 30
+    max-retry: 1
+  slots:
+    # 슬롯 정의: docs/API_CONTRACT_SSOT.md §8.6 기준
+    domains:
+      # ESG 도메인 (15개 슬롯, 필수 4개)
+      esg:
+        - name: esg.energy.electricity.usage
+          keywords: [전기, electricity, 전력사용, 전기사용, 전력량, kwh]
+          required: true
+        - name: esg.energy.electricity.bill
+          keywords: [전기고지서, 전기요금, electricity bill, 전기청구]
+          required: false
+        - name: esg.energy.gas.usage
+          keywords: [가스, gas, 도시가스, 가스사용, 가스량]
+          required: true
+        - name: esg.energy.gas.bill
+          keywords: [가스고지서, 가스요금, gas bill, 가스청구]
+          required: false
+        - name: esg.energy.water.usage
+          keywords: [수도, water, 용수, 수도사용, 용수량]
+          required: false
+        - name: esg.energy.water.bill
+          keywords: [수도고지서, 수도요금, water bill, 수도청구]
+          required: false
+        - name: esg.energy.ghg.evidence
+          keywords: [ghg, 온실가스, greenhouse, 탄소, carbon, 배출량]
+          required: false
+        - name: esg.hazmat.msds
+          keywords: [msds, sds, 물질안전, 유해물질, 화학물질, hazmat]
+          required: true
+        - name: esg.hazmat.inventory
+          keywords: [유해물질목록, 화학물질목록, hazmat inventory, 물질목록]
+          required: false
+        - name: esg.hazmat.disposal.list
+          keywords: [폐기목록, 처리목록, disposal list, 폐기물]
+          required: false
+        - name: esg.hazmat.disposal.evidence
+          keywords: [폐기증빙, 처리증빙, disposal evidence, 폐기확인]
+          required: false
+        - name: esg.ethics.code
+          keywords: [윤리강령, 행동강령, ethics, code of conduct, 윤리규정]
+          required: true
+        - name: esg.ethics.distribution.log
+          keywords: [배포확인, 수신확인, distribution, 서명명단]
+          required: false
+        - name: esg.ethics.pledge
+          keywords: [서약서, pledge, 서약, 윤리서약]
+          required: false
+        - name: esg.ethics.poster.image
+          keywords: [포스터, poster, 윤리포스터, 게시물]
+          required: false
+      # Safety 도메인 (8개 슬롯, 필수 4개)
+      safety:
+        - name: safety.education.status
+          keywords: [교육이수, 안전교육, education status, 교육현황, 수료]
+          required: true
+        - name: safety.fire.inspection
+          keywords: [소방점검, fire inspection, 소화기, 방화, 소방]
+          required: true
+        - name: safety.risk.assessment
+          keywords: [위험성평가, risk assessment, 위험평가, 리스크]
+          required: true
+        - name: safety.management.system
+          keywords: [안전보건관리, management system, 안전매뉴얼, 관리체계]
+          required: true
+        - name: safety.site.photos
+          keywords: [현장사진, site photo, 현장, 사진, image]
+          required: false
+        - name: safety.education.attendance
+          keywords: [출석부, attendance, 교육출석, 참석명단]
+          required: false
+        - name: safety.education.photo
+          keywords: [교육사진, education photo, 교육일사진]
+          required: false
+        - name: safety.tbm
+          keywords: [tbm, toolbox, 작업전회의, 안전회의, 작업전미팅]
+          required: false
+      # Compliance 도메인 (7개 슬롯, 필수 3개)
+      compliance:
+        - name: compliance.contract.sample
+          keywords: [표준계약, 하도급계약, contract sample, 근로계약, 계약서]
+          required: true
+        - name: compliance.education.privacy
+          keywords: [개인정보교육, privacy education, 개인정보보호, 정보보호교육]
+          required: true
+        - name: compliance.fair.trade
+          keywords: [공정거래, fair trade, 자율점검, 공정거래점검]
+          required: true
+        - name: compliance.ethics.report
+          keywords: [내부신고, ethics report, 윤리신고, 신고현황]
+          required: false
+        - name: compliance.education.plan
+          keywords: [교육계획, education plan, 법정교육, 교육일정]
+          required: false
+        - name: compliance.education.attendance
+          keywords: [출석부, attendance, 교육출석, 참석명단]
+          required: false
+        - name: compliance.education.photo
+          keywords: [교육사진, education photo, 교육일사진]
+          required: false


### PR DESCRIPTION
## 변경 요약

application.yaml의 슬롯 정의를 docs/API_CONTRACT_SSOT.md §8.6 기준으로 확장했습니다.

| 도메인 | 변경 전 | 변경 후 | 필수 개수 |
|--------|:-------:|:-------:|:---------:|
| ESG | 4개 | 15개 | 4개 |
| Safety | 4개 | 8개 | 4개 |
| Compliance | 4개 | 7개 | 3개 |

### 주요 변경점
- **ESG**: `esg.energy.usage` → `esg.energy.electricity.usage`, `esg.energy.gas.usage` 분리
- **Safety**: `safety.tbm` 필수→선택, `safety.risk.assessment`, `safety.management.system` 추가
- **Compliance**: `compliance.contract.status` 삭제, `compliance.fair.trade`, `compliance.education.privacy` 추가

## 관련 이슈
- Closes #61

## 변경 파일
- `src/main/resources/application.yaml` - 슬롯 정의 확장
- `src/test/resources/application-test.yaml` - 테스트 프로파일 동기화
- `src/test/java/.../SlotConfigPropertiesTest.java` - 테스트 케이스 업데이트

## 테스트 방법

```bash
# 슬롯 설정 테스트
./gradlew test --tests "SlotConfigPropertiesTest"

# 전체 테스트
./gradlew test && ./gradlew build
```

## 명세 준수 체크

- [x] docs/API_CONTRACT_SSOT.md §8.6 ESG 슬롯 15개 정의
- [x] docs/API_CONTRACT_SSOT.md §8.6 Safety 슬롯 8개 정의
- [x] docs/API_CONTRACT_SSOT.md §8.6 Compliance 슬롯 7개 정의
- [x] ESG 필수 슬롯 4개 (electricity.usage, gas.usage, hazmat.msds, ethics.code)
- [x] Safety 필수 슬롯 4개 (education.status, fire.inspection, risk.assessment, management.system)
- [x] Compliance 필수 슬롯 3개 (contract.sample, education.privacy, fair.trade)
- [x] Safety TBM 필수 아님 검증

## 리뷰 포인트

1. **슬롯명 변경 영향도**: 기존 `esg.energy.usage` → `esg.energy.electricity.usage` 변경으로 기존 슬롯 힌트 데이터 호환성 확인 필요
2. **키워드 커버리지**: 각 슬롯의 keywords가 실제 파일명 패턴을 충분히 커버하는지 검토

## TODO/질문

- [ ] 기존 AI 분석 결과에 저장된 슬롯명(`esg.energy.usage` 등)과의 하위 호환성 - 마이그레이션 필요 여부?
- [ ] AI 레포의 정규식 패턴과 백엔드 keywords 동기화 자동화 방안?