### PR TITLE
feat: E2E 테스트용 초기 데이터 확장 및 테스트 문서 추가 (#79)

### DIFF
--- a/docs/E2E_TEST_SCENARIOS.md
+++ b/docs/E2E_TEST_SCENARIOS.md
@@ -1,0 +1,449 @@
+# E2E 테스트 시나리오
+
+> 프론트엔드-백엔드 통합 테스트용 시나리오 문서
+>
+> **테스트 환경**: http://localhost:8080
+> **공통 비밀번호**: `Test1234!`
+
+---
+
+## 1. 인증 (Authentication)
+
+### 1.1 로그인 성공
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 유효한 계정으로 로그인 |
+| **계정** | `drafter1@techpartner.co.kr` / `Test1234!` |
+| **API** | `POST /api/v1/auth/login` |
+| **예상 결과** | 200 OK, accessToken 반환 |
+| **확인 사항** | - 토큰이 정상 발급되는가<br>- 사용자 정보가 올바른가 |
+
+### 1.2 로그인 실패 - 잘못된 비밀번호
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 잘못된 비밀번호로 로그인 시도 |
+| **계정** | `drafter1@techpartner.co.kr` / `WrongPassword!` |
+| **예상 결과** | 401 Unauthorized, `AUTH_001` |
+
+### 1.3 로그인 실패 - 존재하지 않는 계정
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 존재하지 않는 이메일로 로그인 |
+| **계정** | `notexist@example.com` / `Test1234!` |
+| **예상 결과** | 401 Unauthorized, `AUTH_001` |
+
+---
+
+## 2. 진단 (Diagnostic)
+
+### 2.1 진단 목록 조회 - 기안자
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 기안자가 본인 진단 목록 조회 |
+| **계정** | `drafter1@techpartner.co.kr` |
+| **API** | `GET /api/v1/diagnostics` |
+| **예상 결과** | 본인이 작성한 진단만 표시 |
+| **확인 사항** | - DG-ESG-2026-001 (WRITING)<br>- DG-ESG-2026-006 (APPROVED)<br>- DG-COMPL-2026-001 (WRITING) |
+
+### 2.2 진단 목록 조회 - 도메인 필터
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | ESG 도메인 진단만 조회 |
+| **계정** | `drafter1@techpartner.co.kr` |
+| **API** | `GET /api/v1/diagnostics?domainCode=ESG` |
+| **예상 결과** | ESG 도메인 진단만 표시 |
+
+### 2.3 진단 목록 조회 - 상태 필터
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 작성중 상태 진단만 조회 |
+| **계정** | `drafter1@techpartner.co.kr` |
+| **API** | `GET /api/v1/diagnostics?statuses=WRITING` |
+| **예상 결과** | WRITING 상태 진단만 표시 |
+
+### 2.4 진단 상세 조회
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 진단 상세 정보 조회 |
+| **계정** | `drafter1@techpartner.co.kr` |
+| **API** | `GET /api/v1/diagnostics/{diagnosticId}` |
+| **예상 결과** | 진단 상세 정보 (캠페인, 회사, 기간, 상태 등) |
+
+### 2.5 진단 제출
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 작성중 진단을 제출 |
+| **계정** | `drafter1@techpartner.co.kr` |
+| **대상** | DG-ESG-2026-001 (WRITING 상태) |
+| **API** | `POST /api/v1/diagnostics/{id}/submit` |
+| **예상 결과** | - 상태: WRITING → SUBMITTED<br>- Approval 레코드 생성<br>- approvalId 반환 |
+
+### 2.6 진단 제출 실패 - 이미 제출됨
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 이미 제출된 진단 재제출 시도 |
+| **계정** | `drafter2@techpartner.co.kr` |
+| **대상** | DG-ESG-2026-003 (SUBMITTED 상태) |
+| **예상 결과** | 400 Bad Request, `BIZ_002` |
+
+### 2.7 진단 접근 권한 없음
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 다른 사람의 진단 접근 시도 |
+| **계정** | `drafter1@techpartner.co.kr` |
+| **대상** | 그린매뉴 소속 진단 |
+| **예상 결과** | 403 Forbidden |
+
+---
+
+## 3. 결재 (Approval)
+
+### 3.1 결재 대기 목록 조회 - 결재자
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 결재자가 대기중인 결재 목록 조회 |
+| **계정** | `approver@techpartner.co.kr` |
+| **API** | `GET /api/v1/approvals?status=WAITING` |
+| **예상 결과** | 테크파트너 소속 WAITING 상태 결재 목록 |
+| **확인 사항** | - DG-ESG-2026-003 결재 건 |
+
+### 3.2 결재 승인
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 결재 승인 처리 |
+| **계정** | `approver@techpartner.co.kr` |
+| **API** | `POST /api/v1/approvals/{id}/approve` |
+| **Body** | `{ "comment": "승인합니다" }` |
+| **예상 결과** | - Approval 상태: APPROVED<br>- Diagnostic 상태: APPROVED<br>- Review 레코드 생성 |
+
+### 3.3 결재 반려
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 결재 반려 처리 |
+| **계정** | `approver@techpartner.co.kr` |
+| **API** | `POST /api/v1/approvals/{id}/reject` |
+| **Body** | `{ "comment": "보완 필요합니다" }` |
+| **예상 결과** | - Approval 상태: REJECTED<br>- Diagnostic 상태: RETURNED |
+
+### 3.4 결재 권한 없음 - 다른 회사
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 다른 회사 결재 시도 |
+| **계정** | `approver@techpartner.co.kr` |
+| **대상** | 그린매뉴 결재 건 |
+| **예상 결과** | 403 Forbidden |
+
+---
+
+## 4. 심사 (Review)
+
+### 4.1 심사 대기 목록 조회 - 심사자
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 심사자가 심사 목록 조회 |
+| **계정** | `reviewer.esg@hdhhi.co.kr` |
+| **API** | `GET /api/v1/reviews?status=REVIEWING` |
+| **예상 결과** | ESG 도메인 심사 목록 |
+| **확인 사항** | - DG-ESG-2025-001 (테크파트너, 점수 68)<br>- DG-ESG-2025-002 (그린매뉴, 점수 75) |
+
+### 4.2 심사 상세 조회
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 심사 상세 정보 조회 |
+| **계정** | `reviewer.esg@hdhhi.co.kr` |
+| **API** | `GET /api/v1/reviews/{reviewId}` |
+| **예상 결과** | 심사 상세 (진단 정보, 점수, 위험도 등) |
+
+### 4.3 심사 승인
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 심사 승인 처리 |
+| **계정** | `reviewer.esg@hdhhi.co.kr` |
+| **API** | `POST /api/v1/reviews/{id}/approve` |
+| **Body** | `{ "comment": "우수합니다", "categoryCommentE": "환경 우수" }` |
+| **예상 결과** | - Review 상태: APPROVED<br>- Diagnostic 상태: COMPLETED |
+
+### 4.4 심사 보완 요청
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 보완 요청 처리 |
+| **계정** | `reviewer.esg@hdhhi.co.kr` |
+| **API** | `POST /api/v1/reviews/{id}/request-revision` |
+| **Body** | `{ "comment": "증빙자료 보완 필요" }` |
+| **예상 결과** | Review 상태: REVISION_REQUIRED |
+
+---
+
+## 5. 역할 요청 (Role Request)
+
+### 5.1 역할 요청 생성 - 게스트
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 게스트가 기안자 권한 요청 |
+| **계정** | `newbie1@precision.co.kr` |
+| **API** | `POST /api/v1/role-requests` |
+| **Body** | `{ "domainCode": "ESG", "requestedRole": "DRAFTER", "reason": "업무 담당" }` |
+| **예상 결과** | RoleRequest 생성, 상태: PENDING |
+
+### 5.2 역할 요청 목록 조회 - 심사자
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 심사자가 대기중인 역할 요청 조회 |
+| **계정** | `reviewer.esg@hdhhi.co.kr` |
+| **API** | `GET /api/v1/management/role-requests?status=PENDING` |
+| **예상 결과** | PENDING 상태 역할 요청 목록 |
+
+### 5.3 역할 요청 승인
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 역할 요청 승인 |
+| **계정** | `reviewer.esg@hdhhi.co.kr` |
+| **API** | `POST /api/v1/management/role-requests/{id}/approve` |
+| **예상 결과** | - RoleRequest 상태: APPROVED<br>- UserDomainRole 생성 |
+
+### 5.4 역할 요청 거절
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 역할 요청 거절 |
+| **계정** | `reviewer.esg@hdhhi.co.kr` |
+| **API** | `POST /api/v1/management/role-requests/{id}/reject` |
+| **Body** | `{ "rejectReason": "현재 권한 부여 불가" }` |
+| **예상 결과** | RoleRequest 상태: REJECTED |
+
+---
+
+## 6. 알림 (Notification)
+
+### 6.1 알림 목록 조회
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 본인 알림 목록 조회 |
+| **계정** | `drafter1@techpartner.co.kr` |
+| **API** | `GET /api/v1/notifications` |
+| **예상 결과** | 본인에게 온 알림 목록 |
+
+### 6.2 알림 읽음 처리
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 알림 읽음 표시 |
+| **API** | `PATCH /api/v1/notifications/{id}/read` |
+| **예상 결과** | isRead: true |
+
+---
+
+## 7. 캠페인 (Campaign)
+
+### 7.1 캠페인 목록 조회
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 진행중인 캠페인 목록 조회 |
+| **계정** | 아무 계정 |
+| **API** | `GET /api/v1/campaigns` |
+| **예상 결과** | 캠페인 목록 (6개) |
+
+### 7.2 캠페인 상세 조회
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 캠페인 상세 정보 조회 |
+| **API** | `GET /api/v1/campaigns/{campaignId}` |
+| **예상 결과** | 캠페인 상세 (기간, 마감일, 도메인 등) |
+
+---
+
+## 8. AI 분석 (AI Run API)
+
+### 8.1 AI 슬롯 추정 (Preview)
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | 업로드된 파일의 슬롯 추정 |
+| **계정** | `drafter1@techpartner.co.kr` |
+| **API** | `POST /api/v1/ai/run/diagnostics/{id}/preview` |
+| **예상 결과** | 슬롯 추정 결과 (slotHints) |
+
+### 8.2 AI 분석 요청 (Submit)
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | AI 전체 검증 요청 |
+| **API** | `POST /api/v1/ai/run/diagnostics/{id}/submit` |
+| **예상 결과** | 분석 시작, jobId 반환 |
+
+### 8.3 AI 분석 결과 조회
+
+| 항목 | 내용 |
+|------|------|
+| **시나리오** | AI 분석 결과 조회 |
+| **API** | `GET /api/v1/ai/run/diagnostics/{id}/result` |
+| **예상 결과** | 분석 결과 (verdict, riskLevel, slotResults) |
+
+---
+
+## 9. 도메인별 워크플로우 테스트
+
+> **주의**: 현재 백엔드에 도메인별 분기 미구현 (Issue #78)
+
+### 9.1 ESG 도메인 플로우 (현재 구현됨)
+
+```
+기안자 로그인 → 진단 작성 → 제출 → 결재자 승인 → 심사자 심사 → 완료
+```
+
+| 단계 | 계정 | 상태 변화 |
+|------|------|----------|
+| 1. 진단 제출 | drafter1@techpartner.co.kr | WRITING → SUBMITTED |
+| 2. 결재 승인 | approver@techpartner.co.kr | SUBMITTED → APPROVED |
+| 3. 심사 승인 | reviewer.esg@hdhhi.co.kr | APPROVED → COMPLETED |
+
+### 9.2 SAFETY 도메인 플로우 (구현 예정)
+
+```
+기안자 로그인 → 진단 작성 → 제출 → (결재 스킵) → 심사자 심사 → 완료
+```
+
+| 단계 | 계정 | 상태 변화 |
+|------|------|----------|
+| 1. 진단 제출 | drafter@safebuild.co.kr | WRITING → APPROVED (바로) |
+| 2. 심사 승인 | reviewer.safety@hdhhi.co.kr | APPROVED → COMPLETED |
+
+### 9.3 COMPLIANCE 도메인 플로우 (구현 예정)
+
+SAFETY와 동일
+
+---
+
+## 10. 에러 케이스 테스트
+
+### 10.1 인증 에러
+
+| 코드 | 상황 | 예상 응답 |
+|------|------|----------|
+| AUTH_001 | 잘못된 로그인 정보 | 401 |
+| AUTH_002 | 토큰 만료 | 401 |
+| AUTH_003 | 유효하지 않은 토큰 | 401 |
+
+### 10.2 권한 에러
+
+| 코드 | 상황 | 예상 응답 |
+|------|------|----------|
+| PERM_001 | 해당 액션 권한 없음 | 403 |
+| PERM_002 | 해당 리소스 접근 불가 | 403 |
+
+### 10.3 비즈니스 에러
+
+| 코드 | 상황 | 예상 응답 |
+|------|------|----------|
+| BIZ_001 | 상태 전이 불가 | 400 |
+| BIZ_002 | 이미 제출된 진단 | 400 |
+| BIZ_003 | 이미 처리된 결재 | 400 |
+
+### 10.4 리소스 에러
+
+| 코드 | 상황 | 예상 응답 |
+|------|------|----------|
+| RES_001 | 사용자 없음 | 404 |
+| RES_002 | 진단 없음 | 404 |
+| RES_003 | 결재 없음 | 404 |
+
+---
+
+## 부록: 테스트 계정 요약
+
+### 심사자 (REVIEWER)
+
+| 이메일 | 담당 도메인 |
+|--------|-------------|
+| reviewer.esg@hdhhi.co.kr | ESG |
+| reviewer.safety@hdhhi.co.kr | SAFETY |
+| reviewer.compliance@hdhhi.co.kr | COMPLIANCE |
+
+### 결재자 (APPROVER)
+
+| 이메일 | 회사 | 담당 도메인 |
+|--------|------|-------------|
+| approver@techpartner.co.kr | 테크파트너 | ESG, COMPLIANCE |
+| approver@greenmanu.co.kr | 그린매뉴팩처링 | ESG, SAFETY |
+| approver@safebuild.co.kr | 안전건설 | SAFETY |
+
+### 기안자 (DRAFTER)
+
+| 이메일 | 회사 | 담당 도메인 |
+|--------|------|-------------|
+| drafter1@techpartner.co.kr | 테크파트너 | ESG, COMPLIANCE |
+| drafter2@techpartner.co.kr | 테크파트너 | ESG |
+| drafter@greenmanu.co.kr | 그린매뉴팩처링 | ESG, SAFETY |
+| drafter@safebuild.co.kr | 안전건설 | SAFETY |
+
+### 게스트 (GUEST)
+
+| 이메일 | 회사 |
+|--------|------|
+| newbie1@precision.co.kr | 정밀부품 |
+| newbie2@precision.co.kr | 정밀부품 |
+
+---
+
+## 체크리스트
+
+### 인증
+- [ ] 로그인 성공
+- [ ] 로그인 실패 (잘못된 비밀번호)
+- [ ] 로그인 실패 (없는 계정)
+- [ ] 토큰 갱신
+
+### 진단
+- [ ] 목록 조회 (기안자)
+- [ ] 목록 조회 (결재자)
+- [ ] 목록 조회 (심사자)
+- [ ] 도메인 필터
+- [ ] 상태 필터
+- [ ] 상세 조회
+- [ ] 진단 제출
+- [ ] 제출 실패 (이미 제출됨)
+
+### 결재
+- [ ] 대기 목록 조회
+- [ ] 결재 승인
+- [ ] 결재 반려
+- [ ] 권한 없음 에러
+
+### 심사
+- [ ] 심사 목록 조회
+- [ ] 심사 상세 조회
+- [ ] 심사 승인
+- [ ] 보완 요청
+
+### 역할 요청
+- [ ] 역할 요청 생성
+- [ ] 역할 요청 승인
+- [ ] 역할 요청 거절
+
+### 알림
+- [ ] 알림 목록 조회
+- [ ] 읽음 처리

--- a/docs/TEST_DATA_GUIDE.md
+++ b/docs/TEST_DATA_GUIDE.md
@@ -1,0 +1,242 @@
+# E2E 테스트 데이터 가이드
+
+> 이 문서는 프론트엔드 E2E 테스트를 위한 초기 데이터를 설명합니다.
+> 모든 계정의 비밀번호: `Test1234!`
+
+## 빠른 참조
+
+### 테스트 계정 요약
+
+| 역할 | 이메일 | 회사 | 담당 도메인 |
+|------|--------|------|-------------|
+| 심사자(ESG) | `reviewer.esg@hdhhi.co.kr` | HD현대중공업 | ESG |
+| 심사자(안전) | `reviewer.safety@hdhhi.co.kr` | HD현대중공업 | SAFETY |
+| 심사자(컴플) | `reviewer.compliance@hdhhi.co.kr` | HD현대중공업 | COMPLIANCE |
+| 결재자 | `approver@techpartner.co.kr` | 테크파트너 | ESG, COMPLIANCE |
+| 결재자 | `approver@greenmanu.co.kr` | 그린매뉴팩처링 | ESG, SAFETY |
+| 결재자 | `approver@safebuild.co.kr` | 안전건설 | SAFETY |
+| 기안자 | `drafter1@techpartner.co.kr` | 테크파트너 | ESG, COMPLIANCE |
+| 기안자 | `drafter2@techpartner.co.kr` | 테크파트너 | ESG |
+| 기안자 | `drafter@greenmanu.co.kr` | 그린매뉴팩처링 | ESG, SAFETY |
+| 기안자 | `drafter@safebuild.co.kr` | 안전건설 | SAFETY |
+| 게스트 | `newbie1@precision.co.kr` | 정밀부품 | - (권한 없음) |
+| 게스트 | `newbie2@precision.co.kr` | 정밀부품 | - (권한 없음) |
+
+---
+
+## 1. 회사 데이터 (5개)
+
+| 회사명 | 타입 | 규모 | 업종 |
+|--------|------|------|------|
+| HD현대중공업 | TIER1 (원청) | 대기업 | 제조업 |
+| (주)테크파트너 | TIER2 | 중견기업 | IT/소프트웨어 |
+| (주)그린매뉴팩처링 | TIER2 | 중소기업 | 제조업 |
+| (주)안전건설 | TIER2 | 중견기업 | 건설업 |
+| (주)정밀부품 | TIER2 | 중소기업 | 제조업 |
+
+---
+
+## 2. 캠페인 데이터 (6개)
+
+| 캠페인 코드 | 도메인 | 제목 | 기간 | 마감일 |
+|-------------|--------|------|------|--------|
+| CAMP-ESG-2026-001 | ESG | 2026년 상반기 ESG 공급망 진단 | 2026.01~06 | 2026-03-31 |
+| CAMP-ESG-2025-001 | ESG | 2025년 ESG 공급망 진단 (완료) | 2025.01~12 | 2025-03-31 |
+| CAMP-SAFETY-2026-001 | SAFETY | 2026년 1분기 안전보건 점검 | 2026.01~03 | 2026-02-28 |
+| CAMP-SAFETY-2025-002 | SAFETY | 2025년 하반기 안전보건 점검 (완료) | 2025.07~12 | 2025-11-30 |
+| CAMP-COMPL-2026-001 | COMPLIANCE | 2026년 하도급 컴플라이언스 점검 | 2026.02~04 | 2026-04-15 |
+| CAMP-COMPL-2025-001 | COMPLIANCE | 2025년 하도급 컴플라이언스 점검 (완료) | 2025.03~05 | 2025-05-15 |
+
+---
+
+## 3. 진단 데이터 - 상태별 (17개)
+
+### ESG 도메인 (12건)
+
+| 상태 | 진단코드 | 회사 | 기안자 | 테스트 시나리오 |
+|------|----------|------|--------|-----------------|
+| **WRITING** | DG-ESG-2026-001 | 테크파트너 | drafter1@techpartner.co.kr | 작성중 진단 편집 |
+| **WRITING** | DG-ESG-2026-002 | 그린매뉴팩처링 | drafter@greenmanu.co.kr | 작성중 진단 편집 |
+| **SUBMITTED** | DG-ESG-2026-003 | 테크파트너 | drafter2@techpartner.co.kr | 결재 대기 목록 확인 |
+| **SUBMITTED** | DG-ESG-2026-004 | 정밀부품 | newbie1@precision.co.kr | 게스트가 제출한 건 |
+| **RETURNED** | DG-ESG-2026-005 | 그린매뉴팩처링 | drafter@greenmanu.co.kr | 반려 후 재작성 |
+| **APPROVED** | DG-ESG-2026-006 | 테크파트너 | drafter1@techpartner.co.kr | 심사 대기 |
+| **APPROVED** | DG-ESG-2026-007 | 안전건설 | drafter@safebuild.co.kr | 심사 대기 |
+| **REVIEWING** | DG-ESG-2025-001 | 테크파트너 | drafter1@techpartner.co.kr | 심사중 |
+| **REVIEWING** | DG-ESG-2025-002 | 그린매뉴팩처링 | drafter@greenmanu.co.kr | 심사중 |
+| **COMPLETED** | DG-ESG-2025-003 | 안전건설 | drafter@safebuild.co.kr | 완료된 진단 조회 |
+| **COMPLETED** | DG-ESG-2025-004 | 정밀부품 | newbie1@precision.co.kr | 완료된 진단 조회 |
+
+### SAFETY 도메인 (3건)
+
+| 상태 | 진단코드 | 회사 | 기안자 |
+|------|----------|------|--------|
+| **WRITING** | DG-SAFETY-2026-001 | 그린매뉴팩처링 | drafter@greenmanu.co.kr |
+| **SUBMITTED** | DG-SAFETY-2026-002 | 안전건설 | drafter@safebuild.co.kr |
+| **COMPLETED** | DG-SAFETY-2025-001 | 안전건설 | drafter@safebuild.co.kr |
+
+### COMPLIANCE 도메인 (2건)
+
+| 상태 | 진단코드 | 회사 | 기안자 |
+|------|----------|------|--------|
+| **WRITING** | DG-COMPL-2026-001 | 테크파트너 | drafter1@techpartner.co.kr |
+| **COMPLETED** | DG-COMPL-2025-001 | 테크파트너 | drafter1@techpartner.co.kr |
+
+---
+
+## 4. 결재 데이터 - 상태별 (5건)
+
+| 상태 | 진단 | 요청자 | 결재자 | 코멘트 |
+|------|------|--------|--------|--------|
+| **WAITING** | DG-ESG-2026-003 | drafter2@techpartner.co.kr | - | 결재 대기 테스트 |
+| **WAITING** | DG-SAFETY-2026-002 | drafter@safebuild.co.kr | - | 결재 대기 테스트 |
+| **APPROVED** | DG-ESG-2026-006 | drafter1@techpartner.co.kr | approver@techpartner.co.kr | "검토 완료, 승인합니다." |
+| **APPROVED** | DG-ESG-2025-001 | drafter1@techpartner.co.kr | approver@techpartner.co.kr | "승인합니다." |
+| **REJECTED** | DG-ESG-2026-005 | drafter@greenmanu.co.kr | approver@greenmanu.co.kr | "온실가스 배출량 데이터 누락" |
+
+---
+
+## 5. 심사 데이터 - 상태별 (6건)
+
+| 상태 | 진단 | 회사 | 점수 | 위험도 | 심사자 |
+|------|------|------|------|--------|--------|
+| **REVIEWING** | DG-ESG-2025-001 | 테크파트너 | 68 | MEDIUM | reviewer.esg@hdhhi.co.kr |
+| **REVIEWING** | DG-ESG-2025-002 | 그린매뉴팩처링 | 75 | MEDIUM | reviewer.esg@hdhhi.co.kr |
+| **APPROVED** | DG-ESG-2025-003 | 안전건설 | 82 | LOW | reviewer.esg@hdhhi.co.kr |
+| **APPROVED** | DG-SAFETY-2025-001 | 안전건설 | 91 | LOW | reviewer.safety@hdhhi.co.kr |
+| **REVISION_REQUIRED** | DG-ESG-2025-004 | 정밀부품 | 45 | HIGH | reviewer.esg@hdhhi.co.kr |
+| **REVISION_REQUIRED** | DG-COMPL-2025-001 | 테크파트너 | 58 | MEDIUM | reviewer.compliance@hdhhi.co.kr |
+
+### 위험도 기준
+- **LOW**: 70점 이상
+- **MEDIUM**: 40~69점
+- **HIGH**: 40점 미만
+
+---
+
+## 6. 역할 요청 데이터 - 상태별 (4건)
+
+| 상태 | 요청자 | 도메인 | 요청 역할 | 사유 |
+|------|--------|--------|----------|------|
+| **PENDING** | newbie1@precision.co.kr | ESG | DRAFTER | ESG 진단 업무 담당자 지정 |
+| **PENDING** | newbie2@precision.co.kr | SAFETY | DRAFTER | 안전보건 점검 업무 담당 |
+| **APPROVED** | drafter1@techpartner.co.kr | COMPLIANCE | DRAFTER | 컴플라이언스 업무 추가 담당 |
+| **REJECTED** | newbie2@precision.co.kr | ESG | APPROVER | 결재자 권한 요청 (거절됨) |
+
+---
+
+## 7. 비동기 작업 데이터 (5건)
+
+| 상태 | 작업 타입 | 요청자 | 대상 |
+|------|----------|--------|------|
+| **PENDING** | REPORT_GENERATION | reviewer.esg@hdhhi.co.kr | Review |
+| **RUNNING** | AI_ESG_ANALYSIS | drafter@greenmanu.co.kr | Diagnostic |
+| **SUCCEEDED** | FILE_PARSING | drafter1@techpartner.co.kr | Diagnostic |
+| **SUCCEEDED** | BULK_REPORT | reviewer.esg@hdhhi.co.kr | Campaign |
+| **FAILED** | FILE_PARSING | drafter@safebuild.co.kr | Diagnostic |
+
+---
+
+## 8. 알림 데이터 (10건)
+
+| 타입 | 수신자 | 제목 |
+|------|--------|------|
+| APPROVAL_COMPLETE | approver@techpartner.co.kr | 결재 요청 |
+| APPROVAL_COMPLETE | drafter2@techpartner.co.kr | 결재 완료 |
+| REVISION_REQUIRED | drafter@greenmanu.co.kr | 결재 반려 |
+| REVIEW_COMPLETE | reviewer.esg@hdhhi.co.kr | 심사 요청 |
+| REVIEW_COMPLETE | drafter1@techpartner.co.kr | 심사 완료 |
+| ROLE_APPROVED | newbie1@precision.co.kr | 권한 요청 접수 |
+| ROLE_APPROVED | drafter1@techpartner.co.kr | 권한 승인 |
+| REVISION_REQUIRED | newbie2@precision.co.kr | 권한 거절 |
+| AI_ANALYSIS_COMPLETE | drafter1@techpartner.co.kr | AI 분석 완료 |
+| AI_ANALYSIS_FAILED | drafter@safebuild.co.kr | AI 분석 실패 |
+
+---
+
+## 9. 테스트 시나리오별 계정 추천
+
+### 기안자 플로우 테스트
+```
+계정: drafter1@techpartner.co.kr
+- 작성중 진단이 있음 (DG-ESG-2026-001)
+- 승인된 진단 있음 (DG-ESG-2026-006)
+- 심사중/완료 진단 있음
+- ESG, COMPLIANCE 도메인 권한
+```
+
+### 결재자 플로우 테스트
+```
+계정: approver@techpartner.co.kr
+- 결재 대기 건 있음 (DG-ESG-2026-003)
+- 결재 완료 건 있음
+- ESG, COMPLIANCE 도메인 권한
+```
+
+### 심사자 플로우 테스트
+```
+계정: reviewer.esg@hdhhi.co.kr
+- 심사중 건 있음 (DG-ESG-2025-001, DG-ESG-2025-002)
+- 심사 완료/보완요청 건 있음
+- ESG 도메인 전담
+```
+
+### 게스트(신규 가입) 플로우 테스트
+```
+계정: newbie1@precision.co.kr
+- GUEST 역할 (권한 없음)
+- 역할 요청 PENDING 상태
+- 권한 요청 → 승인/거절 플로우 테스트
+```
+
+### 반려/보완 플로우 테스트
+```
+계정: drafter@greenmanu.co.kr
+- 반려된 진단 있음 (DG-ESG-2026-005)
+- 재작성 → 재제출 플로우 테스트
+```
+
+---
+
+## 10. API 테스트 예시
+
+### 로그인
+```bash
+curl -X POST http://localhost:8080/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "drafter1@techpartner.co.kr", "password": "Test1234!"}'
+```
+
+### 진단 목록 조회 (ESG)
+```bash
+curl -X GET "http://localhost:8080/api/v1/diagnostics?domainCode=ESG" \
+  -H "Authorization: Bearer {TOKEN}"
+```
+
+### 결재 대기 목록 조회
+```bash
+curl -X GET "http://localhost:8080/api/v1/approvals?status=WAITING" \
+  -H "Authorization: Bearer {TOKEN}"
+```
+
+### 심사 목록 조회
+```bash
+curl -X GET "http://localhost:8080/api/v1/reviews?status=REVIEWING" \
+  -H "Authorization: Bearer {TOKEN}"
+```
+
+---
+
+## 11. 데이터 초기화
+
+로컬 환경에서 데이터를 초기화하려면:
+
+```bash
+# Docker PostgreSQL 컨테이너 재시작
+docker restart smartchain-db
+
+# 앱 재시작 (ddl-auto: create이므로 자동 초기화)
+./gradlew bootRun
+```
+
+> **참고**: `local` 프로필은 `ddl-auto: create` 설정이므로 앱 재시작 시 데이터가 초기화됩니다.

--- a/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
+++ b/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
@@ -12,6 +12,8 @@ import com.smartchain.platform.domain.notification.entity.Notification;
 import com.smartchain.platform.domain.notification.repository.NotificationRepository;
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.review.repository.ReviewRepository;
+import com.smartchain.platform.domain.role.repository.RoleRequestRepository;
+import com.smartchain.platform.domain.user.entity.RoleRequest;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.entity.Industry;
@@ -35,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -54,13 +57,12 @@ public class DataInitializer implements CommandLineRunner {
     private final ReviewRepository reviewRepository;
     private final AsyncJobRepository asyncJobRepository;
     private final NotificationRepository notificationRepository;
+    private final RoleRequestRepository roleRequestRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
     @Transactional
     public void run(String... args) {
-        // Role 데이터는 data.sql에서 초기화되므로, Role이 존재하는지 확인하는 로직은 제거하거나 수정할 수 있습니다.
-        // 하지만 다른 데이터(User 등)가 이미 존재하는지 확인하는 것이 안전합니다.
         if (userRepository.count() > 0) {
             log.info("Data already initialized. Skipping...");
             return;
@@ -68,323 +70,611 @@ public class DataInitializer implements CommandLineRunner {
 
         log.info("=== Starting Data Initialization ===");
 
-        // 1. Role 조회 (data.sql에서 이미 생성됨)
+        // ========================================
+        // 1. 기본 데이터: Role, Domain, Industry
+        // ========================================
         Role guestRole = roleRepository.findByCode("GUEST").orElseThrow(() -> new RuntimeException("Role not found: GUEST"));
         Role drafterRole = roleRepository.findByCode("DRAFTER").orElseThrow(() -> new RuntimeException("Role not found: DRAFTER"));
         Role approverRole = roleRepository.findByCode("APPROVER").orElseThrow(() -> new RuntimeException("Role not found: APPROVER"));
         Role reviewerRole = roleRepository.findByCode("REVIEWER").orElseThrow(() -> new RuntimeException("Role not found: REVIEWER"));
         log.info("Roles loaded: GUEST, DRAFTER, APPROVER, REVIEWER");
 
-        // 1-1. Domain 생성
         Domain esgDomain = domainRepository.save(Domain.builder()
-                .code("ESG")
-                .name("ESG 실사")
-                .description("ESG 공급망 실사 및 진단")
-                .isActive(true)
-                .build());
-
+                .code("ESG").name("ESG 실사").description("ESG 공급망 실사 및 진단").isActive(true).build());
         Domain safetyDomain = domainRepository.save(Domain.builder()
-                .code("SAFETY")
-                .name("안전보건")
-                .description("TBM 영상 분석 기반 안전보건 관리")
-                .isActive(true)
-                .build());
-
+                .code("SAFETY").name("안전보건").description("TBM 영상 분석 기반 안전보건 관리").isActive(true).build());
         Domain complianceDomain = domainRepository.save(Domain.builder()
-                .code("COMPLIANCE")
-                .name("컴플라이언스")
-                .description("하도급 계약서 AI 검토")
-                .isActive(true)
-                .build());
+                .code("COMPLIANCE").name("컴플라이언스").description("하도급 계약서 AI 검토").isActive(true).build());
         log.info("Domains created: ESG, SAFETY, COMPLIANCE");
 
-        // 2. Industry 생성
         Industry manufacturing = industryRepository.save(new Industry("제조업", "MANUFACTURING"));
         Industry it = industryRepository.save(new Industry("IT/소프트웨어", "IT"));
-        Industry finance = industryRepository.save(new Industry("금융업", "FINANCE"));
-        Industry retail = industryRepository.save(new Industry("유통/소매", "RETAIL"));
         Industry construction = industryRepository.save(new Industry("건설업", "CONSTRUCTION"));
+        industryRepository.save(new Industry("금융업", "FINANCE"));
+        industryRepository.save(new Industry("유통/소매", "RETAIL"));
         log.info("Industries created: 5 industries");
 
-        // 3. Company 생성
+        // ========================================
+        // 2. 회사 데이터 (5개)
+        // ========================================
         Company ownerCompany = companyRepository.save(Company.builder()
-                .industry(manufacturing)
-                .name("(주)스마트체인")
-                .scale("대기업")
-                .sales(500000000000L)
-                .asset(1000000000000L)
-                .businessNumber("123-45-67890")
-                .companyType(CompanyType.TIER1)
-                .ceoName("김대표")
-                .address("서울시 강남구 테헤란로 123")
-                .contactEmail("contact@smartchain.co.kr")
-                .contactPhone("02-1234-5678")
-                .status(CompanyStatus.ACTIVE)
-                .build());
+                .industry(manufacturing).name("HD현대중공업").scale("대기업")
+                .sales(500000000000L).asset(1000000000000L).businessNumber("123-45-67890")
+                .companyType(CompanyType.TIER1).ceoName("김대표")
+                .address("울산광역시 동구 방어진순환도로 1000").contactEmail("contact@hdhhi.co.kr")
+                .contactPhone("052-202-2114").status(CompanyStatus.ACTIVE).build());
 
         Company partnerCompany1 = companyRepository.save(Company.builder()
-                .industry(it)
-                .name("(주)테크파트너")
-                .scale("중견기업")
-                .sales(50000000000L)
-                .asset(100000000000L)
-                .businessNumber("234-56-78901")
-                .companyType(CompanyType.TIER2)
-                .ceoName("이사장")
-                .address("서울시 서초구 서초대로 456")
-                .contactEmail("info@techpartner.co.kr")
-                .contactPhone("02-2345-6789")
-                .status(CompanyStatus.ACTIVE)
-                .build());
+                .industry(it).name("(주)테크파트너").scale("중견기업")
+                .sales(50000000000L).asset(100000000000L).businessNumber("234-56-78901")
+                .companyType(CompanyType.TIER2).ceoName("이사장")
+                .address("서울시 서초구 서초대로 456").contactEmail("info@techpartner.co.kr")
+                .contactPhone("02-2345-6789").status(CompanyStatus.ACTIVE).build());
 
         Company partnerCompany2 = companyRepository.save(Company.builder()
-                .industry(manufacturing)
-                .name("(주)그린매뉴")
-                .scale("중소기업")
-                .sales(10000000000L)
-                .asset(20000000000L)
-                .businessNumber("345-67-89012")
-                .companyType(CompanyType.TIER2)
-                .ceoName("박공장")
-                .address("경기도 안산시 단원구 산단로 789")
-                .contactEmail("contact@greenmanu.co.kr")
-                .contactPhone("031-345-6789")
-                .status(CompanyStatus.ACTIVE)
-                .build());
-        log.info("Companies created: 3 companies");
+                .industry(manufacturing).name("(주)그린매뉴팩처링").scale("중소기업")
+                .sales(10000000000L).asset(20000000000L).businessNumber("345-67-89012")
+                .companyType(CompanyType.TIER2).ceoName("박공장")
+                .address("경기도 안산시 단원구 산단로 789").contactEmail("contact@greenmanu.co.kr")
+                .contactPhone("031-345-6789").status(CompanyStatus.ACTIVE).build());
 
