### PR TITLE
feat(file): CSV 파일 업로드 지원 추가

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/file/service/FileService.java
+++ b/src/main/java/com/smartchain/platform/domain/file/service/FileService.java
@@ -45,6 +45,7 @@ public class FileService {
             "application/pdf",
             "application/vnd.ms-excel",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "text/csv",
             "image/png",
             "image/jpeg",
             "image/jpg"
@@ -310,6 +311,7 @@ public class FileService {
         return switch (extension) {
             case "PDF" -> "PDF";
             case "XLS", "XLSX" -> "XLSX";
+            case "CSV" -> "CSV";
             case "DOC", "DOCX" -> "DOCX";
             case "PNG" -> "PNG";
             case "JPG", "JPEG" -> "JPG";


### PR DESCRIPTION
## Summary
- 파일 업로드 시 CSV 형식 지원 추가
- `ALLOWED_MIME_TYPES`에 `text/csv` 추가
- `getFileType()` 메서드에 CSV 케이스 추가

## 지원 파일 형식 (변경 후)
`.pdf, .xls, .xlsx, .csv, .png, .jpeg, .jpg`

## Test plan
- [ ] CSV 파일 업로드 테스트
- [ ] 기존 파일 형식(PDF, XLS 등) 업로드 정상 동작 확인

Closes #67