### PR TITLE
fix(role): APPROVER 역할을 ESG 도메인에서만 허용 (#82)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,36 @@
 # Claude Code Learnings
 
+## 2026-02-01: APPROVER 역할이 모든 도메인에서 요청 가능 (#82)
+
+### 원인
+- RoleRequestService.createRoleRequest()에 도메인-역할 정책 검증 없음
+- APPROVER는 ESG 도메인에서만 유효하지만 SAFETY/COMPLIANCE에서도 요청 가능
+
+### 해결
+- 도메인 조회 후 `APPROVER + !ESG` 조합 시 `APPROVER_ONLY_ESG` (R007) 에러 반환
+- ErrorCode에 `APPROVER_ONLY_ESG` 추가 (HttpStatus.BAD_REQUEST)
+
+### 재발 방지
+- 새 도메인-역할 정책 추가 시 createRoleRequest() 검증 로직 확인
+- 정책 변경 시 테스트 케이스 동시 업데이트
+
+### 검증 방법
+```bash
+./gradlew test --tests "RoleRequestServiceTest"
+```
+
+### 관련 커밋
+- (이 PR에 포함)
+
+### 생성/수정 파일
+```
+src/main/java/.../global/error/ErrorCode.java (APPROVER_ONLY_ESG 추가)
+src/main/java/.../domain/role/service/RoleRequestService.java (도메인-역할 정책 검증)
+src/test/java/.../domain/role/service/RoleRequestServiceTest.java (테스트 2건 추가)
+```
+
+---
+
 ## 2026-02-01: 권한요청 승인 후에도 게스트 유지 (#83)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/role/service/RoleRequestService.java
+++ b/src/main/java/com/smartchain/platform/domain/role/service/RoleRequestService.java
@@ -148,6 +148,11 @@ public class RoleRequestService {
         Domain domain = domainRepository.findById(request.getDomainId())
                 .orElseThrow(() -> new CustomException(ErrorCode.DOMAIN_NOT_FOUND));
 
+        // APPROVER는 ESG 도메인에서만 허용
+        if ("APPROVER".equals(request.getRequestedRole()) && !"ESG".equals(domain.getCode())) {
+            throw new CustomException(ErrorCode.APPROVER_ONLY_ESG);
+        }
+
         // 해당 도메인에 이미 권한이 있는지 확인
         if (userDomainRoleRepository.existsByUserUserIdAndDomainDomainId(userId, request.getDomainId())) {
             throw new CustomException(ErrorCode.DUPLICATE_DOMAIN_ROLE);

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -64,6 +64,7 @@ public enum ErrorCode {
     DUPLICATE_ROLE_REQUEST(HttpStatus.CONFLICT, "R003", "이미 대기중인 권한 요청이 있습니다"),
     DUPLICATE_DOMAIN_ROLE(HttpStatus.CONFLICT, "R006", "해당 도메인에 이미 권한이 부여되어 있습니다"),
     INVALID_ROLE_REQUEST(HttpStatus.BAD_REQUEST, "R004", "유효하지 않은 권한입니다"),
+    APPROVER_ONLY_ESG(HttpStatus.BAD_REQUEST, "R007", "결재자(APPROVER) 역할은 ESG 도메인에서만 요청할 수 있습니다"),
     ALREADY_PROCESSED_REQUEST(HttpStatus.CONFLICT, "PERM_003", "이미 처리된 권한 요청입니다"),
     INVALID_DECISION(HttpStatus.BAD_REQUEST, "R005", "유효하지 않은 처리 결과입니다"),
     ALREADY_PROCESSED_APPROVAL(HttpStatus.CONFLICT, "AP002", "이미 처리된 결재 요청입니다"),

--- a/src/test/java/com/smartchain/platform/domain/role/service/RoleRequestServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/role/service/RoleRequestServiceTest.java
@@ -258,6 +258,65 @@ class RoleRequestServiceTest {
                         assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.COMPANY_NOT_FOUND);
                     });
         }
+        @Test
+        @DisplayName("SAFETY 도메인에서 APPROVER 요청 시 실패")
+        void createRoleRequest_ApproverNonEsg_ThrowsException() {
+            // given
+            Domain safetyDomain = mock(Domain.class);
+            lenient().when(safetyDomain.getDomainId()).thenReturn(2L);
+            when(safetyDomain.getCode()).thenReturn("SAFETY");
+
+            RoleRequestCreateDto createDto = RoleRequestCreateDto.builder()
+                    .requestedRole("APPROVER")
+                    .domainId(2L)
+                    .companyId(10L)
+                    .reason("안전보건 결재자 요청")
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(domainRepository.findById(2L)).willReturn(Optional.of(safetyDomain));
+
+            // when & then
+            assertThatThrownBy(() -> roleRequestService.createRoleRequest(1L, createDto))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.APPROVER_ONLY_ESG);
+                    });
+        }
+
+        @Test
+        @DisplayName("ESG 도메인에서 APPROVER 요청 시 정상 처리")
+        void createRoleRequest_ApproverEsg_Success() {
+            // given
+            RoleRequestCreateDto createDto = RoleRequestCreateDto.builder()
+                    .requestedRole("APPROVER")
+                    .domainId(1L)
+                    .companyId(10L)
+                    .reason("ESG 결재자 요청")
+                    .build();
+
+            RoleRequest savedRequest = mock(RoleRequest.class);
+            when(savedRequest.getRequestId()).thenReturn(1L);
+            when(savedRequest.getStatus()).thenReturn(RequestStatus.PENDING);
+            when(savedRequest.getRequestedRole()).thenReturn("APPROVER");
+            when(savedRequest.getCreatedAt()).thenReturn(null);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(domainRepository.findById(1L)).willReturn(Optional.of(testDomain));
+            given(userDomainRoleRepository.existsByUserUserIdAndDomainDomainId(1L, 1L)).willReturn(false);
+            given(roleRequestRepository.existsByUserAndDomainAndStatus(testUser, testDomain, RequestStatus.PENDING)).willReturn(false);
+            given(companyRepository.findById(10L)).willReturn(Optional.of(testCompany));
+            given(roleRequestRepository.save(any(RoleRequest.class))).willReturn(savedRequest);
+
+            // when
+            RoleRequestResponse response = roleRequestService.createRoleRequest(1L, createDto);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getRequestedRole()).isEqualTo("APPROVER");
+            verify(roleRequestRepository).save(any(RoleRequest.class));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 변경 요약
- 권한요청 생성 시 APPROVER 역할을 ESG 외 도메인(SAFETY, COMPLIANCE)에서 요청하면 400 에러 반환
- ErrorCode `APPROVER_ONLY_ESG` (R007) 추가

## 관련 이슈
Closes #82

## 테스트 방법
```bash
./gradlew test --tests "RoleRequestServiceTest"
./gradlew test && ./gradlew build
```

### 추가된 테스트
| 테스트 | 검증 내용 |
|--------|----------|
| SAFETY + APPROVER 요청 | APPROVER_ONLY_ESG 에러 반환 |
| ESG + APPROVER 요청 | 정상 처리 |

## 명세 준수 체크
- [x] ESG가 아닌 도메인에서 APPROVER 요청 시 400 에러 반환
- [x] 에러 응답에 명확한 사유 코드/메시지 포함 (`APPROVER_ONLY_ESG`, R007)
- [x] role/domain validation 단위 테스트 포함

## 리뷰 포인트
1. 정책 검증 위치: 도메인 조회 직후, 중복 확인 전 — 불필요한 DB 쿼리 방지
2. 향후 다른 도메인-역할 제약 추가 시 동일 패턴으로 확장 가능

## TODO / 질문
- [ ] FE에서 도메인 선택 시 APPROVER 옵션을 ESG 외 도메인에서 숨길지 여부
- [ ] 기존 위반 데이터(ESG 외 APPROVER) 존재 여부 확인 → Out of Scope로 분리