-        // 4. User 생성 (비밀번호: Test1234!)
+        Company partnerCompany3 = companyRepository.save(Company.builder()
+                .industry(construction).name("(주)안전건설").scale("중견기업")
+                .sales(30000000000L).asset(50000000000L).businessNumber("456-78-90123")
+                .companyType(CompanyType.TIER2).ceoName("최건설")
+                .address("부산시 해운대구 센텀중앙로 97").contactEmail("contact@safebuild.co.kr")
+                .contactPhone("051-456-7890").status(CompanyStatus.ACTIVE).build());
+
+        Company partnerCompany4 = companyRepository.save(Company.builder()
+                .industry(manufacturing).name("(주)정밀부품").scale("중소기업")
+                .sales(8000000000L).asset(15000000000L).businessNumber("567-89-01234")
+                .companyType(CompanyType.TIER2).ceoName("정부품")
+                .address("경남 창원시 성산구 공단로 123").contactEmail("contact@precision.co.kr")
+                .contactPhone("055-567-8901").status(CompanyStatus.ACTIVE).build());
+        log.info("Companies created: 5 companies");
+
+        // ========================================
+        // 3. 사용자 데이터 (12명)
+        // ========================================
         String encodedPassword = passwordEncoder.encode("Test1234!");
 
-        User reviewer = userRepository.save(User.builder()
-                .name("심사자")
-                .email("reviewer@smartchain.co.kr")
-                .userPassword(encodedPassword)
-                .company(ownerCompany)
-                .role(reviewerRole)
-                .build());
+        // 원청 심사자들 (3명 - 도메인별)
+        User reviewerEsg = userRepository.save(User.builder()
+                .name("김심사(ESG)").email("reviewer.esg@hdhhi.co.kr").userPassword(encodedPassword)
+                .company(ownerCompany).role(reviewerRole).build());
+        User reviewerSafety = userRepository.save(User.builder()
+                .name("이심사(안전)").email("reviewer.safety@hdhhi.co.kr").userPassword(encodedPassword)
+                .company(ownerCompany).role(reviewerRole).build());
+        User reviewerCompliance = userRepository.save(User.builder()
+                .name("박심사(컴플)").email("reviewer.compliance@hdhhi.co.kr").userPassword(encodedPassword)
+                .company(ownerCompany).role(reviewerRole).build());
 
