### PR TITLE
fix(diagnostic): 동시 기안 생성 시 diagnostic_code 중복 키 오류 수정 (#112)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,42 @@
 # Claude Code Learnings
 
+## 2026-02-02: diagnostic_code 중복 키 제약 조건 위반 (동시 요청 race condition)
+
+### 원인
+- `generateDiagnosticCode()`가 `MAX(diagnosticId)`를 조회하여 시퀀스 번호 생성
+- 동시 요청 시 두 트랜잭션이 같은 max ID를 읽어 동일한 코드 생성
+- `diagnostic_diagnostic_code_key` unique 제약 조건 위반으로 `ConstraintViolationException` 발생
+
+### 해결
+- PostgreSQL 시퀀스 `diagnostic_code_seq` 도입 (`nextval`은 트랜잭션 격리 수준과 무관하게 원자적)
+- `DiagnosticRepository.getNextDiagnosticCodeSequence()` 네이티브 쿼리로 시퀀스 조회
+- `data.sql`에서 시퀀스 생성 및 기존 데이터 기반 시작값 동기화
+- 테스트용 `schema.sql` 추가 (H2 호환)
+
+### 재발방지
+- 유니크 코드 생성 시 애플리케이션 레벨 MAX+1 패턴 대신 DB 시퀀스 사용
+- 네이티브 쿼리 사용 시 테스트 환경(H2)에서도 해당 DB 객체가 존재하는지 확인
+
+### 검증방법
+```bash
+./gradlew test
+```
+
+### 관련커밋
+- fix/109-email-verified-not-updated 브랜치 (diagnostic_code 중복 수정 포함)
+
+### 생성/수정 파일
+```
+src/main/java/.../diagnostic/repository/DiagnosticRepository.java (findMaxDiagnosticId → getNextDiagnosticCodeSequence)
+src/main/java/.../diagnostic/service/DiagnosticService.java (generateDiagnosticCode 시퀀스 기반으로 변경)
+src/main/resources/data.sql (시퀀스 생성 SQL 추가)
+src/test/resources/schema.sql (신규 - H2 테스트용 시퀀스)
+src/test/resources/application-test.yaml (sql.init.mode: always, defer-datasource-initialization: true)
+src/test/java/.../diagnostic/service/DiagnosticServiceTest.java (mock 메서드명 변경)
+```
+
+---
+
 ## 2026-02-02: 이메일 인증 완료 후 User.emailVerified 미업데이트 (#109)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/repository/DiagnosticRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/repository/DiagnosticRepository.java
@@ -47,8 +47,8 @@ public interface DiagnosticRepository extends JpaRepository<Diagnostic, Long> {
     @Query("SELECT COUNT(d) FROM Diagnostic d WHERE d.company = :company")
     long countByCompany(@Param("company") Company company);
 
-    @Query("SELECT MAX(d.diagnosticId) FROM Diagnostic d")
-    Long findMaxDiagnosticId();
+    @Query(value = "SELECT nextval('diagnostic_code_seq')", nativeQuery = true)
+    Long getNextDiagnosticCodeSequence();
 
     Page<Diagnostic> findByDomainOrderByCreatedAtDesc(Domain domain, Pageable pageable);
 

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -635,8 +635,7 @@ public class DiagnosticService {
 
     private String generateDiagnosticCode() {
         int year = Year.now().getValue();
-        Long maxId = diagnosticRepository.findMaxDiagnosticId();
-        long sequence = (maxId != null ? maxId : 0L) + 1;
+        long sequence = diagnosticRepository.getNextDiagnosticCodeSequence();
         return String.format("DG-%d-%05d", year, sequence);
     }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -5,3 +5,7 @@ INSERT INTO role (name, code) VALUES ('심사자', 'REVIEWER') ON CONFLICT (code
 
 -- 기존 사용자 이메일 인증 활성화 (email_verified 컬럼 추가 이전 생성된 계정 대응)
 UPDATE "user" SET email_verified = true WHERE email_verified = false;
+
+-- 진단 코드 시퀀스 생성 (동시 요청 시 중복 코드 방지)
+CREATE SEQUENCE IF NOT EXISTS diagnostic_code_seq START WITH 1 INCREMENT BY 1;
+SELECT setval('diagnostic_code_seq', COALESCE((SELECT MAX(diagnostic_id) FROM diagnostic), 0) + 1, false);

--- a/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
@@ -464,7 +464,7 @@ class DiagnosticServiceTest {
 
             given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
             given(campaignRepository.findById(100L)).willReturn(Optional.of(testCampaign));
-            given(diagnosticRepository.findMaxDiagnosticId()).willReturn(0L);
+            given(diagnosticRepository.getNextDiagnosticCodeSequence()).willReturn(1L);
             given(diagnosticRepository.save(any(Diagnostic.class))).willReturn(savedDiagnostic);
             given(diagnosticHistoryRepository.save(any(DiagnosticHistory.class))).willReturn(null);
 

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -6,7 +6,9 @@ spring:
     driver-class-name: org.h2.Driver
   sql:
     init:
-      mode: never
+      mode: always
+      schema-locations: classpath:schema.sql
+      data-locations:
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -15,7 +17,7 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
-    defer-datasource-initialization: false
+    defer-datasource-initialization: true
   h2:
     console:
       enabled: false

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,2 @@
+-- 진단 코드 시퀀스 (테스트용)
+CREATE SEQUENCE IF NOT EXISTS diagnostic_code_seq START WITH 1 INCREMENT BY 1;


### PR DESCRIPTION
## Summary
- `generateDiagnosticCode()`의 `MAX(diagnosticId)` 기반 코드 생성을 PostgreSQL 시퀀스(`diagnostic_code_seq`)로 교체
- 동시 요청 시 race condition으로 인한 `ConstraintViolationException` 해결
- 테스트 환경(H2) 호환을 위한 `schema.sql` 추가

## Test plan
- [x] `./gradlew test` 전체 365건 통과
- [x] `DiagnosticServiceTest` 단위 테스트 통과
- [x] `DiagnosticIntegrationTest` 통합 테스트 통과

Closes #112