### PR TITLE
fix(auth): 테스트 계정 email_verified 활성화로 로그인 실패 수정

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,35 @@
 # Claude Code Learnings
 
+## 2026-02-02: 테스트 계정 email_verified 미활성화로 로그인 실패 (#106)
+
+### 원인
+- User 엔티티의 `emailVerified` 기본값이 `false`
+- email_verified 컬럼 추가 이전에 생성된 기존 계정들이 모두 미인증 상태
+- dev 환경에서 data.sql이 실행되지 않아 기존 데이터 보정 불가
+
+### 해결
+- data.sql에 `UPDATE "User" SET email_verified = true WHERE email_verified = false` 추가
+- dev 프로파일에 `sql.init.mode: always` + `defer-datasource-initialization: true` 설정 추가
+- 서버 기동 시 자동으로 기존 계정의 이메일 인증 상태 활성화
+
+### 재발방지
+- User 엔티티에 새 boolean 필드 추가 시 기존 데이터 마이그레이션 SQL 필수
+- data.sql의 UPDATE문은 멱등(idempotent)하게 작성 (WHERE 조건으로 중복 실행 안전)
+
+### 검증방법
+- 서버 재기동 후 테스트 계정으로 로그인 시 A005 에러 없이 정상 응답 확인
+
+### 관련커밋
+- fix/106-email-verified-activation 브랜치
+
+### 생성/수정 파일
+```
+src/main/resources/data.sql (UPDATE문 추가)
+src/main/resources/application.yaml (dev 프로파일 sql.init 설정 추가)
+```
+
+---
+
 ## 2026-02-02: 특수문자(!) 포함 비밀번호 로그인 500 에러 (#104)
 
 ### 원인

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -182,7 +182,12 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASSWORD}
 
+  sql:
+    init:
+      mode: always
+
   jpa:
+    defer-datasource-initialization: true
     hibernate:
       ddl-auto: validate
     show-sql: false

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,3 +2,6 @@ INSERT INTO role (name, code) VALUES ('게스트', 'GUEST') ON CONFLICT (code) D
 INSERT INTO role (name, code) VALUES ('기안자', 'DRAFTER') ON CONFLICT (code) DO NOTHING;
 INSERT INTO role (name, code) VALUES ('결재자', 'APPROVER') ON CONFLICT (code) DO NOTHING;
 INSERT INTO role (name, code) VALUES ('심사자', 'REVIEWER') ON CONFLICT (code) DO NOTHING;
+
+-- 기존 사용자 이메일 인증 활성화 (email_verified 컬럼 추가 이전 생성된 계정 대응)
+UPDATE "User" SET email_verified = true WHERE email_verified = false;


### PR DESCRIPTION
## Summary
- 기존 계정들의 `email_verified`가 `false`여서 로그인 시 A005 에러 발생
- data.sql에 기존 계정 `email_verified = true` UPDATE 추가
- dev 프로파일에 `sql.init.mode: always` 설정 추가하여 서버 기동 시 자동 보정

## Test plan
- [x] 전체 빌드 성공 (354 tests passed)
- [ ] dev 서버 재기동 후 drafter1@techpartner.co.kr 로그인 확인
- [ ] guest@example.com 로그인 시 A005 대신 정상 인증 에러(401) 확인

Closes #106