-        User approver = userRepository.save(User.builder()
-                .name("결재자")
-                .email("approver@techpartner.co.kr")
-                .userPassword(encodedPassword)
-                .company(partnerCompany1)
-                .role(approverRole)
-                .build());
-
+        // 테크파트너 직원들 (결재자1, 기안자2)
+        User approver1 = userRepository.save(User.builder()
+                .name("김결재(테크)").email("approver@techpartner.co.kr").userPassword(encodedPassword)
+                .company(partnerCompany1).role(approverRole).build());
         User drafter1 = userRepository.save(User.builder()
-                .name("기안자1")
-                .email("drafter1@techpartner.co.kr")
-                .userPassword(encodedPassword)
-                .company(partnerCompany1)
-                .role(drafterRole)
-                .build());
-
+                .name("이기안(테크)").email("drafter1@techpartner.co.kr").userPassword(encodedPassword)
+                .company(partnerCompany1).role(drafterRole).build());
         User drafter2 = userRepository.save(User.builder()
-                .name("기안자2")
-                .email("drafter2@greenmanu.co.kr")
-                .userPassword(encodedPassword)
-                .company(partnerCompany2)
-                .role(drafterRole)
-                .build());
+                .name("박기안(테크)").email("drafter2@techpartner.co.kr").userPassword(encodedPassword)
+                .company(partnerCompany1).role(drafterRole).build());
 
