### PR TITLE
feat(diagnostic): 도메인 상세 조회 API 권한 검증 (#87)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,38 @@
 # Claude Code Learnings
 
+## 2026-02-01: 도메인 상세 조회 API 권한 검증 테스트 보강 (#87)
+
+### 원인
+- 기안 상세 조회 API의 권한 검증 구현은 완료되어 있었으나 테스트 커버리지 부족
+- APPROVER(같은/다른 회사), REVIEWER, 도메인 권한 없는 사용자의 403/200 분기 테스트 미존재
+- DRAFTER 성공/실패와 404만 테스트되고 나머지 역할 시나리오 누락
+
+### 해결
+- APPROVER 같은 회사 상세 조회 성공 테스트 추가
+- APPROVER 다른 회사 상세 조회 403 테스트 추가
+- REVIEWER 도메인 내 상세 조회 성공 테스트 추가
+- 도메인 권한 없는 사용자 403 테스트 추가
+
+### 재발 방지
+- 상세 조회 API 권한 검증 시 모든 역할(DRAFTER/APPROVER/REVIEWER) + 무권한 시나리오 테스트 필수
+- 역할별 접근 범위: DRAFTER=본인, APPROVER=같은 회사, REVIEWER=도메인 전체
+
+### 검증 방법
+```bash
+./gradlew test --tests "DiagnosticServiceTest"
+```
+
+### 관련 커밋
+- (이 PR에 포함)
+
+### 생성/수정 파일
+```
+src/test/java/.../diagnostic/service/DiagnosticServiceTest.java (테스트 4건 추가)
+docs/claude/LEARNINGS.md (엔트리 추가)
+```
+
+---
+
 ## 2026-02-01: 레거시 DRAFTER 리스트 조회 범위 오류 (#86)
 
 ### 원인

--- a/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
@@ -290,6 +290,153 @@ class DiagnosticServiceTest {
                         assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_RESOURCE);
                     });
         }
