### PR TITLE
feat(auth): 도메인-역할 멤버십 조회 API (#81)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,28 @@
 # Claude Code Learnings
 
+## 2026-02-01: 도메인-역할 멤버십 조회 API (#81)
+
+### 원인
+- 로그인 사용자의 도메인별 역할을 일관되게 조회하는 전용 API가 없었음
+- /me 응답에 domainRoles는 포함되지만, GUEST 사용자의 권한요청 상태 정보가 없었음
+
+### 해결
+- `GET /api/v1/auth/me/domains` 엔드포인트 추가
+- GUEST: 빈 domainRoles + roleRequestStatus(PENDING/NONE) 반환
+- 일반 사용자: domainRoles 목록 반환, roleRequestStatus는 null
+
+### 재발방지
+- 기존 buildDomainRoleDtos() 헬퍼를 재사용하여 중복 방지
+- GUEST 분기 처리 시 existsByUserAndStatus로 간결하게 확인
+
+### 검증방법
+- `./gradlew test --tests "AuthServiceTest"` (3개 테스트: 일반사용자/게스트PENDING/게스트NONE)
+
+### 관련커밋
+- feature/81-domain-membership-api 브랜치
+
+---
+
 ## 2026-02-01: 기안 생성 화면 뒤로가기 시 403 발생 (#91)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.smartchain.platform.dto.auth.email.*;
 import com.smartchain.platform.dto.auth.login.LoginRequest;
 import com.smartchain.platform.dto.auth.login.LoginResponse;
 import com.smartchain.platform.dto.auth.logout.LogoutRequest;
+import com.smartchain.platform.dto.auth.myinfo.MyDomainResponse;
 import com.smartchain.platform.dto.auth.myinfo.MyInfoResponse;
 import com.smartchain.platform.dto.auth.register.RegisterRequest;
 import com.smartchain.platform.dto.auth.register.RegisterResponse;
@@ -94,6 +95,14 @@ public class AuthController {
     public ResponseEntity<BaseResponse<MyInfoResponse>> getMyInfo(HttpServletRequest request) {
         Long userId = extractUserIdFromRequest(request);
         MyInfoResponse response = authService.getMyInfo(userId);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @Operation(summary = "내 도메인 역할 조회", description = "현재 로그인된 사용자의 도메인별 역할 목록을 조회합니다. 게스트인 경우 권한요청 상태를 포함합니다.")
+    @GetMapping("/me/domains")
+    public ResponseEntity<BaseResponse<MyDomainResponse>> getMyDomains(HttpServletRequest request) {
+        Long userId = extractUserIdFromRequest(request);
+        MyDomainResponse response = authService.getMyDomains(userId);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 

--- a/src/main/java/com/smartchain/platform/domain/auth/service/AuthService.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.smartchain.platform.domain.auth.service;
 
 import com.smartchain.platform.domain.auth.entity.EmailVerificationCode;
 import com.smartchain.platform.domain.auth.repository.EmailVerificationCodeRepository;
+import com.smartchain.platform.domain.role.repository.RoleRequestRepository;
 import com.smartchain.platform.domain.user.entity.Role;
 import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.domain.user.entity.UserDomainRole;
@@ -16,12 +17,14 @@ import com.smartchain.platform.dto.auth.email.*;
 import com.smartchain.platform.dto.auth.login.LoginRequest;
 import com.smartchain.platform.dto.auth.login.LoginResponse;
 import com.smartchain.platform.dto.auth.logout.LogoutRequest;
+import com.smartchain.platform.dto.auth.myinfo.MyDomainResponse;
 import com.smartchain.platform.dto.auth.myinfo.MyInfoResponse;
 import com.smartchain.platform.dto.auth.register.RegisterRequest;
 import com.smartchain.platform.dto.auth.register.RegisterResponse;
 import com.smartchain.platform.dto.auth.token.TokenRefreshRequest;
 import com.smartchain.platform.dto.auth.token.TokenRefreshResponse;
 import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.enums.RequestStatus;
 import com.smartchain.platform.global.enums.UserStatus;
 import com.smartchain.platform.global.error.ErrorCode;
 import com.smartchain.platform.global.security.JwtTokenProvider;
@@ -47,6 +50,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final UserDomainRoleRepository userDomainRoleRepository;
+    private final RoleRequestRepository roleRequestRepository;
     private final EmailVerificationCodeRepository verificationCodeRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
@@ -303,6 +307,26 @@ public class AuthService {
         builder.domainRoles(buildDomainRoleDtos(user.getUserId()));
 
         return builder.build();
+    }
+
+    public MyDomainResponse getMyDomains(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String globalRole = user.getRole() != null ? user.getRole().getCode() : GUEST_ROLE_CODE;
+        List<DomainRoleDto> domainRoles = buildDomainRoleDtos(userId);
+
+        String roleRequestStatus = null;
+        if (GUEST_ROLE_CODE.equals(globalRole)) {
+            boolean hasPending = roleRequestRepository.existsByUserAndStatus(user, RequestStatus.PENDING);
+            roleRequestStatus = hasPending ? "PENDING" : "NONE";
+        }
+
+        return MyDomainResponse.builder()
+                .globalRole(globalRole)
+                .domainRoles(domainRoles)
+                .roleRequestStatus(roleRequestStatus)
+                .build();
     }
 
     private String generateVerificationCode() {

--- a/src/main/java/com/smartchain/platform/dto/auth/myinfo/MyDomainResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/auth/myinfo/MyDomainResponse.java
@@ -1,0 +1,19 @@
+package com.smartchain.platform.dto.auth.myinfo;
+
+import com.smartchain.platform.dto.auth.common.DomainRoleDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyDomainResponse {
+    private String globalRole;
+    private List<DomainRoleDto> domainRoles;
+    private String roleRequestStatus;
+}

--- a/src/test/java/com/smartchain/platform/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/auth/service/AuthServiceTest.java
@@ -2,20 +2,25 @@ package com.smartchain.platform.domain.auth.service;
 
 import com.smartchain.platform.domain.auth.entity.EmailVerificationCode;
 import com.smartchain.platform.domain.auth.repository.EmailVerificationCodeRepository;
+import com.smartchain.platform.domain.role.repository.RoleRequestRepository;
 import com.smartchain.platform.domain.user.entity.Role;
 import com.smartchain.platform.domain.user.entity.User;
+import com.smartchain.platform.domain.user.entity.UserDomainRole;
+import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.repository.RoleRepository;
 import com.smartchain.platform.domain.user.repository.UserDomainRoleRepository;
 import com.smartchain.platform.domain.user.repository.UserRepository;
 import com.smartchain.platform.dto.auth.email.*;
 import com.smartchain.platform.dto.auth.login.LoginRequest;
 import com.smartchain.platform.dto.auth.login.LoginResponse;
+import com.smartchain.platform.dto.auth.myinfo.MyDomainResponse;
 import com.smartchain.platform.dto.auth.myinfo.MyInfoResponse;
 import com.smartchain.platform.dto.auth.register.RegisterRequest;
 import com.smartchain.platform.dto.auth.register.RegisterResponse;
 import com.smartchain.platform.dto.auth.register.TermsAgreementRequest;
 import com.smartchain.platform.dto.auth.token.TokenRefreshRequest;
 import com.smartchain.platform.dto.auth.token.TokenRefreshResponse;
+import com.smartchain.platform.global.enums.RequestStatus;
 import com.smartchain.platform.global.enums.UserStatus;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
@@ -32,6 +37,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,6 +61,9 @@ class AuthServiceTest {
 
     @Mock
     private UserDomainRoleRepository userDomainRoleRepository;
+
+    @Mock
+    private RoleRequestRepository roleRequestRepository;
 
     @Mock
     private EmailVerificationCodeRepository verificationCodeRepository;
@@ -588,6 +597,110 @@ class AuthServiceTest {
                         CustomException ce = (CustomException) ex;
                         assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
                     });
+        }
+    }
+
+    @Nested
+    @DisplayName("내 도메인 역할 조회 테스트")
+    class GetMyDomainsTest {
+
+        @Test
+        @DisplayName("일반 사용자: 도메인 역할 목록 반환")
+        void getMyDomains_WithDomainRoles_Success() {
+            // given
+            Role drafterRole = new Role("기안자", "DRAFTER");
+            User user = User.builder()
+                    .name("홍길동")
+                    .email("test@test.com")
+                    .userPassword("encodedPassword")
+                    .role(drafterRole)
+                    .build();
+
+            Domain esgDomain = mock(Domain.class);
+            lenient().when(esgDomain.getCode()).thenReturn("ESG");
+            lenient().when(esgDomain.getName()).thenReturn("ESG 실사");
+
+            Role mockDrafterRole = mock(Role.class);
+            lenient().when(mockDrafterRole.getCode()).thenReturn("DRAFTER");
+            lenient().when(mockDrafterRole.getName()).thenReturn("기안자");
+
+            Domain safetyDomain = mock(Domain.class);
+            lenient().when(safetyDomain.getCode()).thenReturn("SAFETY");
+            lenient().when(safetyDomain.getName()).thenReturn("안전보건");
+
+            UserDomainRole udr1 = mock(UserDomainRole.class);
+            lenient().when(udr1.getDomain()).thenReturn(esgDomain);
+            lenient().when(udr1.getRole()).thenReturn(mockDrafterRole);
+
+            UserDomainRole udr2 = mock(UserDomainRole.class);
+            lenient().when(udr2.getDomain()).thenReturn(safetyDomain);
+            lenient().when(udr2.getRole()).thenReturn(mockDrafterRole);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(userDomainRoleRepository.findByUserIdWithDomainAndRole(any()))
+                    .willReturn(List.of(udr1, udr2));
+
+            // when
+            MyDomainResponse response = authService.getMyDomains(1L);
+
+            // then
+            assertThat(response.getGlobalRole()).isEqualTo("DRAFTER");
+            assertThat(response.getDomainRoles()).hasSize(2);
+            assertThat(response.getDomainRoles().get(0).getDomainCode()).isEqualTo("ESG");
+            assertThat(response.getDomainRoles().get(1).getDomainCode()).isEqualTo("SAFETY");
+            assertThat(response.getRoleRequestStatus()).isNull();
+        }
+
+        @Test
+        @DisplayName("게스트 사용자: 빈 목록 + 권한요청 상태 PENDING")
+        void getMyDomains_Guest_PendingRequest() {
+            // given
+            User user = User.builder()
+                    .name("게스트")
+                    .email("guest@test.com")
+                    .userPassword("encodedPassword")
+                    .role(guestRole)
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(userDomainRoleRepository.findByUserIdWithDomainAndRole(any()))
+                    .willReturn(Collections.emptyList());
+            given(roleRequestRepository.existsByUserAndStatus(user, RequestStatus.PENDING))
+                    .willReturn(true);
+
+            // when
+            MyDomainResponse response = authService.getMyDomains(1L);
+
+            // then
+            assertThat(response.getGlobalRole()).isEqualTo("GUEST");
+            assertThat(response.getDomainRoles()).isEmpty();
+            assertThat(response.getRoleRequestStatus()).isEqualTo("PENDING");
+        }
+
+        @Test
+        @DisplayName("게스트 사용자: 빈 목록 + 권한요청 없음 NONE")
+        void getMyDomains_Guest_NoRequest() {
+            // given
+            User user = User.builder()
+                    .name("게스트")
+                    .email("guest@test.com")
+                    .userPassword("encodedPassword")
+                    .role(guestRole)
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(userDomainRoleRepository.findByUserIdWithDomainAndRole(any()))
+                    .willReturn(Collections.emptyList());
+            given(roleRequestRepository.existsByUserAndStatus(user, RequestStatus.PENDING))
+                    .willReturn(false);
+
+            // when
+            MyDomainResponse response = authService.getMyDomains(1L);
+
+            // then
+            assertThat(response.getGlobalRole()).isEqualTo("GUEST");
+            assertThat(response.getDomainRoles()).isEmpty();
+            assertThat(response.getRoleRequestStatus()).isEqualTo("NONE");
         }
     }
 }


### PR DESCRIPTION
## 변경요약
- `GET /api/v1/auth/me/domains` 엔드포인트 추가
- 일반 사용자: 소속 도메인 목록 + 각 도메인별 역할 반환
- GUEST 사용자: 빈 도메인 목록 + 권한요청 상태(PENDING/NONE) 반환
- `MyDomainResponse` DTO 신규 생성
- `AuthService.getMyDomains()` 메서드 추가

## 관련이슈
- Closes #81

## 테스트방법
```bash
./gradlew test --tests "AuthServiceTest"
./gradlew test && ./gradlew build
```

## 명세준수
- [x] UserDomainRole 기반 조회 로직
- [x] GUEST 사용자 분기 처리
- [x] Swagger @Operation 문서화

## 리뷰포인트
- 엔드포인트: `/api/v1/auth/me/domains`
- roleRequestStatus는 GUEST일 때만 반환

## TODO
- [ ] SecurityConfig에서 해당 경로 인증 필터 확인