### PR TITLE
feat(campaign): 캠페인 조회 API 구현

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/campaign/controller/CampaignController.java
+++ b/src/main/java/com/smartchain/platform/domain/campaign/controller/CampaignController.java
@@ -1,0 +1,42 @@
+package com.smartchain.platform.domain.campaign.controller;
+
+import com.smartchain.platform.domain.campaign.service.CampaignService;
+import com.smartchain.platform.dto.campaign.detail.CampaignDetailResponse;
+import com.smartchain.platform.dto.campaign.list.CampaignListResponse;
+import com.smartchain.platform.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/campaigns")
+@RequiredArgsConstructor
+@Tag(name = "Campaign", description = "캠페인 조회 API")
+public class CampaignController {
+
+    private final CampaignService campaignService;
+
+    @Operation(summary = "캠페인 목록 조회", description = "모든 캠페인 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<BaseResponse<CampaignListResponse>> getCampaignList() {
+        log.info("캠페인 목록 조회 요청");
+        CampaignListResponse response = campaignService.getCampaignList();
+        return ResponseEntity.ok(BaseResponse.success("캠페인 목록 조회 완료", response));
+    }
+
+    @Operation(summary = "캠페인 상세 조회", description = "캠페인 상세 정보를 조회합니다.")
+    @GetMapping("/{campaignId}")
+    public ResponseEntity<BaseResponse<CampaignDetailResponse>> getCampaignDetail(
+            @Parameter(description = "캠페인 ID")
+            @PathVariable Long campaignId
+    ) {
+        log.info("캠페인 상세 조회 요청 - campaignId: {}", campaignId);
+        CampaignDetailResponse response = campaignService.getCampaignDetail(campaignId);
+        return ResponseEntity.ok(BaseResponse.success("캠페인 상세 조회 완료", response));
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/campaign/service/CampaignService.java
+++ b/src/main/java/com/smartchain/platform/domain/campaign/service/CampaignService.java
@@ -1,0 +1,144 @@
+package com.smartchain.platform.domain.campaign.service;
+
+import com.smartchain.platform.domain.diagnostic.entity.Campaign;
+import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.domain.diagnostic.repository.CampaignRepository;
+import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
+import com.smartchain.platform.dto.campaign.detail.CampaignDetailResponse;
+import com.smartchain.platform.dto.campaign.detail.CampaignStatsDto;
+import com.smartchain.platform.dto.campaign.list.CampaignItemDto;
+import com.smartchain.platform.dto.campaign.list.CampaignListResponse;
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import com.smartchain.platform.global.enums.DiagnosticStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CampaignService {
+
+    private final CampaignRepository campaignRepository;
+    private final DiagnosticRepository diagnosticRepository;
+
+    /**
+     * 캠페인 목록 조회
+     */
+    public CampaignListResponse getCampaignList() {
+        List<Campaign> campaigns = campaignRepository.findAll();
+
+        List<CampaignItemDto> items = campaigns.stream()
+                .map(this::toCampaignItemDto)
+                .toList();
+
+        return CampaignListResponse.builder()
+                .campaigns(items)
+                .totalCount(items.size())
+                .build();
+    }
+
+    /**
+     * 캠페인 상세 조회
+     */
+    public CampaignDetailResponse getCampaignDetail(Long campaignId) {
+        Campaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CAMPAIGN_NOT_FOUND));
+
+        List<Diagnostic> diagnostics = diagnosticRepository.findByCampaign(campaign);
+
+        // 통계 계산
+        int totalTargets = diagnostics.size();
+        int notStarted = (int) diagnostics.stream()
+                .filter(d -> d.getStatus() == DiagnosticStatus.WRITING)
+                .count();
+        int inProgress = (int) diagnostics.stream()
+                .filter(d -> d.getStatus() == DiagnosticStatus.SUBMITTED || d.getStatus() == DiagnosticStatus.REVIEWING)
+                .count();
+        int submitted = (int) diagnostics.stream()
+                .filter(d -> d.getStatus() == DiagnosticStatus.APPROVED)
+                .count();
+        int approved = (int) diagnostics.stream()
+                .filter(d -> d.getStatus() == DiagnosticStatus.COMPLETED)
+                .count();
+        int rejected = (int) diagnostics.stream()
+                .filter(d -> d.getStatus() == DiagnosticStatus.RETURNED)
+                .count();
+
+        CampaignStatsDto stats = CampaignStatsDto.builder()
+                .totalTargets(totalTargets)
+                .notStarted(notStarted)
+                .inProgress(inProgress)
+                .submitted(submitted)
+                .approved(approved)
+                .rejected(rejected)
+                .build();
+
+        return CampaignDetailResponse.builder()
+                .campaignId(campaign.getCampaignId())
+                .campaignCode(campaign.getCampaignCode())
+                .title(campaign.getTitle())
+                .description(campaign.getContent())
+                .startDate(campaign.getPeriodStartDate())
+                .endDate(campaign.getPeriodEndDate())
+                .deadline(campaign.getDeadline())
+                .status(determineCampaignStatus(campaign))
+                .statusLabel(determineCampaignStatusLabel(campaign))
+                .stats(stats)
+                .targetCompanies(List.of())
+                .templates(List.of())
+                .build();
+    }
+
+    private CampaignItemDto toCampaignItemDto(Campaign campaign) {
+        List<Diagnostic> diagnostics = diagnosticRepository.findByCampaign(campaign);
+
+        int targetCount = diagnostics.size();
+        int submittedCount = (int) diagnostics.stream()
+                .filter(d -> d.getStatus() != DiagnosticStatus.WRITING)
+                .count();
+        int progressRate = targetCount > 0 ? (submittedCount * 100) / targetCount : 0;
+
+        return CampaignItemDto.builder()
+                .campaignId(campaign.getCampaignId())
+                .campaignCode(campaign.getCampaignCode())
+                .title(campaign.getTitle())
+                .description(campaign.getContent())
+                .startDate(campaign.getPeriodStartDate())
+                .endDate(campaign.getPeriodEndDate())
+                .deadline(campaign.getDeadline())
+                .status(determineCampaignStatus(campaign))
+                .statusLabel(determineCampaignStatusLabel(campaign))
+                .targetCompanyCount(targetCount)
+                .submittedCount(submittedCount)
+                .progressRate(progressRate)
+                .build();
+    }
+
+    private String determineCampaignStatus(Campaign campaign) {
+        LocalDate now = LocalDate.now();
+        if (campaign.getPeriodStartDate().isAfter(now)) {
+            return "DRAFT";
+        } else if (campaign.getPeriodEndDate().isBefore(now)) {
+            return "CLOSED";
+        } else {
+            return "ACTIVE";
+        }
+    }
+
+    private String determineCampaignStatusLabel(Campaign campaign) {
+        String status = determineCampaignStatus(campaign);
+        return switch (status) {
+            case "DRAFT" -> "준비중";
+            case "ACTIVE" -> "진행중";
+            case "CLOSED" -> "종료";
+            default -> "알 수 없음";
+        };
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/repository/DiagnosticRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/repository/DiagnosticRepository.java
@@ -1,5 +1,6 @@
 package com.smartchain.platform.domain.diagnostic.repository;
 
+import com.smartchain.platform.domain.diagnostic.entity.Campaign;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.global.enums.DiagnosticStatus;
@@ -47,4 +48,6 @@ public interface DiagnosticRepository extends JpaRepository<Diagnostic, Long> {
 
     @Query("SELECT MAX(d.diagnosticId) FROM Diagnostic d")
     Long findMaxDiagnosticId();
+
+    List<Diagnostic> findByCampaign(Campaign campaign);
 }

--- a/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
+++ b/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
@@ -178,7 +178,38 @@ public class DataInitializer implements CommandLineRunner {
                 .periodEndDate(LocalDate.of(2026, 12, 31))
                 .deadline(LocalDate.of(2026, 3, 31))
                 .build());
-        log.info("Campaign created: 2026년 ESG 공급망 진단");
+
+        Campaign campaign2026Safety = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-2026-002")
+                .ownerCompanyId(ownerCompany.getCompanyId())
+                .title("2026년 상반기 안전보건 점검")
+                .content("2026년 상반기 협력사 안전보건 관리 현황 점검")
+                .periodStartDate(LocalDate.of(2026, 1, 1))
+                .periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 2, 28))
+                .build());
+
+        Campaign campaign2026Compliance = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-2026-003")
+                .ownerCompanyId(ownerCompany.getCompanyId())
+                .title("2026년 하도급 컴플라이언스 점검")
+                .content("2026년도 협력사 하도급 계약 및 법규 준수 현황 점검")
+                .periodStartDate(LocalDate.of(2026, 3, 1))
+                .periodEndDate(LocalDate.of(2026, 5, 31))
+                .deadline(LocalDate.of(2026, 4, 30))
+                .build());
+
+        Campaign campaign2025 = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-2025-001")
+                .ownerCompanyId(ownerCompany.getCompanyId())
+                .title("2025년 ESG 공급망 진단")
+                .content("2025년도 협력사 ESG 경영 현황 진단 및 평가 (완료)")
+                .periodStartDate(LocalDate.of(2025, 1, 1))
+                .periodEndDate(LocalDate.of(2025, 12, 31))
+                .deadline(LocalDate.of(2025, 3, 31))
+                .build());
+
+        log.info("Campaigns created: 4 campaigns (2026 ESG, 2026 Safety, 2026 Compliance, 2025 ESG)");
 
         // 6. Diagnostic 생성
         Diagnostic diagnostic1 = diagnosticRepository.save(Diagnostic.builder()


### PR DESCRIPTION
## Summary
- 캠페인 목록 조회 API 구현 (`GET /api/v1/campaigns`)
- 캠페인 상세 조회 API 구현 (`GET /api/v1/campaigns/{id}`)
- DataInitializer에 더미 캠페인 데이터 4개 추가

## Changes
- `CampaignController` - 캠페인 조회 엔드포인트
- `CampaignService` - 캠페인 비즈니스 로직
- `DiagnosticRepository` - `findByCampaign` 메서드 추가
- `DataInitializer` - 더미 캠페인 데이터 추가

## API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/campaigns` | 캠페인 목록 조회 |
| GET | `/api/v1/campaigns/{id}` | 캠페인 상세 조회 |

## Test Plan
- [ ] Swagger UI에서 API 테스트
- [ ] 캠페인 목록 조회 확인
- [ ] 캠페인 상세 조회 확인

Closes #74