### PR TITLE
feat(auth): 이메일 인증 코드 실제 발송 기능 구현 (#116)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
 	// Spring Boot
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/smartchain/platform/domain/auth/service/AuthService.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/service/AuthService.java
@@ -54,6 +54,7 @@ public class AuthService {
     private final EmailVerificationCodeRepository verificationCodeRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final EmailService emailService;
 
     private static final String GUEST_ROLE_CODE = "GUEST";
     private static final int VERIFICATION_CODE_LENGTH = 6;
@@ -196,9 +197,8 @@ public class AuthService {
 
         verificationCodeRepository.save(verificationCode);
 
-        // TODO: 실제 이메일 발송 로직 구현 (Spring Mail 또는 외부 서비스 연동)
-        // 개발 환경에서는 로그로 코드 출력
-        log.info("Verification code sent: email={}, code={}", email, code);
+        // 이메일 발송 (프로파일에 따라 실제 발송 또는 로깅)
+        emailService.sendVerificationCode(email, code, VERIFICATION_CODE_EXPIRY_MINUTES);
 
         return SendVerificationResponse.builder()
                 .email(email)

--- a/src/main/java/com/smartchain/platform/domain/auth/service/EmailService.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/service/EmailService.java
@@ -1,0 +1,17 @@
+package com.smartchain.platform.domain.auth.service;
+
+/**
+ * 이메일 발송 서비스 인터페이스.
+ * 프로파일에 따라 실제 SMTP 발송 또는 로깅으로 구현됩니다.
+ */
+public interface EmailService {
+
+    /**
+     * 이메일 인증 코드를 발송합니다.
+     *
+     * @param to 수신자 이메일 주소
+     * @param code 인증 코드 (6자리 숫자)
+     * @param expiryMinutes 인증 코드 만료 시간 (분)
+     */
+    void sendVerificationCode(String to, String code, int expiryMinutes);
+}

--- a/src/main/java/com/smartchain/platform/domain/auth/service/LocalEmailService.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/service/LocalEmailService.java
@@ -1,0 +1,26 @@
+package com.smartchain.platform.domain.auth.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+/**
+ * 로컬 개발용 이메일 서비스.
+ * 실제 발송 없이 로그로 인증 코드를 출력합니다.
+ * local 및 test 프로파일에서 활성화됩니다.
+ */
+@Slf4j
+@Service
+@Profile({"local", "test"})
+public class LocalEmailService implements EmailService {
+
+    @Override
+    public void sendVerificationCode(String to, String code, int expiryMinutes) {
+        log.info("========================================");
+        log.info("[LOCAL] Email verification code");
+        log.info("To: {}", to);
+        log.info("Code: {}", code);
+        log.info("Expires in: {} minutes", expiryMinutes);
+        log.info("========================================");
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/auth/service/SmtpEmailService.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/service/SmtpEmailService.java
@@ -1,0 +1,74 @@
+package com.smartchain.platform.domain.auth.service;
+
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+/**
+ * SMTP 기반 이메일 발송 서비스.
+ * dev 프로파일에서 활성화됩니다.
+ */
+@Slf4j
+@Service
+@Profile("dev")
+@RequiredArgsConstructor
+public class SmtpEmailService implements EmailService {
+
+    private final JavaMailSender mailSender;
+
+    private static final String SENDER_NAME = "SmartChain";
+    private static final String SUBJECT = "[SmartChain] 이메일 인증 코드";
+
+    @Override
+    public void sendVerificationCode(String to, String code, int expiryMinutes) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(to);
+            helper.setSubject(SUBJECT);
+            helper.setText(buildEmailContent(code, expiryMinutes), true);
+
+            mailSender.send(message);
+            log.info("Verification email sent successfully: to={}", to);
+        } catch (MessagingException e) {
+            log.error("Failed to send verification email: to={}, error={}", to, e.getMessage());
+            throw new CustomException(ErrorCode.EMAIL_SEND_FAILED);
+        }
+    }
+
+    private String buildEmailContent(String code, int expiryMinutes) {
+        return String.format("""
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="UTF-8">
+                <style>
+                    body { font-family: 'Noto Sans KR', Arial, sans-serif; }
+                    .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+                    .code { font-size: 32px; font-weight: bold; color: #2563eb; letter-spacing: 8px; }
+                    .notice { color: #666; font-size: 14px; margin-top: 20px; }
+                </style>
+            </head>
+            <body>
+                <div class="container">
+                    <h2>SmartChain 이메일 인증</h2>
+                    <p>아래 인증 코드를 입력해 주세요.</p>
+                    <p class="code">%s</p>
+                    <p class="notice">
+                        이 인증 코드는 %d분 후에 만료됩니다.<br>
+                        본인이 요청하지 않은 경우 이 메일을 무시해 주세요.
+                    </p>
+                </div>
+            </body>
+            </html>
+            """, code, expiryMinutes);
+    }
+}

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -82,6 +82,7 @@ public enum ErrorCode {
     FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S002", "파일 업로드에 실패했습니다"),
     AI_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S003", "AI 서비스 연동에 실패했습니다"),
     FILE_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYS_003", "파일 파싱에 실패했습니다"),
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S004", "이메일 발송에 실패했습니다"),
 
     // 503 Service Unavailable - AI Service
     AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI001", "AI 서비스에 연결할 수 없습니다"),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -201,3 +201,14 @@ azure:
 logging:
   level:
     com.smartchain.platform: INFO
+
+# 이메일 설정 (SMTP)
+spring.mail:
+  host: ${MAIL_HOST:smtp.gmail.com}
+  port: ${MAIL_PORT:587}
+  username: ${MAIL_USERNAME}
+  password: ${MAIL_PASSWORD}
+  properties:
+    mail.smtp.auth: true
+    mail.smtp.starttls.enable: true
+    mail.smtp.starttls.required: true

--- a/src/test/java/com/smartchain/platform/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/auth/service/AuthServiceTest.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -73,6 +74,9 @@ class AuthServiceTest {
 
     @Mock
     private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private EmailService emailService;
 
     private Role guestRole;
 
@@ -422,6 +426,7 @@ class AuthServiceTest {
             assertThat(response.getEmail()).isEqualTo("test@test.com");
             assertThat(response.getExpiresInSeconds()).isEqualTo(300);
             verify(verificationCodeRepository).save(any(EmailVerificationCode.class));
+            verify(emailService).sendVerificationCode(eq("test@test.com"), anyString(), eq(5));
         }
 
         @Test

--- a/src/test/java/com/smartchain/platform/domain/auth/service/EmailServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/auth/service/EmailServiceTest.java
@@ -1,0 +1,40 @@
+package com.smartchain.platform.domain.auth.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceTest {
+
+    @Test
+    @DisplayName("LocalEmailService: 인증 코드 발송 시 예외 없이 로깅")
+    void localEmailService_sendVerificationCode_Success() {
+        // given
+        EmailService emailService = new LocalEmailService();
+        String email = "test@test.com";
+        String code = "123456";
+        int expiryMinutes = 5;
+
+        // when & then
+        assertThatCode(() -> emailService.sendVerificationCode(email, code, expiryMinutes))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("LocalEmailService: 다양한 이메일 주소 처리")
+    void localEmailService_variousEmails_Success() {
+        // given
+        EmailService emailService = new LocalEmailService();
+
+        // when & then
+        assertThatCode(() -> {
+            emailService.sendVerificationCode("user@gmail.com", "111111", 5);
+            emailService.sendVerificationCode("admin@company.co.kr", "222222", 10);
+            emailService.sendVerificationCode("test+alias@domain.org", "333333", 3);
+        }).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## 변경 요약
- 이메일 인증 코드 발송 TODO 해결
- 프로파일별 이메일 서비스 구현 (SMTP/로컬 로깅)
- ErrorCode에 EMAIL_SEND_FAILED(S004) 추가

## 관련 이슈
- Closes #116

## 변경 파일
- `build.gradle`: spring-boot-starter-mail 의존성 추가
- `EmailService.java`: 이메일 발송 인터페이스
- `SmtpEmailService.java`: dev 프로파일용 SMTP 발송 구현
- `LocalEmailService.java`: local/test 프로파일용 로깅 구현
- `AuthService.java`: EmailService 주입 및 호출
- `ErrorCode.java`: EMAIL_SEND_FAILED(S004) 추가
- `application.yaml`: dev 프로파일 SMTP 설정 추가
- `AuthServiceTest.java`: emailService mock 추가 및 verify 테스트
- `EmailServiceTest.java`: LocalEmailService 테스트

## 테스트 방법
```bash
./gradlew test --tests "AuthServiceTest"
./gradlew test --tests "EmailServiceTest"
./gradlew build
```
모두 통과 확인됨

## 명세 준수 체크
- [x] CLAUDE.md 워크플로우 준수
- [x] 기존 DTO/Entity 재사용 (신규 EmailService 인터페이스만 추가)
- [x] 테스트 1개 이상 추가 (EmailServiceTest)
- [x] ./gradlew test && ./gradlew build 통과

## 리뷰 포인트
1. SmtpEmailService의 HTML 템플릿 디자인 적절성
2. SMTP 설정을 환경변수로 처리한 방식의 보안성
3. 프로파일별 EmailService 빈 분리 전략

## TODO / 질문
- [ ] 실제 SMTP 서버 정보(MAIL_HOST, MAIL_USERNAME, MAIL_PASSWORD) 환경변수 설정 필요
- [ ] 발송 실패 시 재시도 로직 필요 여부 논의 필요