-        User guest = userRepository.save(User.builder()
-                .name("게스트")
-                .email("guest@example.com")
-                .userPassword(encodedPassword)
-                .company(partnerCompany1)
-                .role(guestRole)
-                .build());
-        log.info("Users created: reviewer, approver, drafter1, drafter2, guest");
+        // 그린매뉴팩처링 직원들
+        User approver2 = userRepository.save(User.builder()
+                .name("최결재(그린)").email("approver@greenmanu.co.kr").userPassword(encodedPassword)
+                .company(partnerCompany2).role(approverRole).build());
+        User drafter3 = userRepository.save(User.builder()
+                .name("정기안(그린)").email("drafter@greenmanu.co.kr").userPassword(encodedPassword)
+                .company(partnerCompany2).role(drafterRole).build());
 
-        // 4-1. UserDomainRole 생성 (도메인별 권한 부여)
-        // reviewer: ESG, SAFETY, COMPLIANCE 모든 도메인에서 REVIEWER
-        userDomainRoleRepository.save(UserDomainRole.builder()
-                .user(reviewer).domain(esgDomain).role(reviewerRole).build());
-        userDomainRoleRepository.save(UserDomainRole.builder()
-                .user(reviewer).domain(safetyDomain).role(reviewerRole).build());
-        userDomainRoleRepository.save(UserDomainRole.builder()
-                .user(reviewer).domain(complianceDomain).role(reviewerRole).build());
+        // 안전건설 직원들
+        User approver3 = userRepository.save(User.builder()
+                .name("강결재(안전)").email("approver@safebuild.co.kr").userPassword(encodedPassword)
+                .company(partnerCompany3).role(approverRole).build());
+        User drafter4 = userRepository.save(User.builder()
+                .name("윤기안(안전)").email("drafter@safebuild.co.kr").userPassword(encodedPassword)
+                .company(partnerCompany3).role(drafterRole).build());
 
