### PR TITLE
feat(role): 권한요청 알림 이벤트 생성 (#89)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/role/service/RoleRequestService.java
+++ b/src/main/java/com/smartchain/platform/domain/role/service/RoleRequestService.java
@@ -1,5 +1,6 @@
 package com.smartchain.platform.domain.role.service;
 
+import com.smartchain.platform.domain.notification.service.NotificationService;
 import com.smartchain.platform.domain.role.repository.RoleRequestRepository;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Domain;
@@ -12,6 +13,7 @@ import com.smartchain.platform.domain.user.repository.DomainRepository;
 import com.smartchain.platform.domain.user.repository.RoleRepository;
 import com.smartchain.platform.domain.user.repository.UserDomainRoleRepository;
 import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.global.enums.NotificationType;
 import com.smartchain.platform.dto.role.approval.RoleApprovalDetailResponse;
 import com.smartchain.platform.dto.role.approval.RoleApprovalItemDto;
 import com.smartchain.platform.dto.role.approval.RoleApprovalListResponse;
@@ -59,6 +61,7 @@ public class RoleRequestService {
     private final RoleRepository roleRepository;
     private final DomainRepository domainRepository;
     private final UserDomainRoleRepository userDomainRoleRepository;
+    private final NotificationService notificationService;
 
     private static final List<String> REQUESTABLE_ROLES = Arrays.asList("DRAFTER", "APPROVER", "REVIEWER");
 
@@ -174,6 +177,9 @@ public class RoleRequestService {
 
         log.info("Role request created: userId={}, requestedRole={}, domainId={}, companyId={}",
                 userId, request.getRequestedRole(), request.getDomainId(), request.getCompanyId());
+
+        // REVIEWER들에게 권한 요청 알림 생성
+        notifyReviewersOfNewRoleRequest(user, savedRequest);
 
         return RoleRequestResponse.builder()
                 .accessRequestId(savedRequest.getRequestId())
@@ -485,11 +491,17 @@ public class RoleRequestService {
 
             message = "권한 요청이 승인되었습니다";
             log.info("Role request approved: requestId={}, approvedBy={}", accessRequestId, userId);
+
+            // 요청자에게 승인 알림 생성
+            notifyRequesterOfApproval(roleRequest);
         } else if ("REJECTED".equals(decision)) {
             roleRequest.reject(currentUser, request.getRejectReason());
             message = "권한 요청이 반려되었습니다";
             log.info("Role request rejected: requestId={}, rejectedBy={}, reason={}",
                     accessRequestId, userId, request.getRejectReason());
+
+            // 요청자에게 반려 알림 생성
+            notifyRequesterOfRejection(roleRequest);
         } else {
             throw new CustomException(ErrorCode.INVALID_DECISION);
         }
@@ -506,5 +518,68 @@ public class RoleRequestService {
                 .processedBy(processedByDto)
                 .message(message)
                 .build();
+    }
+
+    // ========== 알림 생성 헬퍼 메서드 ==========
+
+    private void notifyReviewersOfNewRoleRequest(User requester, RoleRequest roleRequest) {
+        List<User> reviewers = userRepository.findAllByRoleCode("REVIEWER");
+
+        String domainName = roleRequest.getDomain() != null ? roleRequest.getDomain().getName() : "";
+        String roleName = ROLE_NAME_MAP.getOrDefault(roleRequest.getRequestedRole(), roleRequest.getRequestedRole());
+        String title = "새로운 권한 요청";
+        String message = String.format("%s님이 %s 도메인의 %s 권한을 요청했습니다.",
+                requester.getName(), domainName, roleName);
+        String linkUrl = "/management/role-requests/" + roleRequest.getRequestId();
+
+        for (User reviewer : reviewers) {
+            notificationService.createNotification(
+                    reviewer,
+                    NotificationType.ROLE_REQUEST_CREATED,
+                    title,
+                    message,
+                    linkUrl
+            );
+        }
+
+        log.info("Role request notification sent to {} reviewers: requestId={}",
+                reviewers.size(), roleRequest.getRequestId());
+    }
+
+    private void notifyRequesterOfApproval(RoleRequest roleRequest) {
+        User requester = roleRequest.getUser();
+        String domainName = roleRequest.getDomain() != null ? roleRequest.getDomain().getName() : "";
+        String roleName = ROLE_NAME_MAP.getOrDefault(roleRequest.getRequestedRole(), roleRequest.getRequestedRole());
+
+        String title = "권한 요청이 승인되었습니다";
+        String message = String.format("%s 도메인의 %s 권한이 승인되었습니다.", domainName, roleName);
+
+        notificationService.createNotification(
+                requester,
+                NotificationType.ROLE_APPROVED,
+                title,
+                message,
+                null
+        );
+    }
+
+    private void notifyRequesterOfRejection(RoleRequest roleRequest) {
+        User requester = roleRequest.getUser();
+        String domainName = roleRequest.getDomain() != null ? roleRequest.getDomain().getName() : "";
+        String roleName = ROLE_NAME_MAP.getOrDefault(roleRequest.getRequestedRole(), roleRequest.getRequestedRole());
+
+        String title = "권한 요청이 반려되었습니다";
+        String message = String.format("%s 도메인의 %s 권한 요청이 반려되었습니다.", domainName, roleName);
+        if (roleRequest.getRejectReason() != null && !roleRequest.getRejectReason().isEmpty()) {
+            message += " 사유: " + roleRequest.getRejectReason();
+        }
+
+        notificationService.createNotification(
+                requester,
+                NotificationType.ROLE_REQUEST_REJECTED,
+                title,
+                message,
+                null
+        );
     }
 }

--- a/src/main/java/com/smartchain/platform/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/user/repository/UserRepository.java
@@ -40,6 +40,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 통계용 카운트
     long countByStatus(UserStatus status);
 
+    // 역할별 사용자 목록 조회 (알림 발송용)
+    @Query("SELECT u FROM User u WHERE u.role.code = :roleCode")
+    java.util.List<User> findAllByRoleCode(@Param("roleCode") String roleCode);
+
     @Query("SELECT COUNT(u) FROM User u WHERE u.lastLoginAt >= :since")
     long countByLastLoginAtAfter(@Param("since") LocalDateTime since);
 }

--- a/src/main/java/com/smartchain/platform/global/enums/NotificationType.java
+++ b/src/main/java/com/smartchain/platform/global/enums/NotificationType.java
@@ -7,6 +7,8 @@ public enum NotificationType {
     APPROVAL_COMPLETE,      // 결재 완료
     REVIEW_COMPLETE,        // 심사 완료
     ROLE_APPROVED,          // 권한 승인
+    ROLE_REQUEST_CREATED,   // 권한 요청 생성 (수신자에게)
+    ROLE_REQUEST_REJECTED,  // 권한 요청 반려
     REVISION_REQUIRED,      // 보완 요청
     AI_ANALYSIS_COMPLETE,   // AI 분석 완료
     AI_ANALYSIS_FAILED      // AI 분석 실패

--- a/src/test/java/com/smartchain/platform/domain/role/service/RoleRequestServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/role/service/RoleRequestServiceTest.java
@@ -1,5 +1,7 @@
 package com.smartchain.platform.domain.role.service;
 
+import com.smartchain.platform.domain.notification.entity.Notification;
+import com.smartchain.platform.domain.notification.service.NotificationService;
 import com.smartchain.platform.domain.role.repository.RoleRequestRepository;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Domain;
@@ -12,6 +14,7 @@ import com.smartchain.platform.domain.user.repository.DomainRepository;
 import com.smartchain.platform.domain.user.repository.RoleRepository;
 import com.smartchain.platform.domain.user.repository.UserDomainRoleRepository;
 import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.global.enums.NotificationType;
 import com.smartchain.platform.dto.role.approval.RoleApprovalDetailResponse;
 import com.smartchain.platform.dto.role.approval.RoleApprovalListResponse;
 import com.smartchain.platform.dto.role.approval.RoleDecisionRequest;
@@ -42,12 +45,17 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import static org.hamcrest.Matchers.containsString;
+
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class RoleRequestServiceTest {
 
     @InjectMocks
@@ -70,6 +78,9 @@ class RoleRequestServiceTest {
 
     @Mock
     private UserDomainRoleRepository userDomainRoleRepository;
+
+    @Mock
+    private NotificationService notificationService;
 
     @Mock
     private User testUser;
@@ -166,6 +177,7 @@ class RoleRequestServiceTest {
             when(savedRequest.getStatus()).thenReturn(RequestStatus.PENDING);
             when(savedRequest.getRequestedRole()).thenReturn("DRAFTER");
             when(savedRequest.getCreatedAt()).thenReturn(null);
+            when(savedRequest.getDomain()).thenReturn(testDomain);
 
             given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
             given(domainRepository.findById(1L)).willReturn(Optional.of(testDomain));
@@ -173,6 +185,7 @@ class RoleRequestServiceTest {
             given(roleRequestRepository.existsByUserAndDomainAndStatus(testUser, testDomain, RequestStatus.PENDING)).willReturn(false);
             given(companyRepository.findById(10L)).willReturn(Optional.of(testCompany));
             given(roleRequestRepository.save(any(RoleRequest.class))).willReturn(savedRequest);
+            given(userRepository.findAllByRoleCode("REVIEWER")).willReturn(Collections.emptyList());
 
             // when
             RoleRequestResponse response = roleRequestService.createRoleRequest(1L, createDto);
@@ -185,6 +198,7 @@ class RoleRequestServiceTest {
             assertThat(response.getCompanyId()).isEqualTo(10L);
 
             verify(roleRequestRepository).save(any(RoleRequest.class));
+            verify(userRepository).findAllByRoleCode("REVIEWER");
         }
 
         @Test
@@ -392,11 +406,17 @@ class RoleRequestServiceTest {
             when(reviewerUser.getName()).thenReturn("리뷰어");
             when(reviewerUser.getRole()).thenReturn(reviewerRole);
 
+            User requestUser = mock(User.class);
+            when(requestUser.getUserId()).thenReturn(3L);
+
             RoleRequest roleRequest = mock(RoleRequest.class);
             when(roleRequest.getRequestId()).thenReturn(1L);
             when(roleRequest.isPending()).thenReturn(true);
             when(roleRequest.getStatus()).thenReturn(RequestStatus.APPROVED);
             when(roleRequest.getDecidedAt()).thenReturn(LocalDateTime.now());
+            when(roleRequest.getDomain()).thenReturn(null); // no domain = no UserDomainRole creation
+            when(roleRequest.getUser()).thenReturn(requestUser);
+            when(roleRequest.getRequestedRole()).thenReturn("DRAFTER");
 
             RoleDecisionRequest decisionRequest = RoleDecisionRequest.builder()
                     .decision("APPROVED")
@@ -413,6 +433,7 @@ class RoleRequestServiceTest {
             assertThat(response.getStatus()).isEqualTo("APPROVED");
             assertThat(response.getMessage()).isEqualTo("권한 요청이 승인되었습니다");
             verify(roleRequest).approve(reviewerUser);
+            verify(notificationService).createNotification(eq(requestUser), eq(NotificationType.ROLE_APPROVED), anyString(), anyString(), isNull());
         }
 
         @Test
@@ -436,6 +457,7 @@ class RoleRequestServiceTest {
 
             Domain esgDomain = mock(Domain.class);
             when(esgDomain.getDomainId()).thenReturn(1L);
+            when(esgDomain.getName()).thenReturn("ESG 실사");
 
             RoleRequest roleRequest = mock(RoleRequest.class);
             when(roleRequest.getRequestId()).thenReturn(1L);
@@ -501,11 +523,18 @@ class RoleRequestServiceTest {
             when(reviewerUser.getName()).thenReturn("리뷰어");
             when(reviewerUser.getRole()).thenReturn(reviewerRole);
 
+            User requestUser = mock(User.class);
+            when(requestUser.getUserId()).thenReturn(3L);
+
             RoleRequest roleRequest = mock(RoleRequest.class);
             when(roleRequest.getRequestId()).thenReturn(1L);
             when(roleRequest.isPending()).thenReturn(true);
             when(roleRequest.getStatus()).thenReturn(RequestStatus.REJECTED);
             when(roleRequest.getDecidedAt()).thenReturn(LocalDateTime.now());
+            when(roleRequest.getUser()).thenReturn(requestUser);
+            when(roleRequest.getDomain()).thenReturn(testDomain);
+            when(roleRequest.getRequestedRole()).thenReturn("DRAFTER");
+            when(roleRequest.getRejectReason()).thenReturn("정보 부족");
 
             RoleDecisionRequest decisionRequest = RoleDecisionRequest.builder()
                     .decision("REJECTED")
@@ -523,6 +552,148 @@ class RoleRequestServiceTest {
             assertThat(response.getStatus()).isEqualTo("REJECTED");
             assertThat(response.getMessage()).isEqualTo("권한 요청이 반려되었습니다");
             verify(roleRequest).reject(reviewerUser, "정보 부족");
+            verify(notificationService).createNotification(eq(requestUser), eq(NotificationType.ROLE_REQUEST_REJECTED), anyString(), anyString(), isNull());
+        }
+    }
+
+    @Nested
+    @DisplayName("권한 요청 알림 생성 테스트")
+    class RoleRequestNotificationTest {
+
+        @Test
+        @DisplayName("권한 요청 생성 시 모든 REVIEWER에게 알림 생성")
+        void createRoleRequest_NotifiesAllReviewers() {
+            // given
+            RoleRequestCreateDto createDto = RoleRequestCreateDto.builder()
+                    .requestedRole("DRAFTER")
+                    .domainId(1L)
+                    .companyId(10L)
+                    .reason("ESG 담당자 지정")
+                    .build();
+
+            RoleRequest savedRequest = mock(RoleRequest.class);
+            when(savedRequest.getRequestId()).thenReturn(1L);
+            when(savedRequest.getStatus()).thenReturn(RequestStatus.PENDING);
+            when(savedRequest.getRequestedRole()).thenReturn("DRAFTER");
+            when(savedRequest.getCreatedAt()).thenReturn(null);
+            when(savedRequest.getDomain()).thenReturn(testDomain);
+
+            User reviewer1 = mock(User.class);
+            User reviewer2 = mock(User.class);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(domainRepository.findById(1L)).willReturn(Optional.of(testDomain));
+            given(userDomainRoleRepository.existsByUserUserIdAndDomainDomainId(1L, 1L)).willReturn(false);
+            given(roleRequestRepository.existsByUserAndDomainAndStatus(testUser, testDomain, RequestStatus.PENDING)).willReturn(false);
+            given(companyRepository.findById(10L)).willReturn(Optional.of(testCompany));
+            given(roleRequestRepository.save(any(RoleRequest.class))).willReturn(savedRequest);
+            given(userRepository.findAllByRoleCode("REVIEWER")).willReturn(List.of(reviewer1, reviewer2));
+
+            // when
+            roleRequestService.createRoleRequest(1L, createDto);
+
+            // then
+            verify(notificationService, times(2)).createNotification(
+                    any(User.class),
+                    eq(NotificationType.ROLE_REQUEST_CREATED),
+                    eq("새로운 권한 요청"),
+                    anyString(),
+                    anyString()
+            );
+        }
+
+        @Test
+        @DisplayName("권한 요청 승인 시 요청자에게 승인 알림 생성")
+        void processRoleRequest_Approve_NotifiesRequester() {
+            // given
+            Role reviewerRoleMock = mock(Role.class);
+            when(reviewerRoleMock.getCode()).thenReturn("REVIEWER");
+
+            User reviewerUserMock = mock(User.class);
+            when(reviewerUserMock.getUserId()).thenReturn(2L);
+            when(reviewerUserMock.getName()).thenReturn("리뷰어");
+            when(reviewerUserMock.getRole()).thenReturn(reviewerRoleMock);
+
+            User requestUser = mock(User.class);
+            when(requestUser.getUserId()).thenReturn(3L);
+
+            RoleRequest roleRequest = mock(RoleRequest.class);
+            when(roleRequest.getRequestId()).thenReturn(1L);
+            when(roleRequest.isPending()).thenReturn(true);
+            when(roleRequest.getStatus()).thenReturn(RequestStatus.APPROVED);
+            when(roleRequest.getDecidedAt()).thenReturn(LocalDateTime.now());
+            when(roleRequest.getUser()).thenReturn(requestUser);
+            when(roleRequest.getDomain()).thenReturn(testDomain);
+            when(roleRequest.getRequestedRole()).thenReturn("DRAFTER");
+
+            Role drafterRole = mock(Role.class);
+
+            RoleDecisionRequest decisionRequest = RoleDecisionRequest.builder()
+                    .decision("APPROVED")
+                    .build();
+
+            given(userRepository.findById(2L)).willReturn(Optional.of(reviewerUserMock));
+            given(roleRequestRepository.findById(1L)).willReturn(Optional.of(roleRequest));
+            given(roleRepository.findByCode("DRAFTER")).willReturn(Optional.of(drafterRole));
+            given(userDomainRoleRepository.save(any(UserDomainRole.class))).willAnswer(i -> i.getArgument(0));
+
+            // when
+            roleRequestService.processRoleRequest(2L, 1L, decisionRequest);
+
+            // then
+            verify(notificationService).createNotification(
+                    eq(requestUser),
+                    eq(NotificationType.ROLE_APPROVED),
+                    eq("권한 요청이 승인되었습니다"),
+                    anyString(),
+                    isNull()
+            );
+        }
+
+        @Test
+        @DisplayName("권한 요청 반려 시 요청자에게 반려 알림 생성")
+        void processRoleRequest_Reject_NotifiesRequester() {
+            // given
+            Role reviewerRoleMock = mock(Role.class);
+            when(reviewerRoleMock.getCode()).thenReturn("REVIEWER");
+
+            User reviewerUserMock = mock(User.class);
+            when(reviewerUserMock.getUserId()).thenReturn(2L);
+            when(reviewerUserMock.getName()).thenReturn("리뷰어");
+            when(reviewerUserMock.getRole()).thenReturn(reviewerRoleMock);
+
+            User requestUser = mock(User.class);
+            when(requestUser.getUserId()).thenReturn(3L);
+
+            RoleRequest roleRequest = mock(RoleRequest.class);
+            when(roleRequest.getRequestId()).thenReturn(1L);
+            when(roleRequest.isPending()).thenReturn(true);
+            when(roleRequest.getStatus()).thenReturn(RequestStatus.REJECTED);
+            when(roleRequest.getDecidedAt()).thenReturn(LocalDateTime.now());
+            when(roleRequest.getUser()).thenReturn(requestUser);
+            when(roleRequest.getDomain()).thenReturn(testDomain);
+            when(roleRequest.getRequestedRole()).thenReturn("DRAFTER");
+            when(roleRequest.getRejectReason()).thenReturn("정보 부족");
+
+            RoleDecisionRequest decisionRequest = RoleDecisionRequest.builder()
+                    .decision("REJECTED")
+                    .rejectReason("정보 부족")
+                    .build();
+
+            given(userRepository.findById(2L)).willReturn(Optional.of(reviewerUserMock));
+            given(roleRequestRepository.findById(1L)).willReturn(Optional.of(roleRequest));
+
+            // when
+            roleRequestService.processRoleRequest(2L, 1L, decisionRequest);
+
+            // then
+            verify(notificationService).createNotification(
+                    eq(requestUser),
+                    eq(NotificationType.ROLE_REQUEST_REJECTED),
+                    eq("권한 요청이 반려되었습니다"),
+                    argThat(containsString("정보 부족")),
+                    isNull()
+            );
         }
     }
 }


### PR DESCRIPTION
## 변경 요약
- 권한요청 생성 시 모든 REVIEWER에게 `ROLE_REQUEST_CREATED` 알림 생성
- 권한요청 승인 시 요청자에게 `ROLE_APPROVED` 알림 생성
- 권한요청 반려 시 요청자에게 `ROLE_REQUEST_REJECTED` 알림 생성
- 알림 내용에 도메인명, 요청 역할명 포함

## 관련 이슈
Closes #89

## 변경 파일
- `NotificationType.java`: `ROLE_REQUEST_CREATED`, `ROLE_REQUEST_REJECTED` enum 추가
- `UserRepository.java`: `findAllByRoleCode()` 메서드 추가 (REVIEWER 목록 조회용)
- `RoleRequestService.java`: NotificationService 주입 및 알림 생성 헬퍼 메서드 추가
- `RoleRequestServiceTest.java`: 알림 생성 관련 테스트 3개 추가

## 테스트 방법
```bash
./gradlew test --tests "RoleRequestServiceTest"
./gradlew test && ./gradlew build
```
- [x] 권한요청 생성 → 수신자 알림 생성 확인
- [x] 승인 처리 → 요청자에게 승인 알림
- [x] 반려 처리 → 요청자에게 반려 알림
- [x] 알림 내용에 필수 정보 포함 확인

## 명세 준수 체크
- [x] `ROLE_REQUEST_CREATED` 알림 타입 정의
- [x] `ROLE_APPROVED` 알림 타입 사용 (기존 존재)
- [x] `ROLE_REQUEST_REJECTED` 알림 타입 정의
- [x] 권한요청 생성 시 REVIEWER에게 알림
- [x] 승인/반려 시 요청자에게 알림
- [x] 알림 내용에 도메인, 요청 역할 정보 포함

## 리뷰 포인트
1. **알림 생성 타이밍**: 트랜잭션 내에서 알림 생성이 적절한지 검토
2. **REVIEWER 조회 방식**: `findAllByRoleCode("REVIEWER")`로 전체 조회 - 대량 사용자 시 성능 이슈 가능성
3. **알림 메시지 포맷**: 현재 하드코딩된 메시지 형식의 적절성

## TODO/질문
- 푸시 알림, 이메일 알림은 Out of Scope (이슈 명세에 따름)
- 향후 이벤트 기반 구조(ApplicationEvent) 전환 검토 필요 시 별도 이슈로 진행 예정