### PR TITLE
fix(auth): 특수문자 포함 비밀번호 로그인 500 에러 수정

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,8 @@
       "Bash(gh pr merge:*)",
       "Bash(git fetch:*)",
       "Bash(git merge:*)",
-      "Bash(gh issue view:*)"
+      "Bash(gh issue view:*)",
+      "Bash(find:*)"
     ]
   }
 }

--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,37 @@
 # Claude Code Learnings
 
+## 2026-02-02: 특수문자(!) 포함 비밀번호 로그인 500 에러 (#104)
+
+### 원인
+- 클라이언트가 `!` 등 특수문자를 `\!`로 이스케이프하여 JSON 전송
+- Jackson 기본 설정에서 비표준 이스케이프 시퀀스(`\!`)를 파싱하지 못함
+- `JsonMappingException: Unrecognized character escape '!'` 발생하여 500 반환
+
+### 해결
+- `JacksonConfig` 설정 클래스 추가
+- `Jackson2ObjectMapperBuilderCustomizer`로 `ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER` 활성화
+- Spring Boot 기본 ObjectMapper 설정 유지하면서 기능만 추가
+
+### 재발방지
+- 외부 클라이언트 입력을 받는 JSON 파서는 관대한(lenient) 설정 고려
+- 특수문자 포함 비밀번호 테스트 케이스 필수
+
+### 검증방법
+```bash
+./gradlew test --tests "JacksonConfigTest"
+```
+
+### 관련커밋
+- fix/104-login-special-char-500 브랜치
+
+### 생성/수정 파일
+```
+src/main/java/.../global/config/JacksonConfig.java (신규)
+src/test/java/.../global/config/JacksonConfigTest.java (신규)
+```
+
+---
+
 ## 2026-02-01: 도메인별 워크플로우 분기 구현 (#78)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/global/config/JacksonConfig.java
+++ b/src/main/java/com/smartchain/platform/global/config/JacksonConfig.java
@@ -1,0 +1,17 @@
+package com.smartchain.platform.global.config;
+
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer() {
+        return builder -> builder.featuresToEnable(
+                JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER.mappedFeature()
+        );
+    }
+}

--- a/src/test/java/com/smartchain/platform/global/config/JacksonConfigTest.java
+++ b/src/test/java/com/smartchain/platform/global/config/JacksonConfigTest.java
@@ -1,0 +1,42 @@
+package com.smartchain.platform.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartchain.platform.dto.auth.login.LoginRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class JacksonConfigTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("특수문자(!)가 백슬래시 이스케이프된 비밀번호도 정상 파싱되어야 한다")
+    void shouldParseBackslashEscapedSpecialCharacters() throws Exception {
+        // \! 는 표준 JSON 이스케이프가 아니지만, 클라이언트가 보낼 수 있으므로 허용
+        String json = "{\"email\":\"test@test.com\",\"password\":\"Test1234\\!\"}";
+
+        LoginRequest request = objectMapper.readValue(json, LoginRequest.class);
+
+        assertEquals("test@test.com", request.getEmail());
+        assertEquals("Test1234!", request.getPassword());
+    }
+
+    @Test
+    @DisplayName("특수문자가 포함된 정상 JSON 비밀번호도 파싱되어야 한다")
+    void shouldParseNormalSpecialCharacters() throws Exception {
+        String json = "{\"email\":\"test@test.com\",\"password\":\"Test1234!\"}";
+
+        LoginRequest request = objectMapper.readValue(json, LoginRequest.class);
+
+        assertEquals("test@test.com", request.getEmail());
+        assertEquals("Test1234!", request.getPassword());
+    }
+}


### PR DESCRIPTION
## Summary
- `!` 등 특수문자가 포함된 비밀번호로 로그인 시 `JsonMappingException` 500 에러 수정
- Jackson `ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER` 활성화로 비표준 이스케이프 허용
- `Jackson2ObjectMapperBuilderCustomizer` 사용하여 Spring Boot 기본 설정 유지

## Test plan
- [x] `JacksonConfigTest` - `\!` 이스케이프된 비밀번호 파싱 테스트 통과
- [x] `ApiSmokeTest` - 기존 통합 테스트 통과
- [x] 전체 빌드 성공 (354 tests passed)

Closes #104