### PR TITLE
fix: 캠페인/기안/회원가입 버그 수정

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/auth/repository/EmailVerificationCodeRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/repository/EmailVerificationCodeRepository.java
@@ -12,6 +12,8 @@ public interface EmailVerificationCodeRepository extends JpaRepository<EmailVeri
 
     Optional<EmailVerificationCode> findTopByEmailAndVerifiedFalseOrderByCreatedAtDesc(String email);
 
+    Optional<EmailVerificationCode> findTopByEmailAndVerifiedTrueOrderByCreatedAtDesc(String email);
+
     Optional<EmailVerificationCode> findTopByEmailOrderByCreatedAtDesc(String email);
 
     void deleteByExpiresAtBefore(LocalDateTime dateTime);

--- a/src/main/java/com/smartchain/platform/domain/auth/service/AuthService.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/service/AuthService.java
@@ -90,21 +90,31 @@ public class AuthService {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
 
-        // 5. GUEST 역할 조회
+        // 5. 이메일 인증 여부 확인 (회원가입 전 인증 완료 필수)
+        boolean isEmailVerified = verificationCodeRepository
+                .findTopByEmailAndVerifiedTrueOrderByCreatedAtDesc(request.getEmail())
+                .isPresent();
+
+        if (!isEmailVerified) {
+            throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
+        // 6. GUEST 역할 조회
         Role guestRole = roleRepository.findByCode(GUEST_ROLE_CODE)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROLE_NOT_FOUND));
 
-        // 6. 사용자 생성
+        // 7. 사용자 생성 (이메일 인증 완료 상태로)
         User user = User.builder()
                 .name(request.getName())
                 .email(request.getEmail())
                 .userPassword(passwordEncoder.encode(request.getPassword()))
                 .role(guestRole)
+                .emailVerified(true)
                 .build();
 
         User savedUser = userRepository.save(user);
 
-        log.info("User registered: userId={}, email={}", savedUser.getUserId(), savedUser.getEmail());
+        log.info("User registered: userId={}, email={}, emailVerified=true", savedUser.getUserId(), savedUser.getEmail());
 
         return RegisterResponse.builder()
                 .userId(savedUser.getUserId())

--- a/src/main/java/com/smartchain/platform/domain/campaign/controller/CampaignController.java
+++ b/src/main/java/com/smartchain/platform/domain/campaign/controller/CampaignController.java
@@ -4,12 +4,15 @@ import com.smartchain.platform.domain.campaign.service.CampaignService;
 import com.smartchain.platform.dto.campaign.detail.CampaignDetailResponse;
 import com.smartchain.platform.dto.campaign.list.CampaignListResponse;
 import com.smartchain.platform.global.response.BaseResponse;
+import com.smartchain.platform.global.security.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -20,12 +23,14 @@ import org.springframework.web.bind.annotation.*;
 public class CampaignController {
 
     private final CampaignService campaignService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    @Operation(summary = "캠페인 목록 조회", description = "모든 캠페인 목록을 조회합니다.")
+    @Operation(summary = "캠페인 목록 조회", description = "사용자 권한에 해당하는 활성 캠페인 목록을 조회합니다. 종료된 캠페인은 제외됩니다.")
     @GetMapping
-    public ResponseEntity<BaseResponse<CampaignListResponse>> getCampaignList() {
-        log.info("캠페인 목록 조회 요청");
-        CampaignListResponse response = campaignService.getCampaignList();
+    public ResponseEntity<BaseResponse<CampaignListResponse>> getCampaignList(HttpServletRequest request) {
+        Long userId = extractUserIdFromRequest(request);
+        log.info("캠페인 목록 조회 요청 - userId: {}", userId);
+        CampaignListResponse response = campaignService.getCampaignList(userId);
         return ResponseEntity.ok(BaseResponse.success("캠페인 목록 조회 완료", response));
     }
 
@@ -38,5 +43,14 @@ public class CampaignController {
         log.info("캠페인 상세 조회 요청 - campaignId: {}", campaignId);
         CampaignDetailResponse response = campaignService.getCampaignDetail(campaignId);
         return ResponseEntity.ok(BaseResponse.success("캠페인 상세 조회 완료", response));
+    }
+
+    private Long extractUserIdFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7);
+            return jwtTokenProvider.getUserIdFromToken(token);
+        }
+        throw new IllegalArgumentException("Authorization header is missing or invalid");
     }
 }

