### PR TITLE
feat(diagnostic): 도메인별 워크플로우 분기 구현 (#78)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,40 @@
 # Claude Code Learnings
 
+## 2026-02-01: 도메인별 워크플로우 분기 구현 (#78)
+
+### 원인
+- submitDiagnostic()에서 모든 도메인(ESG, SAFETY, COMPLIANCE)에 대해 동일하게 Approval 레코드 생성
+- 기획상 SAFETY/COMPLIANCE는 결재 단계 없이 수신자(REVIEWER)에게 직행해야 함
+- SAFETY/COMPLIANCE 진단 제출 시 결재 단계에 막혀 심사로 진행 불가
+
+### 해결
+- submitDiagnostic()에 도메인별 분기 추가: ESG → Approval 생성, SAFETY/COMPLIANCE → approve() + Review 생성
+- SAFETY/COMPLIANCE는 자동 승인(AUTO_APPROVED) 히스토리 기록 후 Review 레코드 생성
+- DiagnosticSubmitResponse에 reviewId 필드 추가 (SAFETY/COMPLIANCE 응답용)
+- 도메인이 null인 레거시 데이터는 ESG로 기본 처리
+
+### 재발 방지
+- 도메인별 워크플로우 차이: ESG=3단계(기안→결재→심사), SAFETY/COMPLIANCE=2단계(기안→심사)
+- 새 도메인 추가 시 submitDiagnostic()의 분기 로직 확인 필수
+
+### 검증 방법
+```bash
+./gradlew test --tests "DiagnosticServiceTest"
+```
+
+### 관련 커밋
+- (이 PR에 포함)
+
+### 생성/수정 파일
+```
+src/main/java/.../diagnostic/service/DiagnosticService.java (도메인별 분기, ReviewRepository 주입)
+src/main/java/.../dto/diagnostic/submit/DiagnosticSubmitResponse.java (reviewId 필드 추가)
+src/test/java/.../diagnostic/service/DiagnosticServiceTest.java (SAFETY/COMPLIANCE/ESG 제출 테스트 3건 추가)
+docs/claude/LEARNINGS.md (엔트리 추가)
+```
+
+---
+
 ## 2026-02-01: 도메인 상세 조회 API 권한 검증 테스트 보강 (#87)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -5,6 +5,8 @@ import com.smartchain.platform.domain.approval.repository.ApprovalRepository;
 import com.smartchain.platform.domain.diagnostic.entity.Campaign;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.diagnostic.entity.DiagnosticHistory;
+import com.smartchain.platform.domain.review.entity.Review;
+import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.diagnostic.repository.CampaignRepository;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticHistoryRepository;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
@@ -42,6 +44,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,6 +63,7 @@ public class DiagnosticService {
     private final CampaignRepository campaignRepository;
     private final UserRepository userRepository;
     private final ApprovalRepository approvalRepository;
+    private final ReviewRepository reviewRepository;
     private final DomainRepository domainRepository;
 
     private static final List<String> ALLOWED_ROLES = Arrays.asList("DRAFTER", "APPROVER");
@@ -385,26 +389,64 @@ public class DiagnosticService {
                 .build();
         diagnosticHistoryRepository.save(history);
 
-        // Approval 레코드 자동 생성
-        Approval approval = Approval.builder()
-                .diagnostic(diagnostic)
-                .requester(currentUser)
-                .requestComment(request.getSubmitComment())
-                .deadline(diagnostic.getDeadline())
-                .build();
-        Approval savedApproval = approvalRepository.save(approval);
+        // 도메인별 워크플로우 분기
+        String domainCode = domain != null ? domain.getCode() : "ESG";
 
-        log.info("Diagnostic submitted: diagnosticId={}, submittedBy={}, approvalId={}",
-                diagnosticId, userId, savedApproval.getApprovalId());
+        if ("ESG".equals(domainCode)) {
+            // ESG: 결재자에게 결재 요청 (기안자 → 결재자 → 수신자)
+            Approval approval = Approval.builder()
+                    .diagnostic(diagnostic)
+                    .requester(currentUser)
+                    .requestComment(request.getSubmitComment())
+                    .deadline(diagnostic.getDeadline())
+                    .build();
+            Approval savedApproval = approvalRepository.save(approval);
 
-        return DiagnosticSubmitResponse.builder()
-                .diagnosticId(diagnostic.getDiagnosticId())
-                .previousStatus(previousStatus)
-                .newStatus(DiagnosticStatus.SUBMITTED.name())
-                .submittedAt(diagnostic.getSubmittedAt())
-                .approvalId(savedApproval.getApprovalId())
-                .message("기안이 제출되었습니다")
-                .build();
+            log.info("Diagnostic submitted (ESG → Approval): diagnosticId={}, submittedBy={}, approvalId={}",
+                    diagnosticId, userId, savedApproval.getApprovalId());
+
+            return DiagnosticSubmitResponse.builder()
+                    .diagnosticId(diagnostic.getDiagnosticId())
+                    .previousStatus(previousStatus)
+                    .newStatus(DiagnosticStatus.SUBMITTED.name())
+                    .submittedAt(diagnostic.getSubmittedAt())
+                    .approvalId(savedApproval.getApprovalId())
+                    .message("기안이 제출되었습니다")
+                    .build();
+        } else {
+            // SAFETY, COMPLIANCE: 결재 스킵, 수신자에게 직행 (기안자 → 수신자)
+            diagnostic.approve();
+
+            DiagnosticHistory approveHistory = DiagnosticHistory.builder()
+                    .diagnostic(diagnostic)
+                    .actor(currentUser)
+                    .action("AUTO_APPROVED")
+                    .previousStatus(DiagnosticStatus.SUBMITTED.name())
+                    .newStatus(DiagnosticStatus.APPROVED.name())
+                    .comment("결재 스킵 (도메인 정책: " + domainCode + ")")
+                    .build();
+            diagnosticHistoryRepository.save(approveHistory);
+
+            Review review = Review.builder()
+                    .diagnostic(diagnostic)
+                    .company(diagnostic.getCompany())
+                    .domain(domain)
+                    .submittedAt(diagnostic.getSubmittedAt())
+                    .build();
+            Review savedReview = reviewRepository.save(review);
+
+            log.info("Diagnostic submitted ({} → Review, approval skipped): diagnosticId={}, submittedBy={}, reviewId={}",
+                    domainCode, diagnosticId, userId, savedReview.getReviewId());
+
+            return DiagnosticSubmitResponse.builder()
+                    .diagnosticId(diagnostic.getDiagnosticId())
+                    .previousStatus(previousStatus)
+                    .newStatus(DiagnosticStatus.APPROVED.name())
+                    .submittedAt(diagnostic.getSubmittedAt())
+                    .reviewId(savedReview.getReviewId())
+                    .message("기안이 제출되었습니다 (심사 대기)")
+                    .build();
+        }
     }
 
     public AiAnalysisResponse getAiAnalysis(Long userId, Long diagnosticId) {

--- a/src/main/java/com/smartchain/platform/dto/diagnostic/submit/DiagnosticSubmitResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/diagnostic/submit/DiagnosticSubmitResponse.java
@@ -16,6 +16,7 @@ public class DiagnosticSubmitResponse {
     private String previousStatus;
     private String newStatus;            // SUBMITTED
     private LocalDateTime submittedAt;
-    private Long approvalId;             // v3.0: 생성된 결재 ID
+    private Long approvalId;             // v3.0: 생성된 결재 ID (ESG)
+    private Long reviewId;               // v3.1: 생성된 심사 ID (SAFETY/COMPLIANCE)
     private String message;
 }

--- a/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
@@ -8,6 +8,8 @@ import com.smartchain.platform.domain.diagnostic.entity.DiagnosticHistory;
 import com.smartchain.platform.domain.diagnostic.repository.CampaignRepository;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticHistoryRepository;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
+import com.smartchain.platform.domain.review.entity.Review;
+import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.entity.Role;
@@ -71,6 +73,9 @@ class DiagnosticServiceTest {
 
     @Mock
     private ApprovalRepository approvalRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
 
     @Mock
     private DomainRepository domainRepository;
@@ -612,6 +617,140 @@ class DiagnosticServiceTest {
                         CustomException ce = (CustomException) ex;
                         assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.DIAGNOSTIC_INVALID_STATE_TRANSITION);
                     });
+        }
+
+        @Test
+        @DisplayName("SAFETY 도메인 제출 시 결재 스킵 → Review 생성")
+        void submitDiagnostic_Safety_SkipsApproval_CreatesReview() {
+            // given
+            Domain safetyDomain = mock(Domain.class);
+            when(safetyDomain.getCode()).thenReturn("SAFETY");
+
+            DiagnosticSubmitRequest request = DiagnosticSubmitRequest.builder()
+                    .submitComment("안전보건 제출합니다.")
+                    .build();
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            when(diagnostic.getDrafterId()).thenReturn(1L);
+            when(diagnostic.canSubmit()).thenReturn(true);
+            when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.WRITING);
+            when(diagnostic.getSubmittedAt()).thenReturn(LocalDateTime.now());
+            when(diagnostic.getDomain()).thenReturn(safetyDomain);
+            when(diagnostic.getCompany()).thenReturn(testCompany);
+
+            when(drafterUser.hasRoleInDomain("SAFETY", "DRAFTER")).thenReturn(true);
+
+            Review savedReview = mock(Review.class);
+            when(savedReview.getReviewId()).thenReturn(200L);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(1L)).willReturn(Optional.of(diagnostic));
+            given(diagnosticHistoryRepository.save(any(DiagnosticHistory.class))).willReturn(null);
+            given(reviewRepository.save(any(Review.class))).willReturn(savedReview);
+
+            // when
+            DiagnosticSubmitResponse response = diagnosticService.submitDiagnostic(1L, 1L, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getNewStatus()).isEqualTo("APPROVED");
+            assertThat(response.getReviewId()).isEqualTo(200L);
+            assertThat(response.getApprovalId()).isNull();
+
+            verify(diagnostic).submit();
+            verify(diagnostic).approve();
+            verify(reviewRepository).save(any(Review.class));
+            verify(approvalRepository, never()).save(any(Approval.class));
+            // 히스토리 2건: SUBMITTED + AUTO_APPROVED
+            verify(diagnosticHistoryRepository, times(2)).save(any(DiagnosticHistory.class));
+        }
+
+        @Test
+        @DisplayName("COMPLIANCE 도메인 제출 시 결재 스킵 → Review 생성")
+        void submitDiagnostic_Compliance_SkipsApproval_CreatesReview() {
+            // given
+            Domain complianceDomain = mock(Domain.class);
+            when(complianceDomain.getCode()).thenReturn("COMPLIANCE");
+
+            DiagnosticSubmitRequest request = DiagnosticSubmitRequest.builder()
+                    .submitComment("컴플라이언스 제출합니다.")
+                    .build();
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            when(diagnostic.getDrafterId()).thenReturn(1L);
+            when(diagnostic.canSubmit()).thenReturn(true);
+            when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.WRITING);
+            when(diagnostic.getSubmittedAt()).thenReturn(LocalDateTime.now());
+            when(diagnostic.getDomain()).thenReturn(complianceDomain);
+            when(diagnostic.getCompany()).thenReturn(testCompany);
+
+            when(drafterUser.hasRoleInDomain("COMPLIANCE", "DRAFTER")).thenReturn(true);
+
+            Review savedReview = mock(Review.class);
+            when(savedReview.getReviewId()).thenReturn(300L);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(1L)).willReturn(Optional.of(diagnostic));
+            given(diagnosticHistoryRepository.save(any(DiagnosticHistory.class))).willReturn(null);
+            given(reviewRepository.save(any(Review.class))).willReturn(savedReview);
+
+            // when
+            DiagnosticSubmitResponse response = diagnosticService.submitDiagnostic(1L, 1L, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getNewStatus()).isEqualTo("APPROVED");
+            assertThat(response.getReviewId()).isEqualTo(300L);
+            assertThat(response.getApprovalId()).isNull();
+
+            verify(diagnostic).approve();
+            verify(reviewRepository).save(any(Review.class));
+            verify(approvalRepository, never()).save(any(Approval.class));
+        }
+
+        @Test
+        @DisplayName("ESG 도메인 제출 시 Approval 생성 (기존 동작 유지)")
+        void submitDiagnostic_Esg_CreatesApproval() {
+            // given
+            Domain esgDomain = mock(Domain.class);
+            when(esgDomain.getCode()).thenReturn("ESG");
+
+            DiagnosticSubmitRequest request = DiagnosticSubmitRequest.builder()
+                    .submitComment("ESG 제출합니다.")
+                    .build();
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            when(diagnostic.getDrafterId()).thenReturn(1L);
+            when(diagnostic.canSubmit()).thenReturn(true);
+            when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.WRITING);
+            when(diagnostic.getSubmittedAt()).thenReturn(LocalDateTime.now());
+            when(diagnostic.getDeadline()).thenReturn(LocalDate.of(2026, 3, 31));
+            when(diagnostic.getDomain()).thenReturn(esgDomain);
+
+            when(drafterUser.hasRoleInDomain("ESG", "DRAFTER")).thenReturn(true);
+
+            Approval savedApproval = mock(Approval.class);
+            when(savedApproval.getApprovalId()).thenReturn(100L);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(1L)).willReturn(Optional.of(diagnostic));
+            given(diagnosticHistoryRepository.save(any(DiagnosticHistory.class))).willReturn(null);
+            given(approvalRepository.save(any(Approval.class))).willReturn(savedApproval);
+
+            // when
+            DiagnosticSubmitResponse response = diagnosticService.submitDiagnostic(1L, 1L, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getNewStatus()).isEqualTo("SUBMITTED");
+            assertThat(response.getApprovalId()).isEqualTo(100L);
+            assertThat(response.getReviewId()).isNull();
+
+            verify(approvalRepository).save(any(Approval.class));
+            verify(reviewRepository, never()).save(any(Review.class));
         }
 
         @Test