-        // approver: ESG 도메인에서 APPROVER
-        userDomainRoleRepository.save(UserDomainRole.builder()
-                .user(approver).domain(esgDomain).role(approverRole).build());
+        // 게스트 (신규 가입자)
+        User guest1 = userRepository.save(User.builder()
+                .name("신입1").email("newbie1@precision.co.kr").userPassword(encodedPassword)
+                .company(partnerCompany4).role(guestRole).build());
+        User guest2 = userRepository.save(User.builder()
+                .name("신입2").email("newbie2@precision.co.kr").userPassword(encodedPassword)
+                .company(partnerCompany4).role(guestRole).build());
+        log.info("Users created: 12 users");
 
-        // drafter1: ESG 도메인에서 DRAFTER, SAFETY 도메인에서 APPROVER
-        userDomainRoleRepository.save(UserDomainRole.builder()
-                .user(drafter1).domain(esgDomain).role(drafterRole).build());
-        userDomainRoleRepository.save(UserDomainRole.builder()
-                .user(drafter1).domain(safetyDomain).role(approverRole).build());
+        // ========================================
+        // 4. UserDomainRole (도메인별 권한)
+        // ========================================
+        // 심사자: 각자 담당 도메인
+        userDomainRoleRepository.save(UserDomainRole.builder().user(reviewerEsg).domain(esgDomain).role(reviewerRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(reviewerSafety).domain(safetyDomain).role(reviewerRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(reviewerCompliance).domain(complianceDomain).role(reviewerRole).build());
 
-        // drafter2: ESG 도메인에서 DRAFTER
-        userDomainRoleRepository.save(UserDomainRole.builder()
-                .user(drafter2).domain(esgDomain).role(drafterRole).build());
+        // 테크파트너: ESG + COMPLIANCE
+        userDomainRoleRepository.save(UserDomainRole.builder().user(approver1).domain(esgDomain).role(approverRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(approver1).domain(complianceDomain).role(approverRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(drafter1).domain(esgDomain).role(drafterRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(drafter1).domain(complianceDomain).role(drafterRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(drafter2).domain(esgDomain).role(drafterRole).build());
 
-        log.info("UserDomainRoles created: domain-specific roles assigned");
+        // 그린매뉴팩처링: ESG + SAFETY
+        userDomainRoleRepository.save(UserDomainRole.builder().user(approver2).domain(esgDomain).role(approverRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(approver2).domain(safetyDomain).role(approverRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(drafter3).domain(esgDomain).role(drafterRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(drafter3).domain(safetyDomain).role(drafterRole).build());
 
-        // 5. Campaign 생성
-        Campaign campaign2026 = campaignRepository.save(Campaign.builder()
-                .campaignCode("CAMP-2026-001")
-                .ownerCompanyId(ownerCompany.getCompanyId())
-                .domain(esgDomain)
-                .title("2026년 ESG 공급망 진단")
-                .content("2026년도 협력사 ESG 경영 현황 진단 및 평가")
-                .periodStartDate(LocalDate.of(2026, 1, 1))
-                .periodEndDate(LocalDate.of(2026, 12, 31))
-                .deadline(LocalDate.of(2026, 3, 31))
-                .build());
+        // 안전건설: SAFETY
+        userDomainRoleRepository.save(UserDomainRole.builder().user(approver3).domain(safetyDomain).role(approverRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(drafter4).domain(safetyDomain).role(drafterRole).build());
+        log.info("UserDomainRoles created");
 
-        Campaign campaign2026Safety = campaignRepository.save(Campaign.builder()
-                .campaignCode("CAMP-2026-002")
-                .ownerCompanyId(ownerCompany.getCompanyId())
-                .title("2026년 상반기 안전보건 점검")
-                .content("2026년 상반기 협력사 안전보건 관리 현황 점검")
-                .periodStartDate(LocalDate.of(2026, 1, 1))
-                .periodEndDate(LocalDate.of(2026, 6, 30))
-                .deadline(LocalDate.of(2026, 2, 28))
-                .build());
+        // ========================================
+        // 5. Campaign (6개)
+        // ========================================
+        Campaign esgCampaign2026 = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-ESG-2026-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(esgDomain)
+                .title("2026년 상반기 ESG 공급망 진단").content("2026년도 1차 협력사 ESG 경영 현황 진단")
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 3, 31)).build());
 
-        Campaign campaign2026Compliance = campaignRepository.save(Campaign.builder()
-                .campaignCode("CAMP-2026-003")
-                .ownerCompanyId(ownerCompany.getCompanyId())
-                .title("2026년 하도급 컴플라이언스 점검")
-                .content("2026년도 협력사 하도급 계약 및 법규 준수 현황 점검")
-                .periodStartDate(LocalDate.of(2026, 3, 1))
-                .periodEndDate(LocalDate.of(2026, 5, 31))
-                .deadline(LocalDate.of(2026, 4, 30))
-                .build());
+        Campaign esgCampaign2025 = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-ESG-2025-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(esgDomain)
+                .title("2025년 ESG 공급망 진단 (완료)").content("2025년도 협력사 ESG 경영 현황 진단 - 완료")
+                .periodStartDate(LocalDate.of(2025, 1, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
+                .deadline(LocalDate.of(2025, 3, 31)).build());
 
-        Campaign campaign2025 = campaignRepository.save(Campaign.builder()
-                .campaignCode("CAMP-2025-001")
-                .ownerCompanyId(ownerCompany.getCompanyId())
-                .title("2025년 ESG 공급망 진단")
-                .content("2025년도 협력사 ESG 경영 현황 진단 및 평가 (완료)")
-                .periodStartDate(LocalDate.of(2025, 1, 1))
-                .periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2025, 3, 31))
-                .build());
+        Campaign safetyCampaign2026 = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-SAFETY-2026-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(safetyDomain)
+                .title("2026년 1분기 안전보건 점검").content("2026년 1분기 협력사 안전보건 관리 현황 점검")
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 3, 31))
+                .deadline(LocalDate.of(2026, 2, 28)).build());
 
-        log.info("Campaigns created: 4 campaigns (2026 ESG, 2026 Safety, 2026 Compliance, 2025 ESG)");
+        Campaign safetyCampaign2025 = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-SAFETY-2025-002").ownerCompanyId(ownerCompany.getCompanyId()).domain(safetyDomain)
+                .title("2025년 하반기 안전보건 점검 (완료)").content("2025년 하반기 안전보건 점검 완료")
+                .periodStartDate(LocalDate.of(2025, 7, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
+                .deadline(LocalDate.of(2025, 11, 30)).build());
 
-        // 6. Diagnostic 생성
-        Diagnostic diagnostic1 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-2026-00001")
-                .title("(주)테크파트너 2026년 ESG 진단")
-                .campaign(campaign2026)
-                .company(partnerCompany1)
-                .domain(esgDomain)
+        Campaign complianceCampaign2026 = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-COMPL-2026-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(complianceDomain)
+                .title("2026년 하도급 컴플라이언스 점검").content("2026년도 협력사 하도급 계약 법규 준수 점검")
+                .periodStartDate(LocalDate.of(2026, 2, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
+                .deadline(LocalDate.of(2026, 4, 15)).build());
+
+        Campaign complianceCampaign2025 = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-COMPL-2025-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(complianceDomain)
+                .title("2025년 하도급 컴플라이언스 점검 (완료)").content("2025년도 하도급 점검 완료")
+                .periodStartDate(LocalDate.of(2025, 3, 1)).periodEndDate(LocalDate.of(2025, 5, 31))
+                .deadline(LocalDate.of(2025, 5, 15)).build());
+        log.info("Campaigns created: 6 campaigns");
+
+        // ========================================
+        // 6. Diagnostic - 모든 상태 커버 (15개)
+        // ========================================
+        // ESG 진단들
+        // WRITING (작성중) - 2건
+        Diagnostic esgWriting1 = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2026-001").title("테크파트너 2026 ESG 진단")
+                .campaign(esgCampaign2026).company(partnerCompany1).domain(esgDomain)
                 .drafterId(drafter1.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1))
-                .periodEndDate(LocalDate.of(2026, 12, 31))
-                .deadline(LocalDate.of(2026, 3, 31))
-                .build());
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 3, 31)).build());
 