--- a/src/main/java/com/smartchain/platform/domain/campaign/service/CampaignService.java
+++ b/src/main/java/com/smartchain/platform/domain/campaign/service/CampaignService.java
@@ -4,6 +4,10 @@ import com.smartchain.platform.domain.diagnostic.entity.Campaign;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.diagnostic.repository.CampaignRepository;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
+import com.smartchain.platform.domain.user.entity.Domain;
+import com.smartchain.platform.domain.user.entity.User;
+import com.smartchain.platform.domain.user.entity.UserDomainRole;
+import com.smartchain.platform.domain.user.repository.UserRepository;
 import com.smartchain.platform.dto.campaign.detail.CampaignDetailResponse;
 import com.smartchain.platform.dto.campaign.detail.CampaignStatsDto;
 import com.smartchain.platform.dto.campaign.list.CampaignItemDto;
@@ -17,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -27,12 +32,49 @@ public class CampaignService {
 
     private final CampaignRepository campaignRepository;
     private final DiagnosticRepository diagnosticRepository;
+    private final UserRepository userRepository;
 
     /**
-     * 캠페인 목록 조회
+     * 캠페인 목록 조회 (사용자 권한 기반 필터링 + 종료된 캠페인 제외)
      */
-    public CampaignListResponse getCampaignList() {
-        List<Campaign> campaigns = campaignRepository.findAll();
+    public CampaignListResponse getCampaignList(Long userId) {
+        User currentUser = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        LocalDate today = LocalDate.now();
+        List<Campaign> campaigns;
+
+        // 사용자의 도메인별 역할 확인
+        List<UserDomainRole> domainRoles = currentUser.getDomainRoles();
+
+        if (domainRoles.isEmpty()) {
+            // 도메인 역할이 없는 경우 (레거시 또는 GUEST) - 빈 목록 반환
+            log.info("User {} has no domain roles, returning empty campaign list", userId);
+            return CampaignListResponse.builder()
+                    .campaigns(List.of())
+                    .totalCount(0)
+                    .build();
+        }
+
+        // REVIEWER 권한이 있는지 확인 (REVIEWER는 모든 캠페인 조회 가능)
+        boolean isReviewer = domainRoles.stream()
+                .anyMatch(udr -> "REVIEWER".equals(udr.getRole().getCode()));
+
+        if (isReviewer) {
+            // REVIEWER는 종료되지 않은 모든 캠페인 조회
+            campaigns = campaignRepository.findAllNotClosed(today);
+            log.info("Reviewer {} fetching all active campaigns, count={}", userId, campaigns.size());
+        } else {
+            // DRAFTER/APPROVER는 자신의 도메인 권한에 해당하는 캠페인만 조회
+            List<Domain> userDomains = domainRoles.stream()
+                    .map(UserDomainRole::getDomain)
+                    .distinct()
+                    .toList();
+
+            campaigns = campaignRepository.findByDomainsAndNotClosed(userDomains, today);
+            log.info("User {} fetching campaigns for domains {}, count={}",
+                    userId, userDomains.stream().map(Domain::getCode).toList(), campaigns.size());
+        }
 
         List<CampaignItemDto> items = campaigns.stream()
                 .map(this::toCampaignItemDto)

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/repository/CampaignRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/repository/CampaignRepository.java
@@ -5,8 +5,11 @@ import com.smartchain.platform.domain.user.entity.Domain;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +20,16 @@ public interface CampaignRepository extends JpaRepository<Campaign, Long> {
     List<Campaign> findByDomain(Domain domain);
 
     Page<Campaign> findByDomainOrderByCreatedAtDesc(Domain domain, Pageable pageable);
+
+    /**
+     * 사용자 권한 도메인에 해당하고, 종료되지 않은(ACTIVE/DRAFT) 캠페인 목록 조회
+     */
+    @Query("SELECT c FROM Campaign c WHERE c.domain IN :domains AND c.periodEndDate >= :today ORDER BY c.createdAt DESC")
+    List<Campaign> findByDomainsAndNotClosed(@Param("domains") List<Domain> domains, @Param("today") LocalDate today);
+
+    /**
+     * 모든 도메인의 종료되지 않은 캠페인 목록 조회 (REVIEWER용)
+     */
+    @Query("SELECT c FROM Campaign c WHERE c.periodEndDate >= :today ORDER BY c.createdAt DESC")
+    List<Campaign> findAllNotClosed(@Param("today") LocalDate today);
 }

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -280,6 +280,11 @@ public class DiagnosticService {
         Campaign campaign = campaignRepository.findById(request.getCampaignId())
                 .orElseThrow(() -> new CustomException(ErrorCode.CAMPAIGN_NOT_FOUND));
 
+        // 캠페인 종료 여부 확인 (종료된 캠페인에는 진단 생성 불가)
+        if (campaign.getPeriodEndDate().isBefore(LocalDate.now())) {
+            throw new CustomException(ErrorCode.CAMPAIGN_CLOSED);
+        }
+
         // 캠페인의 도메인 또는 요청의 도메인 코드로 도메인 조회
         Domain domain = campaign.getDomain();
         if (domain == null && request.getDomainCode() != null) {

--- a/src/main/java/com/smartchain/platform/domain/role/service/RoleRequestService.java
+++ b/src/main/java/com/smartchain/platform/domain/role/service/RoleRequestService.java
@@ -492,6 +492,13 @@ public class RoleRequestService {
                     log.info("User global role upgraded from GUEST to {}: userId={}",
                             roleRequest.getRequestedRole(), requestUser.getUserId());
                 }
+
+                // 회사 정보 연결 (회사가 없는 경우에만)
+                if (requestUser.getCompany() == null && roleRequest.getCompany() != null) {
+                    requestUser.changeCompany(roleRequest.getCompany());
+                    log.info("User company assigned: userId={}, companyId={}",
+                            requestUser.getUserId(), roleRequest.getCompany().getCompanyId());
+                }
             }
 
             message = "권한 요청이 승인되었습니다";

--- a/src/main/java/com/smartchain/platform/domain/user/entity/User.java
+++ b/src/main/java/com/smartchain/platform/domain/user/entity/User.java
@@ -80,6 +80,10 @@ public class User extends BaseTimeEntity {
         this.role = newRole;
     }
 
+    public void changeCompany(Company newCompany) {
+        this.company = newCompany;
+    }
+
     public void changeStatus(UserStatus newStatus) {
         this.status = newStatus;
     }

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "C001", "회사를 찾을 수 없습니다"),
     DIAGNOSTIC_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "진단을 찾을 수 없습니다"),
     CAMPAIGN_NOT_FOUND(HttpStatus.NOT_FOUND, "D002", "캠페인을 찾을 수 없습니다"),
+    CAMPAIGN_CLOSED(HttpStatus.BAD_REQUEST, "D003", "종료된 캠페인에는 진단을 생성할 수 없습니다"),
     APPROVAL_NOT_FOUND(HttpStatus.NOT_FOUND, "AP001", "결재를 찾을 수 없습니다"),
     EVIDENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "E001", "증빙파일을 찾을 수 없습니다"),
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "RES_004", "파일을 찾을 수 없습니다"),


### PR DESCRIPTION
## Summary
- 이메일 인증 후에도 emailVerified=false 버그 수정
- 권한 요청 승인 시 회사 미연결 버그 수정
- 캠페인 목록 권한/상태 필터링 누락 버그 수정
- 종료된 캠페인에서 진단 생성 가능한 버그 수정

## Test plan
- [ ] 회원가입 → 이메일 인증 → 로그인 성공 확인
- [ ] 권한 요청 승인 후 /auth/me에서 company 확인
- [ ] 캠페인 목록 API에서 권한에 따른 필터링 확인
- [ ] 종료된 캠페인으로 진단 생성 시 에러 확인

## Related Issues
- #132 DataInitializer 수정
- #133 LEARNINGS.md 업데이트