### PR DESCRIPTION
## 변경 요약
- `submitDiagnostic()`에 도메인별 워크플로우 분기 추가
  - **ESG**: 기안자 → 결재자 → 수신자 (Approval 생성, 기존 동작 유지)
  - **SAFETY/COMPLIANCE**: 기안자 → 수신자 (결재 스킵, 자동승인 후 Review 직접 생성)
- `DiagnosticSubmitResponse`에 `reviewId` 필드 추가
- 도메인이 null인 레거시 데이터는 ESG로 기본 처리

## 관련 이슈
- Closes #78

## 테스트 방법
```bash
./gradlew test --tests "DiagnosticServiceTest"
```

### 추가된 테스트
| 시나리오 | 기대 결과 |
|---------|----------|
| SAFETY 도메인 제출 | Approval 미생성, Review 생성, 상태 APPROVED |
| COMPLIANCE 도메인 제출 | Approval 미생성, Review 생성, 상태 APPROVED |
| ESG 도메인 제출 (명시적) | Approval 생성, Review 미생성, 상태 SUBMITTED |

### 수동 검증
- 기안자: `drafter1@techpartner.co.kr` / `Test1234!`
- 결재자: `approver@techpartner.co.kr` / `Test1234!`
- 수신자: `reviewer@smartchain.co.kr` / `Test1234!`

## 명세 준수 체크
- [x] ESG: 기안자 → 결재자 → 수신자 워크플로우
- [x] SAFETY: 기안자 → 수신자 (결재 스킵)
- [x] COMPLIANCE: 기안자 → 수신자 (결재 스킵)
- [x] 자동승인 히스토리 기록 (AUTO_APPROVED)
- [x] 레거시 데이터 하위 호환

## 리뷰 포인트
- SAFETY/COMPLIANCE 제출 시 `diagnostic.approve()`로 상태를 APPROVED로 전환 후 Review 생성 — 이 상태 전이가 기획 의도에 맞는지 확인
- AUTO_APPROVED 히스토리에 도메인 코드 기록하여 추적 가능하게 함
- 프론트엔드에서 응답의 `approvalId` vs `reviewId` 존재 여부로 분기 필요

## TODO/질문
- FE에서 제출 후 리다이렉트 경로 분기 필요 (ESG→결재대기, SAFETY/COMPLIANCE→심사대기)
- 알림(Notification) 발송 분기는 별도 이슈로 처리 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)