-        Diagnostic diagnostic2 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-2026-00002")
-                .title("(주)그린매뉴 2026년 ESG 진단")
-                .campaign(campaign2026)
-                .company(partnerCompany2)
-                .domain(esgDomain)
+        Diagnostic esgWriting2 = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2026-002").title("그린매뉴 2026 ESG 진단")
+                .campaign(esgCampaign2026).company(partnerCompany2).domain(esgDomain)
+                .drafterId(drafter3.getUserId())
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 3, 31)).build());
+
+        // SUBMITTED (제출됨) - 2건
+        Diagnostic esgSubmitted1 = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2026-003").title("테크파트너 2026 ESG 진단 (제출)")
+                .campaign(esgCampaign2026).company(partnerCompany1).domain(esgDomain)
                 .drafterId(drafter2.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1))
-                .periodEndDate(LocalDate.of(2026, 12, 31))
-                .deadline(LocalDate.of(2026, 3, 31))
-                .build());
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 3, 31)).build());
+        esgSubmitted1.submit();
+        diagnosticRepository.save(esgSubmitted1);
 
-        // 진단1: 제출 상태로 변경
-        diagnostic1.submit();
-        diagnosticRepository.save(diagnostic1);
-        log.info("Diagnostics created: 2 diagnostics");
+        Diagnostic esgSubmitted2 = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2026-004").title("정밀부품 2026 ESG 진단 (제출)")
+                .campaign(esgCampaign2026).company(partnerCompany4).domain(esgDomain)
+                .drafterId(guest1.getUserId())
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 3, 31)).build());
+        esgSubmitted2.submit();
+        diagnosticRepository.save(esgSubmitted2);
 
-        // 7. Approval 생성
-        Approval approval1 = approvalRepository.save(Approval.builder()
-                .diagnostic(diagnostic1)
-                .requester(drafter1)
-                .requestComment("ESG 진단 결과 검토 요청드립니다.")
-                .deadline(LocalDate.of(2026, 2, 28))
-                .build());
-        log.info("Approval created: 1 approval (WAITING)");
+        // RETURNED (반려됨) - 1건
+        Diagnostic esgReturned = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2026-005").title("그린매뉴 2026 ESG 진단 (반려)")
+                .campaign(esgCampaign2026).company(partnerCompany2).domain(esgDomain)
+                .drafterId(drafter3.getUserId())
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 3, 31)).build());
+        esgReturned.submit();
+        esgReturned.returnForRevision();
+        diagnosticRepository.save(esgReturned);
 
-        // 8. Review 생성 (승인된 진단에 대해서만)
-        // diagnostic1을 승인 상태로 변경하고 Review 생성
-        Diagnostic diagnosticForReview = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-2026-00003")
-                .title("(주)테크파트너 2025년 ESG 진단 (완료)")
-                .campaign(campaign2026)
-                .company(partnerCompany1)
-                .domain(esgDomain)
+        // APPROVED (승인됨, 심사대기) - 2건
+        Diagnostic esgApproved1 = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2026-006").title("테크파트너 2026 ESG 진단 (승인)")
+                .campaign(esgCampaign2026).company(partnerCompany1).domain(esgDomain)
                 .drafterId(drafter1.getUserId())
-                .periodStartDate(LocalDate.of(2025, 1, 1))
-                .periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2025, 3, 31))
-                .build());
-        diagnosticForReview.markAsApproved();
-        diagnosticRepository.save(diagnosticForReview);
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 3, 31)).build());
+        esgApproved1.submit();
+        esgApproved1.approve();
+        diagnosticRepository.save(esgApproved1);
 
-        Review review1 = reviewRepository.save(Review.builder()
-                .diagnostic(diagnosticForReview)
-                .company(partnerCompany1)
-                .assignedReviewer(reviewer)
-                .domain(esgDomain)
-                .score(72)
-                .submittedAt(LocalDateTime.now().minusDays(5))
-                .build());
-        log.info("Review created: 1 review (REVIEWING, score=72, MEDIUM risk)");
+        Diagnostic esgApproved2 = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2026-007").title("안전건설 2026 ESG 진단 (승인)")
+                .campaign(esgCampaign2026).company(partnerCompany3).domain(esgDomain)
+                .drafterId(drafter4.getUserId())
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 3, 31)).build());
+        esgApproved2.submit();
+        esgApproved2.approve();
+        diagnosticRepository.save(esgApproved2);
 
