### PR TITLE
feat(job): 업로드 처리 파이프라인 상태 조회 (#88)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/job/entity/AsyncJob.java
+++ b/src/main/java/com/smartchain/platform/domain/job/entity/AsyncJob.java
@@ -3,6 +3,7 @@ package com.smartchain.platform.domain.job.entity;
 import com.smartchain.platform.global.entity.BaseTimeEntity;
 import com.smartchain.platform.global.enums.JobStatus;
 import com.smartchain.platform.global.enums.JobType;
+import com.smartchain.platform.global.enums.PipelinePhase;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,6 +33,9 @@ public class AsyncJob extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private JobStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private PipelinePhase currentPhase;
 
     private int progress;
 
@@ -67,6 +71,7 @@ public class AsyncJob extends BaseTimeEntity {
         this.jobId = generateJobId(jobType);
         this.jobType = jobType;
         this.status = JobStatus.PENDING;
+        this.currentPhase = PipelinePhase.QUEUED;
         this.progress = 0;
         this.requesterId = requesterId;
         this.targetId = targetId;
@@ -92,6 +97,7 @@ public class AsyncJob extends BaseTimeEntity {
 
     public void start() {
         this.status = JobStatus.RUNNING;
+        this.currentPhase = PipelinePhase.OCR;
         this.startedAt = LocalDateTime.now();
         this.message = "작업이 실행 중입니다";
     }
@@ -101,8 +107,30 @@ public class AsyncJob extends BaseTimeEntity {
         this.message = message;
     }
 
+    /**
+     * 파이프라인 단계 진행 및 진행률 업데이트
+     */
+    public void advancePhase(PipelinePhase phase, int progress, String message) {
+        this.currentPhase = phase;
+        this.progress = progress;
+        this.message = message;
+    }
+
+    /**
+     * 다음 파이프라인 단계로 자동 진행
+     */
+    public void advanceToNextPhase() {
+        if (this.currentPhase != null && !this.currentPhase.isTerminal()) {
+            this.currentPhase = this.currentPhase.next();
+            this.message = this.currentPhase.getDescription();
+            // 단계별 진행률 계산 (4단계 기준)
+            this.progress = Math.min(100, this.currentPhase.getOrder() * 25);
+        }
+    }
+
     public void succeed(String resultUrl) {
         this.status = JobStatus.SUCCEEDED;
+        this.currentPhase = PipelinePhase.COMPLETED;
         this.progress = 100;
         this.completedAt = LocalDateTime.now();
         this.resultUrl = resultUrl;

--- a/src/main/java/com/smartchain/platform/domain/job/service/JobService.java
+++ b/src/main/java/com/smartchain/platform/domain/job/service/JobService.java
@@ -5,6 +5,7 @@ import com.smartchain.platform.domain.job.repository.AsyncJobRepository;
 import com.smartchain.platform.dto.job.JobRetryResponse;
 import com.smartchain.platform.dto.job.JobStatusResponse;
 import com.smartchain.platform.global.enums.JobStatus;
+import com.smartchain.platform.global.enums.PipelinePhase;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -81,6 +82,17 @@ public class JobService {
                 .message(job.getMessage())
                 .startedAt(job.getStartedAt())
                 .estimatedCompletionAt(job.getEstimatedCompletionAt());
+
+        // 파이프라인 단계 정보 추가
+        PipelinePhase phase = job.getCurrentPhase();
+        if (phase != null) {
+            builder.pipeline(JobStatusResponse.PipelineInfo.builder()
+                    .currentPhase(phase.name())
+                    .phaseDescription(phase.getDescription())
+                    .phaseOrder(phase.getOrder())
+                    .totalPhases(PipelinePhase.values().length - 1)  // QUEUED 제외
+                    .build());
+        }
 
         if (job.getStatus() == JobStatus.SUCCEEDED) {
             builder.completedAt(job.getCompletedAt())

--- a/src/main/java/com/smartchain/platform/dto/job/JobStatusResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/job/JobStatusResponse.java
@@ -15,11 +15,21 @@ public class JobStatusResponse {
     private String status;
     private int progress;
     private String message;
+    private PipelineInfo pipeline;
     private LocalDateTime startedAt;
     private LocalDateTime completedAt;
     private LocalDateTime estimatedCompletionAt;
     private JobResultDto result;
     private JobErrorDto error;
+
+    @Getter
+    @Builder
+    public static class PipelineInfo {
+        private String currentPhase;
+        private String phaseDescription;
+        private int phaseOrder;
+        private int totalPhases;
+    }
 
     @Getter
     @Builder

--- a/src/main/java/com/smartchain/platform/global/enums/PipelinePhase.java
+++ b/src/main/java/com/smartchain/platform/global/enums/PipelinePhase.java
@@ -1,0 +1,48 @@
+package com.smartchain.platform.global.enums;
+
+/**
+ * 파일 업로드 처리 파이프라인 단계
+ * OCR -> VALIDATION -> METRICS 순서로 진행
+ */
+public enum PipelinePhase {
+    QUEUED("대기 중", 0),
+    OCR("OCR 처리 중", 1),
+    VALIDATION("검증 중", 2),
+    METRICS("메트릭 추출 중", 3),
+    COMPLETED("완료", 4);
+
+    private final String description;
+    private final int order;
+
+    PipelinePhase(String description, int order) {
+        this.description = description;
+        this.order = order;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    /**
+     * 다음 단계 반환. 마지막 단계면 COMPLETED 반환
+     */
+    public PipelinePhase next() {
+        return switch (this) {
+            case QUEUED -> OCR;
+            case OCR -> VALIDATION;
+            case VALIDATION -> METRICS;
+            case METRICS, COMPLETED -> COMPLETED;
+        };
+    }
+
+    /**
+     * 현재 단계가 완료 단계인지 확인
+     */
+    public boolean isTerminal() {
+        return this == COMPLETED;
+    }
+}

--- a/src/test/java/com/smartchain/platform/domain/job/service/JobServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/job/service/JobServiceTest.java
@@ -6,6 +6,7 @@ import com.smartchain.platform.dto.job.JobRetryResponse;
 import com.smartchain.platform.dto.job.JobStatusResponse;
 import com.smartchain.platform.global.enums.JobStatus;
 import com.smartchain.platform.global.enums.JobType;
+import com.smartchain.platform.global.enums.PipelinePhase;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +51,7 @@ class JobServiceTest {
         lenient().when(testJob.getMessage()).thenReturn("파일 파싱 중...");
         lenient().when(testJob.getRequesterId()).thenReturn(userId);
         lenient().when(testJob.getStartedAt()).thenReturn(LocalDateTime.now());
+        lenient().when(testJob.getCurrentPhase()).thenReturn(PipelinePhase.VALIDATION);
     }
 
     @Nested
@@ -144,6 +146,46 @@ class JobServiceTest {
             assertThat(response.getError()).isNotNull();
             assertThat(response.getError().getCode()).isEqualTo("SYS_003");
             assertThat(response.getError().isRetryable()).isTrue();
+        }
+
+        @Test
+        @DisplayName("파이프라인 단계 정보가 포함된 작업 상태 조회")
+        void getJobStatus_WithPipelineInfo_Success() {
+            // given
+            when(testJob.getCurrentPhase()).thenReturn(PipelinePhase.VALIDATION);
+            given(asyncJobRepository.findByJobId(jobId)).willReturn(Optional.of(testJob));
+
+            // when
+            JobStatusResponse response = jobService.getJobStatus(userId, jobId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getPipeline()).isNotNull();
+            assertThat(response.getPipeline().getCurrentPhase()).isEqualTo("VALIDATION");
+            assertThat(response.getPipeline().getPhaseDescription()).isEqualTo("검증 중");
+            assertThat(response.getPipeline().getPhaseOrder()).isEqualTo(2);
+            assertThat(response.getPipeline().getTotalPhases()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("파이프라인 완료 단계 조회")
+        void getJobStatus_CompletedPipeline_Success() {
+            // given
+            when(testJob.getStatus()).thenReturn(JobStatus.SUCCEEDED);
+            when(testJob.getCurrentPhase()).thenReturn(PipelinePhase.COMPLETED);
+            when(testJob.getCompletedAt()).thenReturn(LocalDateTime.now());
+            when(testJob.getResultUrl()).thenReturn("/diagnostics/1/files/102/parsing-result");
+
+            given(asyncJobRepository.findByJobId(jobId)).willReturn(Optional.of(testJob));
+
+            // when
+            JobStatusResponse response = jobService.getJobStatus(userId, jobId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getPipeline()).isNotNull();
+            assertThat(response.getPipeline().getCurrentPhase()).isEqualTo("COMPLETED");
+            assertThat(response.getPipeline().getPhaseDescription()).isEqualTo("완료");
         }
     }
 

--- a/src/test/java/com/smartchain/platform/global/enums/PipelinePhaseTest.java
+++ b/src/test/java/com/smartchain/platform/global/enums/PipelinePhaseTest.java
@@ -1,0 +1,50 @@
+package com.smartchain.platform.global.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("PipelinePhase Enum 테스트")
+class PipelinePhaseTest {
+
+    @Test
+    @DisplayName("파이프라인 단계 순서가 올바르게 정의됨")
+    void pipelinePhase_OrderIsCorrect() {
+        assertThat(PipelinePhase.QUEUED.getOrder()).isEqualTo(0);
+        assertThat(PipelinePhase.OCR.getOrder()).isEqualTo(1);
+        assertThat(PipelinePhase.VALIDATION.getOrder()).isEqualTo(2);
+        assertThat(PipelinePhase.METRICS.getOrder()).isEqualTo(3);
+        assertThat(PipelinePhase.COMPLETED.getOrder()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("다음 단계 전이가 올바르게 동작함")
+    void pipelinePhase_NextTransitionIsCorrect() {
+        assertThat(PipelinePhase.QUEUED.next()).isEqualTo(PipelinePhase.OCR);
+        assertThat(PipelinePhase.OCR.next()).isEqualTo(PipelinePhase.VALIDATION);
+        assertThat(PipelinePhase.VALIDATION.next()).isEqualTo(PipelinePhase.METRICS);
+        assertThat(PipelinePhase.METRICS.next()).isEqualTo(PipelinePhase.COMPLETED);
+        assertThat(PipelinePhase.COMPLETED.next()).isEqualTo(PipelinePhase.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("터미널 단계 확인이 올바르게 동작함")
+    void pipelinePhase_IsTerminalIsCorrect() {
+        assertThat(PipelinePhase.QUEUED.isTerminal()).isFalse();
+        assertThat(PipelinePhase.OCR.isTerminal()).isFalse();
+        assertThat(PipelinePhase.VALIDATION.isTerminal()).isFalse();
+        assertThat(PipelinePhase.METRICS.isTerminal()).isFalse();
+        assertThat(PipelinePhase.COMPLETED.isTerminal()).isTrue();
+    }
+
+    @Test
+    @DisplayName("단계별 설명이 올바르게 정의됨")
+    void pipelinePhase_DescriptionIsCorrect() {
+        assertThat(PipelinePhase.QUEUED.getDescription()).isEqualTo("대기 중");
+        assertThat(PipelinePhase.OCR.getDescription()).isEqualTo("OCR 처리 중");
+        assertThat(PipelinePhase.VALIDATION.getDescription()).isEqualTo("검증 중");
+        assertThat(PipelinePhase.METRICS.getDescription()).isEqualTo("메트릭 추출 중");
+        assertThat(PipelinePhase.COMPLETED.getDescription()).isEqualTo("완료");
+    }
+}


### PR DESCRIPTION
## 변경 요약
- `PipelinePhase` enum 추가: OCR → VALIDATION → METRICS 파이프라인 단계 정의
- `AsyncJob` 엔티티에 `currentPhase` 필드 추가
- `JobStatusResponse`에 `PipelineInfo` 포함하여 단계 정보 제공
- 단계 전환 메서드 (`advancePhase`, `advanceToNextPhase`) 추가

## 관련 이슈
Closes #88

## 테스트 방법
1. `./gradlew test --tests "PipelinePhaseTest"` - PipelinePhase enum 단위 테스트
2. `./gradlew test --tests "JobServiceTest"` - 파이프라인 단계 조회 통합 테스트
3. `GET /api/v1/jobs/{jobId}` 호출 시 `pipeline` 필드 확인

## 명세 준수 체크
- [x] 상태: PENDING | RUNNING | SUCCEEDED | FAILED
- [x] 단계 정보: currentPhase, phaseDescription, phaseOrder, totalPhases
- [x] 기존 API (`GET /api/v1/jobs/{jobId}`) 확장
- [x] 기존 `AsyncJob`, `JobStatusResponse` DTO 재사용

## 리뷰 포인트
1. `PipelinePhase` enum의 단계 순서와 진행률 계산 로직
2. `AsyncJob.advanceToNextPhase()` 메서드의 자동 진행률 계산

## TODO/질문
- [ ] AI FastAPI 연동 시 콜백에서 `advancePhase()` 호출 필요
- [ ] SSE/폴링 기반 실시간 업데이트는 추후 이슈로 분리