+
+        @Test
+        @DisplayName("APPROVER가 같은 회사 기안 상세 조회 성공")
+        void getDiagnosticDetail_AsApprover_SameCompany_Success() {
+            // given
+            Domain esgDomain = mock(Domain.class);
+            when(esgDomain.getDomainId()).thenReturn(1L);
+            when(esgDomain.getCode()).thenReturn("ESG");
+            when(esgDomain.getName()).thenReturn("ESG 실사");
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            when(diagnostic.getDiagnosticCode()).thenReturn("DG-2026-00001");
+            when(diagnostic.getCampaign()).thenReturn(testCampaign);
+            when(diagnostic.getCompany()).thenReturn(testCompany);
+            when(diagnostic.getDomain()).thenReturn(esgDomain);
+            when(diagnostic.getDrafterId()).thenReturn(1L); // 다른 사용자가 작성
+            when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.SUBMITTED);
+            when(diagnostic.getPeriodStartDate()).thenReturn(LocalDate.of(2026, 1, 1));
+            when(diagnostic.getPeriodEndDate()).thenReturn(LocalDate.of(2026, 12, 31));
+            when(diagnostic.getDeadline()).thenReturn(LocalDate.of(2026, 3, 31));
+            when(diagnostic.getQualitativeProgress()).thenReturn(100);
+            when(diagnostic.getQuantitativeProgress()).thenReturn(100);
+            when(diagnostic.getOverallProgress()).thenReturn(100);
+            when(diagnostic.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            when(approverUser.hasAnyRoleInDomain("ESG", "DRAFTER", "APPROVER", "REVIEWER")).thenReturn(true);
+            when(approverUser.hasRoleInDomain("ESG", "DRAFTER")).thenReturn(false);
+            when(approverUser.hasRoleInDomain("ESG", "APPROVER")).thenReturn(true);
+
+            given(userRepository.findById(2L)).willReturn(Optional.of(approverUser));
+            given(diagnosticRepository.findById(1L)).willReturn(Optional.of(diagnostic));
+
+            // when
+            DiagnosticDetailResponse response = diagnosticService.getDiagnosticDetail(2L, 1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getDiagnosticId()).isEqualTo(1L);
+            assertThat(response.getStatus()).isEqualTo("SUBMITTED");
+        }
+
+        @Test
+        @DisplayName("APPROVER가 다른 회사 기안 조회 시 403")
+        void getDiagnosticDetail_AsApprover_DifferentCompany_ThrowsException() {
+            // given
+            Domain esgDomain = mock(Domain.class);
+            when(esgDomain.getCode()).thenReturn("ESG");
+
+            Company otherCompany = mock(Company.class);
+            when(otherCompany.getCompanyId()).thenReturn(999L);
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDomain()).thenReturn(esgDomain);
+            when(diagnostic.getCompany()).thenReturn(otherCompany);
+
+            when(approverUser.hasAnyRoleInDomain("ESG", "DRAFTER", "APPROVER", "REVIEWER")).thenReturn(true);
+            when(approverUser.hasRoleInDomain("ESG", "DRAFTER")).thenReturn(false);
+            when(approverUser.hasRoleInDomain("ESG", "APPROVER")).thenReturn(true);
+
+            given(userRepository.findById(2L)).willReturn(Optional.of(approverUser));
+            given(diagnosticRepository.findById(1L)).willReturn(Optional.of(diagnostic));
+
+            // when & then
+            assertThatThrownBy(() -> diagnosticService.getDiagnosticDetail(2L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_RESOURCE);
+                    });
+        }
+
+        @Test
+        @DisplayName("REVIEWER가 도메인 내 기안 상세 조회 성공")
+        void getDiagnosticDetail_AsReviewer_Success() {
+            // given
+            Domain esgDomain = mock(Domain.class);
+            when(esgDomain.getDomainId()).thenReturn(1L);
+            when(esgDomain.getCode()).thenReturn("ESG");
+            when(esgDomain.getName()).thenReturn("ESG 실사");
+
+            Company otherCompany = mock(Company.class);
+            when(otherCompany.getCompanyId()).thenReturn(999L);
+            when(otherCompany.getName()).thenReturn("다른회사");
+
+            User reviewerUser = mock(User.class);
+            lenient().when(reviewerUser.getUserId()).thenReturn(3L);
+            lenient().when(reviewerUser.getName()).thenReturn("수신자");
+            lenient().when(reviewerUser.getDomainRoles()).thenReturn(new ArrayList<>());
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            when(diagnostic.getDiagnosticCode()).thenReturn("DG-2026-00001");
+            when(diagnostic.getCampaign()).thenReturn(testCampaign);
+            when(diagnostic.getCompany()).thenReturn(otherCompany);
+            when(diagnostic.getDomain()).thenReturn(esgDomain);
+            when(diagnostic.getDrafterId()).thenReturn(1L);
+            when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.REVIEWING);
+            when(diagnostic.getPeriodStartDate()).thenReturn(LocalDate.of(2026, 1, 1));
+            when(diagnostic.getPeriodEndDate()).thenReturn(LocalDate.of(2026, 12, 31));
+            when(diagnostic.getDeadline()).thenReturn(LocalDate.of(2026, 3, 31));
+            when(diagnostic.getQualitativeProgress()).thenReturn(100);
+            when(diagnostic.getQuantitativeProgress()).thenReturn(100);
+            when(diagnostic.getOverallProgress()).thenReturn(100);
+            when(diagnostic.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            when(reviewerUser.hasAnyRoleInDomain("ESG", "DRAFTER", "APPROVER", "REVIEWER")).thenReturn(true);
+            when(reviewerUser.hasRoleInDomain("ESG", "DRAFTER")).thenReturn(false);
+            when(reviewerUser.hasRoleInDomain("ESG", "APPROVER")).thenReturn(false);
+
+            given(userRepository.findById(3L)).willReturn(Optional.of(reviewerUser));
+            given(diagnosticRepository.findById(1L)).willReturn(Optional.of(diagnostic));
+
+            // when
+            DiagnosticDetailResponse response = diagnosticService.getDiagnosticDetail(3L, 1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getDiagnosticId()).isEqualTo(1L);
+            assertThat(response.getStatus()).isEqualTo("REVIEWING");
+        }
+
+        @Test
+        @DisplayName("도메인 권한 없는 사용자가 상세 조회 시 403")
+        void getDiagnosticDetail_NoDomainRole_ThrowsException() {
+            // given
+            Domain esgDomain = mock(Domain.class);
+            when(esgDomain.getCode()).thenReturn("ESG");
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDomain()).thenReturn(esgDomain);
+
+            User noRoleUser = mock(User.class);
+            when(noRoleUser.getUserId()).thenReturn(99L);
+            when(noRoleUser.hasAnyRoleInDomain("ESG", "DRAFTER", "APPROVER", "REVIEWER")).thenReturn(false);
+
+            given(userRepository.findById(99L)).willReturn(Optional.of(noRoleUser));
+            given(diagnosticRepository.findById(1L)).willReturn(Optional.of(diagnostic));
+
+            // when & then
+            assertThatThrownBy(() -> diagnosticService.getDiagnosticDetail(99L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_ACTION);
+                    });
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 변경 요약
- 기안 상세 조회 API(`GET /api/v1/diagnostics/{id}`)의 역할별 권한 검증 테스트 4건 추가
- 기존 구현(404/403 분기)은 이미 완료되어 있었으며, 누락된 테스트 커버리지를 보강

## 관련 이슈
- Closes #87

## 테스트 방법
```bash
./gradlew test --tests "DiagnosticServiceTest"
```

### 추가된 테스트 시나리오
| 시나리오 | 기대 결과 |
|---------|----------|
| APPROVER가 같은 회사 기안 조회 | 200 + 상세 데이터 |
| APPROVER가 다른 회사 기안 조회 | 403 (PERMISSION_DENIED_RESOURCE) |
| REVIEWER가 도메인 내 기안 조회 | 200 + 상세 데이터 |
| 도메인 권한 없는 사용자 조회 | 403 (PERMISSION_DENIED_ACTION) |

### 수동 검증 (계정 정보)
- 기안자: `drafter1@techpartner.co.kr` / `Test1234!`
- 결재자: `approver@techpartner.co.kr` / `Test1234!`
- 수신자: `reviewer@smartchain.co.kr` / `Test1234!`

## 명세 준수 체크
- [x] 상세 데이터 정상 반환 (기존 구현)
- [x] 권한 검증 적용 - 본인 건 또는 권한 범위 내 (기존 구현)
- [x] 존재하지 않는 리소스: 404 (기존 테스트)
- [x] 권한 없는 리소스: 403 (신규 테스트 추가)

## 리뷰 포인트
- 테스트만 추가한 PR이므로 프로덕션 코드 변경 없음
- `validateDomainAccess()` → `validateCompanyAndOwnership()` 체인의 역할별 분기가 정확히 검증되는지 확인

## TODO/질문
- 없음 (기존 구현이 AC를 이미 충족)

🤖 Generated with [Claude Code](https://claude.com/claude-code)