### PR TITLE
fix(auth): data.sql 테이블명 대소문자 수정 (#106)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -8,13 +8,14 @@
 - dev 환경에서 data.sql이 실행되지 않아 기존 데이터 보정 불가
 
 ### 해결
-- data.sql에 `UPDATE "User" SET email_verified = true WHERE email_verified = false` 추가
+- data.sql에 `UPDATE "user" SET email_verified = true WHERE email_verified = false` 추가
 - dev 프로파일에 `sql.init.mode: always` + `defer-datasource-initialization: true` 설정 추가
 - 서버 기동 시 자동으로 기존 계정의 이메일 인증 상태 활성화
 
 ### 재발방지
 - User 엔티티에 새 boolean 필드 추가 시 기존 데이터 마이그레이션 SQL 필수
 - data.sql의 UPDATE문은 멱등(idempotent)하게 작성 (WHERE 조건으로 중복 실행 안전)
+- `@Table(name = "\"User\"")` → Hibernate는 소문자 `"user"`로 생성함. data.sql에서도 `"user"` 사용 필수
 
 ### 검증방법
 - 서버 재기동 후 테스트 계정으로 로그인 시 A005 에러 없이 정상 응답 확인

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4,4 +4,4 @@ INSERT INTO role (name, code) VALUES ('결재자', 'APPROVER') ON CONFLICT (code
 INSERT INTO role (name, code) VALUES ('심사자', 'REVIEWER') ON CONFLICT (code) DO NOTHING;
 
 -- 기존 사용자 이메일 인증 활성화 (email_verified 컬럼 추가 이전 생성된 계정 대응)
-UPDATE "User" SET email_verified = true WHERE email_verified = false;
+UPDATE "user" SET email_verified = true WHERE email_verified = false;


### PR DESCRIPTION
## Summary
- `UPDATE "User"` → `UPDATE "user"` 수정
- Hibernate `SpringPhysicalNamingStrategy`가 테이블명을 소문자로 변환하므로 data.sql도 소문자 필요
- 서버 기동 시 `ScriptStatementFailedException` 해결

## Test plan
- [x] `./gradlew bootRun` 정상 기동 확인 (에러 없음)
- [x] 전체 빌드 성공 (354 tests passed)

Closes #106