-        // 9. AsyncJob 생성
-        AsyncJob job1 = AsyncJob.builder()
-                .jobType(JobType.FILE_PARSING)
-                .requesterId(drafter1.getUserId())
-                .targetId(diagnostic1.getDiagnosticId())
-                .requestPayload("{\"fileId\": 1}")
-                .estimatedSeconds(60)
-                .build();
-        job1.start();
-        job1.succeed("/diagnostics/1/files/1/parsing-result");
-        asyncJobRepository.save(job1);
+        // REVIEWING (심사중) - 2건
+        Diagnostic esgReviewing1 = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2025-001").title("테크파트너 2025 ESG 진단 (심사중)")
+                .campaign(esgCampaign2025).company(partnerCompany1).domain(esgDomain)
+                .drafterId(drafter1.getUserId())
+                .periodStartDate(LocalDate.of(2025, 1, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
+                .deadline(LocalDate.of(2025, 3, 31)).build());
+        esgReviewing1.submit();
+        esgReviewing1.approve();
+        esgReviewing1.startReview();
+        diagnosticRepository.save(esgReviewing1);
 
-        AsyncJob job2 = AsyncJob.builder()
-                .jobType(JobType.REPORT_GENERATION)
-                .requesterId(reviewer.getUserId())
-                .targetId(review1.getReviewId())
-                .requestPayload("{\"reviewId\": 1}")
-                .estimatedSeconds(120)
-                .build();
-        asyncJobRepository.save(job2);
-        log.info("AsyncJobs created: 2 jobs (1 SUCCEEDED, 1 PENDING)");
+        Diagnostic esgReviewing2 = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2025-002").title("그린매뉴 2025 ESG 진단 (심사중)")
+                .campaign(esgCampaign2025).company(partnerCompany2).domain(esgDomain)
+                .drafterId(drafter3.getUserId())
+                .periodStartDate(LocalDate.of(2025, 1, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
+                .deadline(LocalDate.of(2025, 3, 31)).build());
+        esgReviewing2.submit();
+        esgReviewing2.approve();
+        esgReviewing2.startReview();
+        diagnosticRepository.save(esgReviewing2);
 
-        // 10. Notification 생성
+        // COMPLETED (완료) - 2건
+        Diagnostic esgCompleted1 = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2025-003").title("안전건설 2025 ESG 진단 (완료)")
+                .campaign(esgCampaign2025).company(partnerCompany3).domain(esgDomain)
+                .drafterId(drafter4.getUserId())
+                .periodStartDate(LocalDate.of(2025, 1, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
+                .deadline(LocalDate.of(2025, 3, 31)).build());
+        esgCompleted1.submit();
+        esgCompleted1.approve();
+        esgCompleted1.startReview();
+        esgCompleted1.complete();
+        diagnosticRepository.save(esgCompleted1);
+
+        Diagnostic esgCompleted2 = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-ESG-2025-004").title("정밀부품 2025 ESG 진단 (완료)")
+                .campaign(esgCampaign2025).company(partnerCompany4).domain(esgDomain)
+                .drafterId(guest1.getUserId())
+                .periodStartDate(LocalDate.of(2025, 1, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
+                .deadline(LocalDate.of(2025, 3, 31)).build());
+        esgCompleted2.submit();
+        esgCompleted2.approve();
+        esgCompleted2.startReview();
+        esgCompleted2.complete();
+        diagnosticRepository.save(esgCompleted2);
+
+        // SAFETY 진단 (3건)
+        Diagnostic safetyWriting = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-SAFETY-2026-001").title("그린매뉴 2026 안전보건 점검")
+                .campaign(safetyCampaign2026).company(partnerCompany2).domain(safetyDomain)
+                .drafterId(drafter3.getUserId())
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 3, 31))
+                .deadline(LocalDate.of(2026, 2, 28)).build());
+
+        Diagnostic safetySubmitted = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-SAFETY-2026-002").title("안전건설 2026 안전보건 점검 (제출)")
+                .campaign(safetyCampaign2026).company(partnerCompany3).domain(safetyDomain)
+                .drafterId(drafter4.getUserId())
+                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 3, 31))
+                .deadline(LocalDate.of(2026, 2, 28)).build());
+        safetySubmitted.submit();
+        diagnosticRepository.save(safetySubmitted);
+
+        Diagnostic safetyCompleted = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-SAFETY-2025-001").title("안전건설 2025 안전보건 점검 (완료)")
+                .campaign(safetyCampaign2025).company(partnerCompany3).domain(safetyDomain)
+                .drafterId(drafter4.getUserId())
+                .periodStartDate(LocalDate.of(2025, 7, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
+                .deadline(LocalDate.of(2025, 11, 30)).build());
+        safetyCompleted.submit();
+        safetyCompleted.approve();
+        safetyCompleted.startReview();
+        safetyCompleted.complete();
+        diagnosticRepository.save(safetyCompleted);
+
+        // COMPLIANCE 진단 (2건)
+        Diagnostic complianceWriting = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-COMPL-2026-001").title("테크파트너 2026 컴플라이언스 점검")
+                .campaign(complianceCampaign2026).company(partnerCompany1).domain(complianceDomain)
+                .drafterId(drafter1.getUserId())
+                .periodStartDate(LocalDate.of(2026, 2, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
+                .deadline(LocalDate.of(2026, 4, 15)).build());
+
+        Diagnostic complianceCompleted = diagnosticRepository.save(Diagnostic.builder()
+                .diagnosticCode("DG-COMPL-2025-001").title("테크파트너 2025 컴플라이언스 점검 (완료)")
+                .campaign(complianceCampaign2025).company(partnerCompany1).domain(complianceDomain)
+                .drafterId(drafter1.getUserId())
+                .periodStartDate(LocalDate.of(2025, 3, 1)).periodEndDate(LocalDate.of(2025, 5, 31))
+                .deadline(LocalDate.of(2025, 5, 15)).build());
+        complianceCompleted.submit();
+        complianceCompleted.approve();
+        complianceCompleted.startReview();
+        complianceCompleted.complete();
+        diagnosticRepository.save(complianceCompleted);
+
+        log.info("Diagnostics created: 17 diagnostics (all statuses covered)");
+
+        // ========================================
+        // 7. Approval - 모든 상태 커버 (6건)
+        // ========================================
+        // WAITING (대기중) - 2건
+        approvalRepository.save(Approval.builder()
+                .diagnostic(esgSubmitted1).requester(drafter2)
+                .requestComment("ESG 진단 결과 검토 요청드립니다.")
+                .deadline(LocalDate.of(2026, 3, 15)).build());
+
+        approvalRepository.save(Approval.builder()
+                .diagnostic(safetySubmitted).requester(drafter4)
+                .requestComment("안전보건 점검 결과 결재 요청합니다.")
+                .deadline(LocalDate.of(2026, 2, 20)).build());
+
+        // APPROVED (승인) - 2건
+        Approval approvedApproval1 = Approval.builder()
+                .diagnostic(esgApproved1).requester(drafter1)
+                .requestComment("ESG 진단 완료하여 결재 요청드립니다.")
+                .deadline(LocalDate.of(2026, 3, 10)).build();
+        approvedApproval1.approve(approver1, "검토 완료, 승인합니다.");
+        approvalRepository.save(approvedApproval1);
+
+        Approval approvedApproval2 = Approval.builder()
+                .diagnostic(esgReviewing1).requester(drafter1)
+                .requestComment("2025년 ESG 진단 결재 요청")
+                .deadline(LocalDate.of(2025, 3, 20)).build();
+        approvedApproval2.approve(approver1, "승인합니다.");
+        approvalRepository.save(approvedApproval2);
+
+        // REJECTED (반려) - 2건
+        Approval rejectedApproval1 = Approval.builder()
+                .diagnostic(esgReturned).requester(drafter3)
+                .requestComment("ESG 진단 결재 요청드립니다.")
+                .deadline(LocalDate.of(2026, 3, 1)).build();
+        rejectedApproval1.reject(approver2, "온실가스 배출량 데이터가 누락되었습니다. 보완 후 재제출 바랍니다.");
+        approvalRepository.save(rejectedApproval1);
+
+        Approval rejectedApproval2 = Approval.builder()
+                .diagnostic(esgSubmitted2).requester(guest1)
+                .requestComment("ESG 진단 검토 부탁드립니다.")
+                .deadline(LocalDate.of(2026, 3, 25)).build();
+        // 이건 WAITING 상태로 유지 (게스트가 요청한 건)
+
+        log.info("Approvals created: 5 approvals (WAITING: 2, APPROVED: 2, REJECTED: 1)");
+
+        // ========================================
+        // 8. Review - 모든 상태 커버 (6건)
+        // ========================================
+        // REVIEWING (심사중) - 2건
+        Review reviewReviewing1 = reviewRepository.save(Review.builder()
+                .diagnostic(esgReviewing1).company(partnerCompany1).domain(esgDomain)
+                .assignedReviewer(reviewerEsg).score(68)
+                .submittedAt(LocalDateTime.now().minusDays(3)).build());
+
+        Review reviewReviewing2 = reviewRepository.save(Review.builder()
+                .diagnostic(esgReviewing2).company(partnerCompany2).domain(esgDomain)
+                .assignedReviewer(reviewerEsg).score(75)
+                .submittedAt(LocalDateTime.now().minusDays(5)).build());
+
+        // APPROVED (심사완료) - 2건
+        Review reviewApproved1 = Review.builder()
+                .diagnostic(esgCompleted1).company(partnerCompany3).domain(esgDomain)
+                .assignedReviewer(reviewerEsg).score(82)
+                .submittedAt(LocalDateTime.now().minusDays(30)).build();
+        reviewApproved1 = reviewRepository.save(reviewApproved1);
+        reviewApproved1.approve(reviewerEsg, "우수한 ESG 경영 현황입니다.",
+                "환경관리 체계 우수", "안전보건 관리 양호", "지배구조 개선 필요");
+        reviewRepository.save(reviewApproved1);
+
+        Review reviewApproved2 = Review.builder()
+                .diagnostic(safetyCompleted).company(partnerCompany3).domain(safetyDomain)
+                .assignedReviewer(reviewerSafety).score(91)
+                .submittedAt(LocalDateTime.now().minusDays(45)).build();
+        reviewApproved2 = reviewRepository.save(reviewApproved2);
+        reviewApproved2.approve(reviewerSafety, "안전보건 관리 체계 우수합니다.", null, null, null);
+        reviewRepository.save(reviewApproved2);
+
+        // REVISION_REQUIRED (보완요청) - 2건
+        Review reviewRevision1 = Review.builder()
+                .diagnostic(esgCompleted2).company(partnerCompany4).domain(esgDomain)
+                .assignedReviewer(reviewerEsg).score(45)
+                .submittedAt(LocalDateTime.now().minusDays(20)).build();
+        reviewRevision1 = reviewRepository.save(reviewRevision1);
+        reviewRevision1.requestRevision(reviewerEsg, "환경 부문 증빙자료가 부족합니다. 에너지 사용량 증빙 보완 필요.");
+        reviewRepository.save(reviewRevision1);
+
+        Review reviewRevision2 = Review.builder()
+                .diagnostic(complianceCompleted).company(partnerCompany1).domain(complianceDomain)
+                .assignedReviewer(reviewerCompliance).score(58)
+                .submittedAt(LocalDateTime.now().minusDays(60)).build();
+        reviewRevision2 = reviewRepository.save(reviewRevision2);
+        reviewRevision2.requestRevision(reviewerCompliance, "하도급 계약서 일부 조항 검토 필요. 대금지급 조건 명시 보완 요청.");
+        reviewRepository.save(reviewRevision2);
+
+        log.info("Reviews created: 6 reviews (REVIEWING: 2, APPROVED: 2, REVISION_REQUIRED: 2)");
+
+        // ========================================
+        // 9. RoleRequest - 모든 상태 커버 (4건)
+        // ========================================
+        // PENDING (대기중) - 2건
+        roleRequestRepository.save(RoleRequest.builder()
+                .user(guest1).company(partnerCompany4).domain(esgDomain)
+                .requestedRole("DRAFTER").reason("ESG 진단 업무 담당자로 지정되었습니다.")
+                .status(RequestStatus.PENDING).build());
+
+        roleRequestRepository.save(RoleRequest.builder()
+                .user(guest2).company(partnerCompany4).domain(safetyDomain)
+                .requestedRole("DRAFTER").reason("안전보건 점검 업무를 담당하게 되었습니다.")
+                .status(RequestStatus.PENDING).build());
+
+        // APPROVED (승인) - 1건
+        RoleRequest approvedRequest = RoleRequest.builder()
+                .user(drafter1).company(partnerCompany1).domain(complianceDomain)
+                .requestedRole("DRAFTER").reason("컴플라이언스 업무도 담당하게 되었습니다.")
+                .status(RequestStatus.PENDING).build();
+        approvedRequest.approve(reviewerCompliance);
+        roleRequestRepository.save(approvedRequest);
+
+        // REJECTED (거절) - 1건
+        RoleRequest rejectedRequest = RoleRequest.builder()
+                .user(guest2).company(partnerCompany4).domain(esgDomain)
+                .requestedRole("APPROVER").reason("결재자 권한이 필요합니다.")
+                .status(RequestStatus.PENDING).build();
+        rejectedRequest.reject(reviewerEsg, "현재 기안자 권한만 부여 가능합니다. 담당자 확인 후 재요청 바랍니다.");
+        roleRequestRepository.save(rejectedRequest);
+
+        log.info("RoleRequests created: 4 requests (PENDING: 2, APPROVED: 1, REJECTED: 1)");
+
+        // ========================================
+        // 10. AsyncJob (5건)
+        // ========================================
+        AsyncJob jobSucceeded = AsyncJob.builder()
+                .jobType(JobType.FILE_PARSING).requesterId(drafter1.getUserId())
+                .targetId(esgSubmitted1.getDiagnosticId())
+                .requestPayload("{\"fileId\": 1}").estimatedSeconds(60).build();
+        jobSucceeded.start();
+        jobSucceeded.succeed("/api/v1/diagnostics/" + esgSubmitted1.getDiagnosticId() + "/files/1/result");
+        asyncJobRepository.save(jobSucceeded);
+
+        AsyncJob jobPending = AsyncJob.builder()
+                .jobType(JobType.REPORT_GENERATION).requesterId(reviewerEsg.getUserId())
+                .targetId(reviewReviewing1.getReviewId())
+                .requestPayload("{\"reviewId\": " + reviewReviewing1.getReviewId() + "}").estimatedSeconds(120).build();
+        asyncJobRepository.save(jobPending);
+
+        AsyncJob jobRunning = AsyncJob.builder()
+                .jobType(JobType.AI_ESG_ANALYSIS).requesterId(drafter3.getUserId())
+                .targetId(esgWriting2.getDiagnosticId())
+                .requestPayload("{\"diagnosticId\": " + esgWriting2.getDiagnosticId() + "}").estimatedSeconds(180).build();
+        jobRunning.start();
+        asyncJobRepository.save(jobRunning);
+
+        AsyncJob jobFailed = AsyncJob.builder()
+                .jobType(JobType.FILE_PARSING).requesterId(drafter4.getUserId())
+                .targetId(safetySubmitted.getDiagnosticId())
+                .requestPayload("{\"fileId\": 99}").estimatedSeconds(60).build();
+        jobFailed.start();
+        jobFailed.fail("FILE_NOT_FOUND", "요청한 파일을 찾을 수 없습니다.", false);
+        asyncJobRepository.save(jobFailed);
+
+        AsyncJob jobBulk = AsyncJob.builder()
+                .jobType(JobType.BULK_REPORT).requesterId(reviewerEsg.getUserId())
+                .targetId(esgCampaign2025.getCampaignId())
+                .requestPayload("{\"campaignId\": " + esgCampaign2025.getCampaignId() + "}").estimatedSeconds(300).build();
+        jobBulk.start();
+        jobBulk.succeed("/api/v1/reports/bulk/campaign-" + esgCampaign2025.getCampaignId() + ".zip");
+        asyncJobRepository.save(jobBulk);
+
+        log.info("AsyncJobs created: 5 jobs (PENDING: 1, RUNNING: 1, SUCCEEDED: 2, FAILED: 1)");
+
+        // ========================================
+        // 11. Notification (다양한 타입, 10건)
+        // ========================================
+        // 결재 관련
         notificationRepository.save(Notification.builder()
-                .user(drafter1)
-                .type(NotificationType.APPROVAL_COMPLETE)
-                .title("ESG 진단 결재 완료")
-                .message("(주)테크파트너 2025년 ESG 진단 결재가 승인되었습니다.")
-                .linkUrl("/diagnostics/" + diagnosticForReview.getDiagnosticId())
-                .build());
+                .user(approver1).type(NotificationType.APPROVAL_COMPLETE)
+                .title("결재 요청").message("테크파트너 2026 ESG 진단 결재 요청이 도착했습니다.")
+                .linkUrl("/approvals").build());
 
         notificationRepository.save(Notification.builder()
-                .user(reviewer)
-                .type(NotificationType.REVIEW_COMPLETE)
-                .title("심사 대기 건 등록")
-                .message("새로운 심사 건이 등록되었습니다: (주)테크파트너")
-                .linkUrl("/reviews/" + review1.getReviewId())
-                .build());
+                .user(drafter2).type(NotificationType.APPROVAL_COMPLETE)
+                .title("결재 완료").message("ESG 진단 결재가 승인되었습니다.")
+                .linkUrl("/diagnostics/" + esgApproved1.getDiagnosticId()).build());
 
         notificationRepository.save(Notification.builder()
-                .user(guest)
-                .type(NotificationType.ROLE_APPROVED)
-                .title("권한 승인 완료")
-                .message("요청하신 기안자 권한이 승인되었습니다.")
-                .linkUrl("/profile")
-                .build());
-        log.info("Notifications created: 3 notifications");
+                .user(drafter3).type(NotificationType.REVISION_REQUIRED)
+                .title("결재 반려").message("ESG 진단이 반려되었습니다. 사유: 온실가스 배출량 데이터 누락")
+                .linkUrl("/diagnostics/" + esgReturned.getDiagnosticId()).build());
 
