### PR TITLE
fix(file): 파일 목록 조회 500 에러 및 업로드 상태 검증 추가

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,41 @@
 # Claude Code Learnings
 
+## 2026-02-01: 파일 목록 조회 500 에러 및 삭제 409 에러 (#60)
+
+### 원인
+- `GET /api/v1/diagnostics/{id}/files` 파일 목록 조회 엔드포인트가 미구현되어 500 (S001) 발생
+- `uploadFile()`에서 진단 상태(SUBMITTED+) 검증이 누락되어 제출된 진단에도 업로드 허용
+- 업로드는 되지만 삭제 시 `isSubmittedOrLater()` 검증에 걸려 409 (BIZ_001) 발생
+
+### 해결
+- `FileController`에 `GET /api/v1/diagnostics/{diagnosticId}/files` 엔드포인트 추가
+- `FileService.getFileList()` 메서드 추가 (EvidenceFileDto 리스트 반환)
+- `FileService.uploadFile()`에 `isSubmittedOrLater()` 검증 추가 (WRITING/RETURNED만 허용)
+- 테스트 3건 추가: 파일 목록 조회 성공, 빈 목록 반환, 제출된 진단 업로드 차단
+
+### 재발 방지
+- 프론트엔드가 호출하는 API 엔드포인트와 백엔드 구현 1:1 대조 필수
+- 파일 업로드/삭제 등 상태 의존 API는 동일한 상태 검증 로직 적용
+- `FileServiceTest`에서 상태별 업로드/삭제 시나리오 검증
+
+### 검증 방법
+```bash
+./gradlew test --tests "FileServiceTest"
+./gradlew build
+```
+
+### 관련 커밋
+- (이 PR에 포함)
+
+### 생성/수정 파일
+```
+src/main/java/.../file/controller/FileController.java (파일 목록 조회 엔드포인트 추가)
+src/main/java/.../file/service/FileService.java (getFileList, 업로드 상태 검증 추가)
+src/test/java/.../file/service/FileServiceTest.java (테스트 3건 추가)
+```
+
+---
+
 ## 2026-01-30: SlotResult DTO에 extras 필드 누락 (#72)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/file/controller/FileController.java
+++ b/src/main/java/com/smartchain/platform/domain/file/controller/FileController.java
@@ -3,6 +3,7 @@ package com.smartchain.platform.domain.file.controller;
 import com.smartchain.platform.domain.file.service.FileService;
 import com.smartchain.platform.dto.common.file.*;
 import com.smartchain.platform.global.response.BaseResponse;
+import java.util.List;
 import com.smartchain.platform.global.security.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -37,6 +38,17 @@ public class FileController {
         return ResponseEntity
                 .status(HttpStatus.ACCEPTED)
                 .body(BaseResponse.success("파일 업로드가 시작되었습니다", response));
+    }
+
+    @Operation(summary = "파일 목록 조회", description = "진단에 업로드된 파일 목록을 조회합니다.")
+    @GetMapping("/api/v1/diagnostics/{diagnosticId}/files")
+    public ResponseEntity<BaseResponse<List<EvidenceFileDto>>> getFileList(
+            HttpServletRequest request,
+            @Parameter(description = "진단 ID")
+            @PathVariable Long diagnosticId) {
+        Long userId = extractUserIdFromRequest(request);
+        List<EvidenceFileDto> response = fileService.getFileList(userId, diagnosticId);
+        return ResponseEntity.ok(BaseResponse.success(response));
     }
 
     @Operation(summary = "파싱 결과 조회", description = "파일의 파싱 결과를 조회합니다. DRAFTER, APPROVER 권한 필요.")

--- a/src/main/java/com/smartchain/platform/domain/file/service/FileService.java
+++ b/src/main/java/com/smartchain/platform/domain/file/service/FileService.java
@@ -63,6 +63,12 @@ public class FileService {
                 .orElseThrow(() -> new CustomException(ErrorCode.DIAGNOSTIC_NOT_FOUND));
 
         validateDiagnosticAccess(user, diagnostic);
+
+        // 제출 이후 상태에서는 파일 업로드 불가
+        if (isSubmittedOrLater(diagnostic.getStatus())) {
+            throw new CustomException(ErrorCode.DIAGNOSTIC_INVALID_STATE_TRANSITION);
+        }
+
         validateFileForUpload(file);
 
         // 파일 저장소에 업로드
@@ -105,6 +111,38 @@ public class FileService {
                 .uploadedAt(LocalDateTime.now())
                 .jobId(savedJob.getJobId())
                 .statusCheckUrl(savedJob.getStatusCheckUrl())
+                .build();
+    }
+
+    /**
+     * 진단별 파일 목록 조회
+     */
+    public List<EvidenceFileDto> getFileList(Long userId, Long diagnosticId) {
+        User user = validateUser(userId);
+
+        Diagnostic diagnostic = diagnosticRepository.findById(diagnosticId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DIAGNOSTIC_NOT_FOUND));
+
+        validateDiagnosticAccess(user, diagnostic);
+
+        List<EvidenceFile> files = evidenceFileRepository.findByDiagnosticId(diagnosticId);
+
+        return files.stream()
+                .map(this::toEvidenceFileDto)
+                .collect(Collectors.toList());
+    }
+
+    private EvidenceFileDto toEvidenceFileDto(EvidenceFile file) {
+        return EvidenceFileDto.builder()
+                .fileId(file.getResultFileId())
+                .fileName(file.getOriginalFileName())
+                .fileUrl("/api/v1/files/" + file.getResultFileId() + "/download-url")
+                .fileType(getFileType(file.getOriginalFileName()))
+                .fileSize(file.getFileSize())
+                .parsingStatus(file.getParsingStatus() != null ? file.getParsingStatus().name() : null)
+                .parsedDataUrl("/api/v1/diagnostics/" + file.getDiagnostic().getDiagnosticId()
+                        + "/files/" + file.getResultFileId() + "/parsing-result")
+                .uploadedAt(file.getCreatedAt())
                 .build();
     }
 

