### PR TITLE
feat(security): GUEST RBAC 접근 차단 구현 (#84)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,30 @@
 # Claude Code Learnings
 
+## 2026-02-01: GUEST RBAC 차단 (#84)
+
+### 원인
+- SecurityConfig에서 `.anyRequest().permitAll()` 설정으로 모든 요청 허용
+- JWT 토큰이 있어도 Spring Security 컨텍스트에 인증 정보가 설정되지 않음
+- GUEST 사용자가 보호된 리소스(diagnostics, approvals 등)에 접근 가능
+
+### 해결
+- `JwtAuthenticationFilter` 신규 생성: JWT에서 role 추출 → `ROLE_` prefix로 SimpleGrantedAuthority 설정
+- SecurityConfig 전면 개편: 보호 대상 경로에 `hasAnyRole("DRAFTER", "APPROVER", "REVIEWER")` 적용
+- 공개 경로(auth, roles, swagger, health)는 permitAll 유지
+- 401/403 시 표준 ErrorResponse JSON 반환 (AuthenticationEntryPoint, AccessDeniedHandler)
+
+### 재발방지
+- 새 컨트롤러 추가 시 SecurityConfig의 보호 경로 목록에 반드시 추가
+- DomainAuthorizationTest 통합 테스트로 역할별 접근 제어 검증
+
+### 검증방법
+- `./gradlew test --tests "DomainAuthorizationTest"` (GUEST 차단 + 역할 불일치 테스트 통과)
+
+### 관련커밋
+- feature/84-guest-rbac-blocking 브랜치
+
+---
+
 ## 2026-02-01: 도메인-역할 멤버십 조회 API (#81)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/global/config/SecurityConfig.java
+++ b/src/main/java/com/smartchain/platform/global/config/SecurityConfig.java
@@ -1,7 +1,14 @@
 package com.smartchain.platform.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartchain.platform.global.error.ErrorCode;
+import com.smartchain.platform.global.response.ErrorResponse;
+import com.smartchain.platform.global.security.JwtAuthenticationFilter;
+import com.smartchain.platform.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -9,10 +16,15 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -22,15 +34,47 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        // Swagger 허용
+                        // 공개 경로
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        // Health check 허용
                         .requestMatchers("/health").permitAll()
-                        // Auth API 허용
                         .requestMatchers("/api/v1/auth/**").permitAll()
-                        // 개발 중엔 전부 허용 (나중에 수정)
-                        .anyRequest().permitAll()
-                );
+                        // GUEST 허용 경로 (권한 요청)
+                        .requestMatchers("/api/v1/roles/**").permitAll()
+                        // 보호 대상: GUEST 이외 역할만 접근 가능
+                        .requestMatchers(
+                                "/api/v1/diagnostics/**",
+                                "/api/v1/approvals/**",
+                                "/api/v1/reviews/**",
+                                "/api/v1/notifications/**",
+                                "/api/v1/files/**",
+                                "/api/v1/ai/**",
+                                "/api/v1/campaigns/**",
+                                "/api/v1/domains/**",
+                                "/api/v1/management/**",
+                                "/api/v1/jobs/**"
+                        ).hasAnyRole("DRAFTER", "APPROVER", "REVIEWER")
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(401);
+                            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            response.setCharacterEncoding("UTF-8");
+                            response.getWriter().write(
+                                    objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.INVALID_TOKEN))
+                            );
+                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.setStatus(403);
+                            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            response.setCharacterEncoding("UTF-8");
+                            response.getWriter().write(
+                                    objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.ACCESS_DENIED))
+                            );
+                        })
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/smartchain/platform/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/smartchain/platform/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.smartchain.platform.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Long userId = jwtTokenProvider.getUserIdFromToken(token);
+            String role = jwtTokenProvider.getRoleFromToken(token);
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId, null,
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                    );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## 변경요약
- `JwtAuthenticationFilter` 신규: JWT 토큰 → Spring Security 인증 컨텍스트 설정
- `SecurityConfig` 전면 개편: `.anyRequest().permitAll()` 제거, 역할 기반 접근 제어 적용
- 보호 대상: diagnostics, approvals, reviews, notifications, files, ai, campaigns, domains, management, jobs
- 공개 경로: auth, roles, swagger, health
- 401/403 시 표준 `ErrorResponse` JSON 반환

## 관련이슈
- Closes #84

## 테스트방법
```bash
./gradlew test --tests "DomainAuthorizationTest"
./gradlew test && ./gradlew build
```
- GUEST → `/api/v1/diagnostics`: 403 확인
- GUEST → `/api/v1/approvals`: 403 확인
- GUEST → `/api/v1/reviews/dashboard`: 403 확인
- DRAFTER → `/api/v1/diagnostics`: 정상 접근 (기존 통합 테스트)

## 명세준수
- [x] GUEST가 보호된 리소스 접근 시 403 + 표준 에러코드 반환
- [x] 프론트 우회 URL 직접 접근 시에도 서버에서 차단
- [x] ErrorCode `ACCESS_DENIED` (기존 정의) 사용

## 리뷰포인트
- `/api/v1/roles/**`는 GUEST도 접근 가능 (권한 요청 기능)
- `anyRequest().authenticated()`: 목록에 없는 새 경로는 인증 필수 (GUEST 포함)
- JWT 필터는 SecurityConfig에서 `UsernamePasswordAuthenticationFilter` 앞에 등록

## TODO
- [ ] 도메인별 세분화된 RBAC (DRAFTER→approvals 차단 등)은 별도 이슈로 관리