### PR TITLE
feat(diagnostic): 기안 목록 조회 keyword/status 필터링 구현

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,44 @@
 # Claude Code Learnings
 
+## 2026-02-01: 기안 목록 조회 필터링(status, keyword) 미구현
+
+### 원인
+- Controller에 `keyword` 파라미터 자체가 없어 검색 기능 불가
+- 프론트엔드가 `status`(단수)로 보내지만 백엔드는 `statuses`(복수)로 받아 매칭 실패
+- Repository 복합 쿼리에서 빈 리스트 IN 절 문제 잔존 (boolean 플래그 미적용)
+- 기존 if/else if 구조로 status + keyword + deadline 동시 필터링 불가
+
+### 해결
+- Controller에 `keyword`, `status`(alias) 파라미터 추가
+- Repository에 `findByFilters()` 통합 쿼리 추가 (boolean 플래그로 빈 IN 절 회피)
+- Repository에 `findByCompanyAndFilters()` 레거시 통합 쿼리 추가
+- Service의 if/else if 분기를 단일 통합 쿼리 호출로 교체
+- keyword는 title, diagnosticCode, company.name에 LIKE 검색
+
+### 재발 방지
+- 새 필터 파라미터 추가 시 프론트엔드 파라미터명과 1:1 대조
+- JPQL IN 절에는 항상 boolean 플래그 패턴 사용
+- 필터 조건은 if/else 분기 대신 단일 쿼리에 optional 조건으로 통합
+
+### 검증 방법
+```bash
+./gradlew test --tests "DiagnosticServiceTest"
+./gradlew build
+```
+
+### 관련 커밋
+- (이 PR에 포함)
+
+### 생성/수정 파일
+```
+src/main/java/.../diagnostic/controller/DiagnosticController.java (keyword, status 파라미터 추가)
+src/main/java/.../diagnostic/service/DiagnosticService.java (통합 필터링 로직)
+src/main/java/.../diagnostic/repository/DiagnosticRepository.java (findByFilters, findByCompanyAndFilters 추가)
+src/test/java/.../diagnostic/service/DiagnosticServiceTest.java (keyword, status 필터 테스트 추가)
+```
+
+---
+
 ## 2026-02-01: 파일 목록 조회 500 에러 및 삭제 409 에러 (#60)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/controller/DiagnosticController.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/controller/DiagnosticController.java