+        // 심사 관련
+        notificationRepository.save(Notification.builder()
+                .user(reviewerEsg).type(NotificationType.REVIEW_COMPLETE)
+                .title("심사 요청").message("새로운 ESG 심사 건이 등록되었습니다: 테크파트너")
+                .linkUrl("/reviews/" + reviewReviewing1.getReviewId()).build());
+
+        notificationRepository.save(Notification.builder()
+                .user(drafter1).type(NotificationType.REVIEW_COMPLETE)
+                .title("심사 완료").message("ESG 심사가 완료되었습니다. 등급: B")
+                .linkUrl("/diagnostics/" + esgCompleted1.getDiagnosticId()).build());
+
+        // 역할 관련
+        notificationRepository.save(Notification.builder()
+                .user(guest1).type(NotificationType.ROLE_APPROVED)
+                .title("권한 요청 접수").message("DRAFTER 권한 요청이 접수되었습니다.")
+                .linkUrl("/profile").build());
+
+        notificationRepository.save(Notification.builder()
+                .user(drafter1).type(NotificationType.ROLE_APPROVED)
+                .title("권한 승인").message("컴플라이언스 도메인 DRAFTER 권한이 승인되었습니다.")
+                .linkUrl("/profile").build());
+
+        notificationRepository.save(Notification.builder()
+                .user(guest2).type(NotificationType.REVISION_REQUIRED)
+                .title("권한 거절").message("APPROVER 권한 요청이 거절되었습니다.")
+                .linkUrl("/profile").build());
+
+        // AI 분석 관련
+        notificationRepository.save(Notification.builder()
+                .user(drafter1).type(NotificationType.AI_ANALYSIS_COMPLETE)
+                .title("AI 분석 완료").message("ESG 진단 AI 분석이 완료되었습니다.")
+                .linkUrl("/diagnostics/" + esgSubmitted1.getDiagnosticId()).build());
+
+        notificationRepository.save(Notification.builder()
+                .user(drafter4).type(NotificationType.AI_ANALYSIS_FAILED)
+                .title("AI 분석 실패").message("파일 분석에 실패했습니다. 파일을 확인해주세요.")
+                .linkUrl("/diagnostics/" + safetySubmitted.getDiagnosticId()).build());
+
+        log.info("Notifications created: 10 notifications (various types)");
+
+        // ========================================
+        // 완료 로그
+        // ========================================
         log.info("=== Data Initialization Completed ===");
-        log.info("Test accounts (password: Test1234!):");
-        log.info("  - Reviewer: reviewer@smartchain.co.kr");
-        log.info("  - Approver: approver@techpartner.co.kr");
-        log.info("  - Drafter1: drafter1@techpartner.co.kr");
-        log.info("  - Drafter2: drafter2@greenmanu.co.kr");
-        log.info("  - Guest: guest@example.com");
+        log.info("");
+        log.info("============================================");
+        log.info("        TEST ACCOUNTS (password: Test1234!)");
+        log.info("============================================");
+        log.info("");
+        log.info("[원청 심사자 - REVIEWER]");
+        log.info("  ESG:        reviewer.esg@hdhhi.co.kr");
+        log.info("  안전보건:   reviewer.safety@hdhhi.co.kr");
+        log.info("  컴플라이언스: reviewer.compliance@hdhhi.co.kr");
+        log.info("");
+        log.info("[협력사 결재자 - APPROVER]");
+        log.info("  테크파트너: approver@techpartner.co.kr (ESG, COMPLIANCE)");
+        log.info("  그린매뉴:   approver@greenmanu.co.kr (ESG, SAFETY)");
+        log.info("  안전건설:   approver@safebuild.co.kr (SAFETY)");
+        log.info("");
+        log.info("[협력사 기안자 - DRAFTER]");
+        log.info("  테크파트너: drafter1@techpartner.co.kr, drafter2@techpartner.co.kr");
+        log.info("  그린매뉴:   drafter@greenmanu.co.kr");
+        log.info("  안전건설:   drafter@safebuild.co.kr");
+        log.info("");
+        log.info("[게스트 - GUEST]");
+        log.info("  정밀부품:   newbie1@precision.co.kr, newbie2@precision.co.kr");
+        log.info("============================================");
     }
 }


### PR DESCRIPTION
## Summary

- DataInitializer 확장: 다양한 테스트 시나리오 커버
- 테스트 문서 2개 추가

## 변경 내용

### DataInitializer 확장

| 항목 | 기존 → 변경 |
|------|-------------|
| 사용자 | 5 → 12명 |
| 진단 | 3 → 16개 (모든 상태) |
| 결재 | 1 → 5개 (WAITING/APPROVED/REJECTED) |
| 심사 | 1 → 6개 (REVIEWING/APPROVED/REVISION_REQUIRED) |
| 역할요청 | 0 → 4개 |

### 추가된 문서

- `docs/TEST_DATA_GUIDE.md` - 테스트 계정/데이터 가이드
- `docs/E2E_TEST_SCENARIOS.md` - 40+ E2E 테스트 시나리오

## Test plan

- [x] 로컬에서 앱 시작 후 데이터 초기화 확인
- [x] 각 테스트 계정 로그인 확인

Closes #79