--- a/src/test/java/com/smartchain/platform/domain/file/service/FileServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/file/service/FileServiceTest.java
@@ -135,6 +135,45 @@ class FileServiceTest {
     }
 
     @Nested
+    @DisplayName("파일 목록 조회 테스트")
+    class GetFileListTest {
+
+        @Test
+        @DisplayName("DRAFTER가 파일 목록 조회 성공")
+        void getFileList_Success() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(10L)).willReturn(Optional.of(testDiagnostic));
+            given(evidenceFileRepository.findByDiagnosticId(10L))
+                    .willReturn(List.of(testEvidenceFile));
+
+            // when
+            List<EvidenceFileDto> result = fileService.getFileList(1L, 10L);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getFileId()).isEqualTo(200L);
+            assertThat(result.get(0).getFileName()).isEqualTo("test.pdf");
+            assertThat(result.get(0).getParsingStatus()).isEqualTo("SUCCESS");
+        }
+
+        @Test
+        @DisplayName("파일이 없는 진단의 목록 조회 시 빈 리스트 반환")
+        void getFileList_Empty() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(10L)).willReturn(Optional.of(testDiagnostic));
+            given(evidenceFileRepository.findByDiagnosticId(10L)).willReturn(List.of());
+
+            // when
+            List<EvidenceFileDto> result = fileService.getFileList(1L, 10L);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
     @DisplayName("파일 업로드 테스트")
     class UploadFileTest {
 
@@ -182,6 +221,26 @@ class FileServiceTest {
                     .satisfies(ex -> {
                         CustomException ce = (CustomException) ex;
                         assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED);
+                    });
+        }
+
+        @Test
+        @DisplayName("제출된 진단에 파일 업로드 시 실패")
+        void uploadFile_SubmittedDiagnostic_ThrowsException() {
+            // given
+            MockMultipartFile file = new MockMultipartFile(
+                    "file", "test.pdf", "application/pdf", "test content".getBytes());
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(10L)).willReturn(Optional.of(testDiagnostic));
+            given(testDiagnostic.getStatus()).willReturn(DiagnosticStatus.SUBMITTED);
+
+            // when & then
+            assertThatThrownBy(() -> fileService.uploadFile(1L, 10L, file))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.DIAGNOSTIC_INVALID_STATE_TRANSITION);
                     });
         }
 


### PR DESCRIPTION
## 변경 요약
- **GET /api/v1/diagnostics/{id}/files** 파일 목록 조회 엔드포인트 신규 추가 (기존 500 에러 해결)
- **uploadFile()** 에 진단 상태 검증 추가 — SUBMITTED 이후 상태에서 파일 업로드 차단 (DELETE 409 근본 원인 해결)
- FileService에 `getFileList()`, `toEvidenceFileDto()` 메서드 추가

## 관련 이슈
- #60 (프론트엔드 이슈 #70에서 발견된 백엔드 버그)

## 테스트 방법
\`\`\`bash
./gradlew test --tests "FileServiceTest"   # 파일 서비스 테스트 (3건 추가, 총 12건)
./gradlew test                              # 전체 테스트 통과
./gradlew build                             # 빌드 성공
\`\`\`

### 수동 검증
1. GET /api/v1/diagnostics/2/files → 200 + 파일 목록 반환 확인
2. SUBMITTED 상태 진단(id=1)에 파일 업로드 시도 → 409 BIZ_001 반환 확인
3. WRITING 상태 진단에 파일 업로드 후 삭제 → 정상 동작 확인

## 명세 준수 체크
- [x] EvidenceFileDto 기존 DTO 재사용
- [x] BaseResponse<T> 래퍼 사용
- [x] 기존 권한 검증 패턴(validateDiagnosticAccess) 재사용
- [x] isSubmittedOrLater() 기존 로직 재사용

## 리뷰 포인트
1. 파일 목록 조회의 역할 검증: 현재 validateDiagnosticAccess만 사용 (DRAFTER/APPROVER/REVIEWER 모두 접근 가능). 추가 제한 필요한지?
2. EvidenceFileDto.parsingStatus 값이 entity의 ParsingStatus enum name과 동일 (WAITING/PROCESSING/SUCCESS/FAILED). 프론트엔드 기대값(PENDING?)과 차이가 있을 수 있음

## TODO / 질문
- [ ] API_QUICK_REFERENCE.md에 GET /api/v1/diagnostics/{id}/files 추가 필요
- [ ] 프론트엔드에서 기대하는 parsingStatus 값 확인 필요 (WAITING vs PENDING)