@@ -37,7 +37,7 @@ public class DiagnosticController {
     private final AiAnalysisJobService aiAnalysisJobService;
     private final JwtTokenProvider jwtTokenProvider;
 
-    @Operation(summary = "기안 목록 조회", description = "기안 목록을 조회합니다. DRAFTER는 본인 기안만, APPROVER는 소속 회사 전체 기안을 조회합니다. domainCode로 특정 도메인 필터링 가능합니다.")
+    @Operation(summary = "기안 목록 조회", description = "기안 목록을 조회합니다. DRAFTER는 본인 기안만, APPROVER는 소속 회사 전체 기안을 조회합니다. domainCode, status, keyword로 필터링 가능합니다.")
     @GetMapping
     public ResponseEntity<BaseResponse<DiagnosticListResponse>> getDiagnosticList(
             HttpServletRequest request,
@@ -45,6 +45,10 @@ public class DiagnosticController {
             @RequestParam(required = false) String domainCode,
             @Parameter(description = "상태 필터 (쉼표로 구분, 예: WRITING,SUBMITTED)")
             @RequestParam(required = false) String statuses,
+            @Parameter(description = "상태 필터 (statuses의 alias)")
+            @RequestParam(required = false) String status,
+            @Parameter(description = "검색 키워드 (제목, 기안코드, 회사명)")
+            @RequestParam(required = false) String keyword,
             @Parameter(description = "마감일 시작")
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate deadlineFrom,
             @Parameter(description = "마감일 종료")
@@ -52,7 +56,9 @@ public class DiagnosticController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         Long userId = extractUserIdFromRequest(request);
-        DiagnosticListResponse response = diagnosticService.getDiagnosticList(userId, domainCode, statuses, deadlineFrom, deadlineTo, page, size);
+        // status를 statuses의 alias로 지원
+        String effectiveStatuses = statuses != null ? statuses : status;
+        DiagnosticListResponse response = diagnosticService.getDiagnosticList(userId, domainCode, effectiveStatuses, keyword, deadlineFrom, deadlineTo, page, size);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/repository/DiagnosticRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/repository/DiagnosticRepository.java
@@ -76,50 +76,68 @@ public interface DiagnosticRepository extends JpaRepository<Diagnostic, Long> {
             @Param("domains") List<Domain> domains,
             Pageable pageable);
 
-    // 도메인 기반 복합 조회 (여러 역할의 도메인을 한번에 처리)
+    // 도메인 기반 복합 조회 (여러 역할의 도메인을 한번에 처리) — 레거시 호환용
     @Query("SELECT DISTINCT d FROM Diagnostic d WHERE " +
-           "(d.domain IN :reviewerDomains) OR " +
-           "(d.domain IN :approverDomains AND d.company = :company) OR " +
-           "(d.domain IN :drafterDomains AND d.drafterId = :drafterId) " +
+           "(:hasReviewer = true AND d.domain IN :reviewerDomains) OR " +
+           "(:hasApprover = true AND d.domain IN :approverDomains AND d.company = :company) OR " +
+           "(:hasDrafter = true AND d.domain IN :drafterDomains AND d.drafterId = :drafterId) " +
            "ORDER BY d.createdAt DESC")
     Page<Diagnostic> findByUserDomainRoles(
             @Param("reviewerDomains") List<Domain> reviewerDomains,
             @Param("approverDomains") List<Domain> approverDomains,
             @Param("drafterDomains") List<Domain> drafterDomains,
+            @Param("hasReviewer") boolean hasReviewer,
+            @Param("hasApprover") boolean hasApprover,
+            @Param("hasDrafter") boolean hasDrafter,
             @Param("company") Company company,
             @Param("drafterId") Long drafterId,
             Pageable pageable);
 
-    // 상태 필터 포함 도메인 기반 복합 조회
-    @Query("SELECT DISTINCT d FROM Diagnostic d WHERE " +
-           "d.status IN :statuses AND (" +
-           "(d.domain IN :reviewerDomains) OR " +
-           "(d.domain IN :approverDomains AND d.company = :company) OR " +
-           "(d.domain IN :drafterDomains AND d.drafterId = :drafterId)) " +
+    // 통합 필터링 쿼리 (status + keyword + domain 권한 + deadline)
+    @Query("SELECT DISTINCT d FROM Diagnostic d LEFT JOIN d.company c WHERE " +
+           "(" +
+           "  (:hasReviewer = true AND d.domain IN :reviewerDomains) OR " +
+           "  (:hasApprover = true AND d.domain IN :approverDomains AND d.company = :company) OR " +
+           "  (:hasDrafter = true AND d.domain IN :drafterDomains AND d.drafterId = :drafterId)" +
+           ") " +
+           "AND (:hasStatuses = false OR d.status IN :statuses) " +
+           "AND (:keyword IS NULL OR d.title LIKE %:keyword% OR d.diagnosticCode LIKE %:keyword% OR c.name LIKE %:keyword%) " +
+           "AND (:deadlineFrom IS NULL OR d.deadline >= :deadlineFrom) " +
+           "AND (:deadlineTo IS NULL OR d.deadline <= :deadlineTo) " +
            "ORDER BY d.createdAt DESC")
-    Page<Diagnostic> findByUserDomainRolesAndStatusIn(
+    Page<Diagnostic> findByFilters(
             @Param("reviewerDomains") List<Domain> reviewerDomains,
             @Param("approverDomains") List<Domain> approverDomains,
             @Param("drafterDomains") List<Domain> drafterDomains,
+            @Param("hasReviewer") boolean hasReviewer,
+            @Param("hasApprover") boolean hasApprover,
+            @Param("hasDrafter") boolean hasDrafter,
             @Param("company") Company company,
             @Param("drafterId") Long drafterId,
+            @Param("hasStatuses") boolean hasStatuses,
             @Param("statuses") List<DiagnosticStatus> statuses,
+            @Param("keyword") String keyword,
+            @Param("deadlineFrom") LocalDate deadlineFrom,
+            @Param("deadlineTo") LocalDate deadlineTo,
             Pageable pageable);
 
-    // 기한 필터 포함 도메인 기반 복합 조회
-    @Query("SELECT DISTINCT d FROM Diagnostic d WHERE " +
-           "d.deadline BETWEEN :fromDate AND :toDate AND (" +
-           "(d.domain IN :reviewerDomains) OR " +
-           "(d.domain IN :approverDomains AND d.company = :company) OR " +
-           "(d.domain IN :drafterDomains AND d.drafterId = :drafterId)) " +
+    // 레거시 통합 필터링 (도메인 역할 없는 사용자용)
+    @Query("SELECT d FROM Diagnostic d LEFT JOIN d.company c WHERE " +
+           "d.company = :company " +
+           "AND (:hasDomain = false OR d.domain = :domain) " +
+           "AND (:hasStatuses = false OR d.status IN :statuses) " +
+           "AND (:keyword IS NULL OR d.title LIKE %:keyword% OR d.diagnosticCode LIKE %:keyword% OR c.name LIKE %:keyword%) " +
+           "AND (:deadlineFrom IS NULL OR d.deadline >= :deadlineFrom) " +
+           "AND (:deadlineTo IS NULL OR d.deadline <= :deadlineTo) " +
            "ORDER BY d.createdAt DESC")
-    Page<Diagnostic> findByUserDomainRolesAndDeadlineBetween(
-            @Param("reviewerDomains") List<Domain> reviewerDomains,
-            @Param("approverDomains") List<Domain> approverDomains,
-            @Param("drafterDomains") List<Domain> drafterDomains,
+    Page<Diagnostic> findByCompanyAndFilters(
             @Param("company") Company company,
-            @Param("drafterId") Long drafterId,
-            @Param("fromDate") LocalDate fromDate,
-            @Param("toDate") LocalDate toDate,
+            @Param("hasDomain") boolean hasDomain,
+            @Param("domain") Domain domain,
+            @Param("hasStatuses") boolean hasStatuses,
+            @Param("statuses") List<DiagnosticStatus> statuses,
+            @Param("keyword") String keyword,
+            @Param("deadlineFrom") LocalDate deadlineFrom,
+            @Param("deadlineTo") LocalDate deadlineTo,
             Pageable pageable);
 }

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -73,12 +73,19 @@ public class DiagnosticService {
             "COMPLETED", "완료"
     );
 
-    public DiagnosticListResponse getDiagnosticList(Long userId, String domainCode, String statuses, LocalDate deadlineFrom,
+    public DiagnosticListResponse getDiagnosticList(Long userId, String domainCode, String statuses,
+                                                     String keyword, LocalDate deadlineFrom,
                                                      LocalDate deadlineTo, int page, int size) {
         User currentUser = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         Company userCompany = currentUser.getCompany();
+
+        // 공통 필터 파라미터 준비
+        List<DiagnosticStatus> statusList = (statuses != null && !statuses.isEmpty())
+                ? parseStatuses(statuses) : Collections.emptyList();
+        boolean hasStatuses = !statusList.isEmpty();
+        String trimmedKeyword = (keyword != null && !keyword.isBlank()) ? keyword.trim() : null;
 
         // 도메인별 역할 분류
         List<Domain> reviewerDomains = new ArrayList<>();
@@ -98,7 +105,8 @@ public class DiagnosticService {
         // 도메인 역할이 없으면 레거시 로직 사용
         boolean hasDomainRoles = !reviewerDomains.isEmpty() || !approverDomains.isEmpty() || !drafterDomains.isEmpty();
         if (!hasDomainRoles) {
-            return getDiagnosticListLegacy(currentUser, userCompany, domainCode, statuses, deadlineFrom, deadlineTo, page, size);
+            return getDiagnosticListLegacy(currentUser, userCompany, domainCode, hasStatuses, statusList,
+                    trimmedKeyword, deadlineFrom, deadlineTo, page, size);
         }
 
         // domainCode 파라미터가 있으면 해당 도메인으로 필터링
@@ -108,101 +116,60 @@ public class DiagnosticService {
             drafterDomains = drafterDomains.stream().filter(d -> d.getCode().equals(domainCode)).toList();
         }
 
-        // 빈 리스트를 placeholder 도메인으로 대체 (JPQL IN 절 처리)
-        if (reviewerDomains.isEmpty()) {
-            reviewerDomains = Collections.emptyList();
-        }
-        if (approverDomains.isEmpty()) {
-            approverDomains = Collections.emptyList();
-        }
-        if (drafterDomains.isEmpty()) {
-            drafterDomains = Collections.emptyList();
+        boolean hasReviewer = !reviewerDomains.isEmpty();
+        boolean hasApprover = !approverDomains.isEmpty();
+        boolean hasDrafter = !drafterDomains.isEmpty();
+
+        // 모든 도메인 리스트가 비어있으면 빈 결과 반환
+        if (!hasReviewer && !hasApprover && !hasDrafter) {
+            return buildEmptyResponse(page, size);
         }
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<Diagnostic> diagnosticPage;
 
-        // APPROVER 권한 검증을 위한 회사 정보 (없으면 빈 회사로 처리)
-        Company companyForQuery = userCompany != null ? userCompany : null;
+        Page<Diagnostic> diagnosticPage = diagnosticRepository.findByFilters(
+                hasReviewer ? reviewerDomains : Collections.singletonList(null),
+                hasApprover ? approverDomains : Collections.singletonList(null),
+                hasDrafter ? drafterDomains : Collections.singletonList(null),
+                hasReviewer, hasApprover, hasDrafter,
+                userCompany, userId,
+                hasStatuses, hasStatuses ? statusList : Collections.singletonList(DiagnosticStatus.WRITING),
+                trimmedKeyword, deadlineFrom, deadlineTo,
+                pageable);
 
-        if (statuses != null && !statuses.isEmpty()) {
-            List<DiagnosticStatus> statusList = parseStatuses(statuses);
-            diagnosticPage = diagnosticRepository.findByUserDomainRolesAndStatusIn(
-                    reviewerDomains, approverDomains, drafterDomains,
-                    companyForQuery, userId, statusList, pageable);
-        } else if (deadlineFrom != null && deadlineTo != null) {
-            diagnosticPage = diagnosticRepository.findByUserDomainRolesAndDeadlineBetween(
-                    reviewerDomains, approverDomains, drafterDomains,
-                    companyForQuery, userId, deadlineFrom, deadlineTo, pageable);
-        } else {
-            diagnosticPage = diagnosticRepository.findByUserDomainRoles(
-                    reviewerDomains, approverDomains, drafterDomains,
-                    companyForQuery, userId, pageable);
-        }
-
-        List<DiagnosticListItemDto> content = diagnosticPage.getContent().stream()
-                .map(this::mapToListItemDto)
-                .toList();
-
-        PageDto pageDto = PageDto.builder()
-                .number(diagnosticPage.getNumber())
-                .size(diagnosticPage.getSize())
-                .totalElements(diagnosticPage.getTotalElements())
-                .totalPages(diagnosticPage.getTotalPages())
-                .build();
-
-        return DiagnosticListResponse.builder()
-                .content(content)
-                .page(pageDto)
-                .build();
+        return buildListResponse(diagnosticPage);
     }
 
     /**
      * 레거시: 도메인 역할이 없는 사용자용 기안 목록 조회
      */
     private DiagnosticListResponse getDiagnosticListLegacy(User currentUser, Company userCompany,
-                                                            String domainCode, String statuses, LocalDate deadlineFrom,
-                                                            LocalDate deadlineTo, int page, int size) {
+                                                            String domainCode, boolean hasStatuses,
+                                                            List<DiagnosticStatus> statusList, String keyword,
+                                                            LocalDate deadlineFrom, LocalDate deadlineTo,
+                                                            int page, int size) {
         validateAccessRole(currentUser);
 
         if (userCompany == null) {
             throw new CustomException(ErrorCode.PERMISSION_DENIED_RESOURCE);
         }
 
-        Pageable pageable = PageRequest.of(page, size);
-        Page<Diagnostic> diagnosticPage;
-
-        // domainCode 필터가 있으면 도메인별 조회
+        Domain domain = null;
+        boolean hasDomain = false;
         if (domainCode != null && !domainCode.isEmpty()) {
-            Domain domain = domainRepository.findByCode(domainCode)
+            domain = domainRepository.findByCode(domainCode)
                     .orElseThrow(() -> new CustomException(ErrorCode.DOMAIN_NOT_FOUND));
-            diagnosticPage = diagnosticRepository.findByDomainOrderByCreatedAtDesc(domain, pageable);
-        } else if (statuses != null && !statuses.isEmpty()) {
-            List<DiagnosticStatus> statusList = parseStatuses(statuses);
-            diagnosticPage = diagnosticRepository.findByCompanyAndStatusInOrderByCreatedAtDesc(
-                    userCompany, statusList, pageable);
-        } else if (deadlineFrom != null && deadlineTo != null) {
-            diagnosticPage = diagnosticRepository.findByCompanyAndDeadlineBetweenOrderByCreatedAtDesc(
-                    userCompany, deadlineFrom, deadlineTo, pageable);
-        } else {
-            diagnosticPage = diagnosticRepository.findByCompanyOrderByCreatedAtDesc(userCompany, pageable);
+            hasDomain = true;
         }
 
-        List<DiagnosticListItemDto> content = diagnosticPage.getContent().stream()
-                .map(this::mapToListItemDto)
-                .toList();
+        Pageable pageable = PageRequest.of(page, size);
 
-        PageDto pageDto = PageDto.builder()
-                .number(diagnosticPage.getNumber())
-                .size(diagnosticPage.getSize())
-                .totalElements(diagnosticPage.getTotalElements())
-                .totalPages(diagnosticPage.getTotalPages())
-                .build();
+        Page<Diagnostic> diagnosticPage = diagnosticRepository.findByCompanyAndFilters(
+                userCompany, hasDomain, domain,
+                hasStatuses, hasStatuses ? statusList : Collections.singletonList(DiagnosticStatus.WRITING),
+                keyword, deadlineFrom, deadlineTo, pageable);
 
-        return DiagnosticListResponse.builder()
-                .content(content)
-                .page(pageDto)
-                .build();
+        return buildListResponse(diagnosticPage);
     }
 
     public DiagnosticDetailResponse getDiagnosticDetail(Long userId, Long diagnosticId) {
@@ -556,6 +523,38 @@ public class DiagnosticService {
                 throw new CustomException(ErrorCode.PERMISSION_DENIED_RESOURCE);
             }
         }
+    }
+
+    private DiagnosticListResponse buildListResponse(Page<Diagnostic> diagnosticPage) {
+        List<DiagnosticListItemDto> content = diagnosticPage.getContent().stream()
+                .map(this::mapToListItemDto)
+                .toList();
+
+        PageDto pageDto = PageDto.builder()
+                .number(diagnosticPage.getNumber())
+                .size(diagnosticPage.getSize())
+                .totalElements(diagnosticPage.getTotalElements())
+                .totalPages(diagnosticPage.getTotalPages())
+                .build();
+
+        return DiagnosticListResponse.builder()
+                .content(content)
+                .page(pageDto)
+                .build();
+    }
+
+    private DiagnosticListResponse buildEmptyResponse(int page, int size) {
+        PageDto pageDto = PageDto.builder()
+                .number(page)
+                .size(size)
+                .totalElements(0)
+                .totalPages(0)
+                .build();
+
+        return DiagnosticListResponse.builder()
+                .content(Collections.emptyList())
+                .page(pageDto)
+                .build();
     }
 
     private List<DiagnosticStatus> parseStatuses(String statuses) {

--- a/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
@@ -48,6 +48,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -151,11 +152,11 @@ class DiagnosticServiceTest {
             Page<Diagnostic> diagnosticPage = new PageImpl<>(List.of(diagnostic), PageRequest.of(0, 10), 1);
 
             given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
-            given(diagnosticRepository.findByCompanyOrderByCreatedAtDesc(eq(testCompany), any()))
+            given(diagnosticRepository.findByCompanyAndFilters(eq(testCompany), eq(false), any(), eq(false), any(), any(), any(), any(), any()))
                     .willReturn(diagnosticPage);
 
             // when
-            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, null, null, null, null, 0, 10);
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, null, null, null, null, null, 0, 10);
 
             // then
             assertThat(response).isNotNull();
@@ -187,11 +188,11 @@ class DiagnosticServiceTest {
             Page<Diagnostic> diagnosticPage = new PageImpl<>(List.of(diagnostic), PageRequest.of(0, 10), 1);
 
             given(userRepository.findById(2L)).willReturn(Optional.of(approverUser));
-            given(diagnosticRepository.findByCompanyOrderByCreatedAtDesc(eq(testCompany), any()))
+            given(diagnosticRepository.findByCompanyAndFilters(eq(testCompany), eq(false), any(), eq(false), any(), any(), any(), any(), any()))
                     .willReturn(diagnosticPage);
 
             // when
-            DiagnosticListResponse response = diagnosticService.getDiagnosticList(2L, null, null, null, null, 0, 10);
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(2L, null, null, null, null, null, 0, 10);
 
             // then
             assertThat(response).isNotNull();
@@ -209,7 +210,7 @@ class DiagnosticServiceTest {
             given(userRepository.findById(99L)).willReturn(Optional.of(guestUser));
 
             // when & then
-            assertThatThrownBy(() -> diagnosticService.getDiagnosticList(99L, null, null, null, null, 0, 10))
+            assertThatThrownBy(() -> diagnosticService.getDiagnosticList(99L, null, null, null, null, null, 0, 10))
                     .isInstanceOf(CustomException.class)
                     .satisfies(ex -> {
                         CustomException ce = (CustomException) ex;
@@ -617,11 +618,11 @@ class DiagnosticServiceTest {
 
             given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
             given(domainRepository.findByCode("ENV")).willReturn(Optional.of(envDomain));
-            given(diagnosticRepository.findByDomainOrderByCreatedAtDesc(eq(envDomain), any()))
+            given(diagnosticRepository.findByCompanyAndFilters(eq(testCompany), eq(true), eq(envDomain), eq(false), any(), any(), any(), any(), any()))
                     .willReturn(diagnosticPage);
 
             // when
-            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, "ENV", null, null, null, 0, 10);
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, "ENV", null, null, null, null, 0, 10);
 
             // then
             assertThat(response).isNotNull();
@@ -629,7 +630,6 @@ class DiagnosticServiceTest {
             assertThat(response.getContent().get(0).getDomain()).isNotNull();
             assertThat(response.getContent().get(0).getDomain().getCode()).isEqualTo("ENV");
             assertThat(response.getContent().get(0).getDomain().getName()).isEqualTo("환경");
-            verify(diagnosticRepository).findByDomainOrderByCreatedAtDesc(eq(envDomain), any());
         }
 
         @Test
@@ -676,6 +676,77 @@ class DiagnosticServiceTest {
         }
 
         @Test
+        @DisplayName("keyword 필터로 기안 목록 검색 성공 (레거시)")
+        void getDiagnosticList_WithKeywordFilter_Legacy_Success() {
+            // given
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            lenient().when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            lenient().when(diagnostic.getDiagnosticCode()).thenReturn("DG-2026-00001");
+            lenient().when(diagnostic.getTitle()).thenReturn("2026년 ESG 자가진단");
+            lenient().when(diagnostic.getCampaign()).thenReturn(testCampaign);
+            lenient().when(diagnostic.getCompany()).thenReturn(testCompany);
+            lenient().when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.WRITING);
+            lenient().when(diagnostic.getPeriodStartDate()).thenReturn(LocalDate.of(2026, 1, 1));
+            lenient().when(diagnostic.getPeriodEndDate()).thenReturn(LocalDate.of(2026, 12, 31));
+            lenient().when(diagnostic.getDeadline()).thenReturn(LocalDate.of(2026, 3, 31));
+            lenient().when(diagnostic.getQualitativeProgress()).thenReturn(0);
+            lenient().when(diagnostic.getQuantitativeProgress()).thenReturn(0);
+            lenient().when(diagnostic.getOverallProgress()).thenReturn(0);
+            lenient().when(diagnostic.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            Page<Diagnostic> diagnosticPage = new PageImpl<>(List.of(diagnostic), PageRequest.of(0, 10), 1);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findByCompanyAndFilters(
+                    eq(testCompany), eq(false), any(), eq(false), any(),
+                    eq("ESG"), any(), any(), any()))
+                    .willReturn(diagnosticPage);
+
+            // when
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, null, null, "ESG", null, null, 0, 10);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("status 필터로 기안 목록 조회 성공 (레거시)")
+        void getDiagnosticList_WithStatusFilter_Legacy_Success() {
+            // given
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            lenient().when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            lenient().when(diagnostic.getDiagnosticCode()).thenReturn("DG-2026-00001");
+            lenient().when(diagnostic.getTitle()).thenReturn("2026년 ESG 자가진단");
+            lenient().when(diagnostic.getCampaign()).thenReturn(testCampaign);
+            lenient().when(diagnostic.getCompany()).thenReturn(testCompany);
+            lenient().when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.WRITING);
+            lenient().when(diagnostic.getPeriodStartDate()).thenReturn(LocalDate.of(2026, 1, 1));
+            lenient().when(diagnostic.getPeriodEndDate()).thenReturn(LocalDate.of(2026, 12, 31));
+            lenient().when(diagnostic.getDeadline()).thenReturn(LocalDate.of(2026, 3, 31));
+            lenient().when(diagnostic.getQualitativeProgress()).thenReturn(0);
+            lenient().when(diagnostic.getQuantitativeProgress()).thenReturn(0);
+            lenient().when(diagnostic.getOverallProgress()).thenReturn(0);
+            lenient().when(diagnostic.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            Page<Diagnostic> diagnosticPage = new PageImpl<>(List.of(diagnostic), PageRequest.of(0, 10), 1);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findByCompanyAndFilters(
+                    eq(testCompany), eq(false), any(), eq(true), any(),
+                    any(), any(), any(), any()))
+                    .willReturn(diagnosticPage);
+
+            // when
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, null, "WRITING", null, null, null, 0, 10);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getContent()).hasSize(1);
+            assertThat(response.getContent().get(0).getStatus()).isEqualTo("WRITING");
+        }
+
+        @Test
         @DisplayName("존재하지 않는 domainCode 필터 시 DOMAIN_NOT_FOUND")
         void getDiagnosticList_InvalidDomainCode_ThrowsException() {
             // given
@@ -683,7 +754,7 @@ class DiagnosticServiceTest {
             given(domainRepository.findByCode("INVALID")).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> diagnosticService.getDiagnosticList(1L, "INVALID", null, null, null, 0, 10))
+            assertThatThrownBy(() -> diagnosticService.getDiagnosticList(1L, "INVALID", null, null, null, null, 0, 10))
                     .isInstanceOf(CustomException.class)
                     .satisfies(ex -> {
                         CustomException ce = (CustomException) ex;


### PR DESCRIPTION
## 변경 요약
- `GET /api/v1/diagnostics`에 `keyword`, `status` 쿼리 파라미터 추가
- `status`는 기존 `statuses`의 alias로 동작 (프론트엔드 호환)
- keyword 검색: 제목, 기안코드, 회사명에 LIKE 매칭
- Repository 통합 JPQL 쿼리로 모든 필터 동시 적용 가능 (기존 if/else 분기 제거)
- boolean 플래그 패턴으로 빈 리스트 IN 절 SQL 에러 방지

## 관련 이슈
- 프론트엔드 PR #89에서 보고된 백엔드 필터링 미구현 건

## 테스트 방법
```bash
./gradlew test --tests "DiagnosticServiceTest"  # 테스트 2건 추가, 전체 통과
./gradlew test                                   # 전체 테스트 통과
./gradlew build                                  # 빌드 성공
```

### 수동 검증
1. `GET /api/v1/diagnostics?status=WRITING` -> WRITING 상태만 반환
2. `GET /api/v1/diagnostics?keyword=ESG` -> 제목/코드/회사명에 ESG 포함된 기안만 반환
3. `GET /api/v1/diagnostics?domainCode=ESG&status=WRITING&keyword=테크` -> 복합 필터
4. `GET /api/v1/diagnostics?statuses=WRITING,SUBMITTED` -> 복수 상태 필터 (기존 호환)

## 명세 준수 체크
- [x] 기존 `statuses` 파라미터 하위 호환 유지
- [x] `status` 단수형 alias 추가 (프론트엔드 호환)
- [x] `BaseResponse<T>` 래퍼 사용
- [x] 빈 결과 시 빈 배열 + page 정보 정상 반환

## 리뷰 포인트
1. JPQL LIKE 검색은 DB 인덱스 활용 불가 (`%keyword%`). 데이터 규모가 커지면 Full-Text Search 고려 필요
2. `findByUserDomainRoles` 기존 메서드도 boolean 플래그 패턴으로 변경함 (기존 호출부 없으므로 안전)

## TODO / 질문
- [ ] 프론트엔드에서 `status` vs `statuses` 중 어떤 파라미터명을 표준으로 할지 합의 필요