### PR TITLE
feat(auth): 로그인 API에 Google reCAPTCHA v3 검증 추가

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,47 @@
 # Claude Code Learnings
 
+## 2026-02-04: Google reCAPTCHA v3 로그인 보안 검증 구현
+
+### 원인
+- 로그인 API에 봇/자동화 공격 방지 보안 레이어 부재
+- 프론트엔드에서 reCAPTCHA v3 구현 요청에 따른 백엔드 검증 필요
+
+### 해결
+- `RecaptchaConfig`: reCAPTCHA 설정 (secretKey, scoreThreshold, enabled)
+- `RecaptchaService`: Google reCAPTCHA API 검증 서비스
+  - POST `https://www.google.com/recaptcha/api/siteverify`로 토큰 검증
+  - success 체크, action 변조 방지, score 임계값(0.5) 검증
+- `LoginRequest`에 `recaptchaToken` 필드 추가
+- `AuthService.login()`에 reCAPTCHA 검증 로직 추가 (비밀번호 검증 전 수행)
+- `ErrorCode`에 `RECAPTCHA_FAILED` (CAPTCHA_001), `RECAPTCHA_LOW_SCORE` (CAPTCHA_002) 추가
+
+### 재발방지
+- 보안 검증 로직은 주요 인증 로직 앞에 배치
+- 환경변수로 enabled 플래그 제공하여 개발/테스트 환경에서 비활성화 가능
+- score 임계값은 환경변수로 조정 가능 (기본 0.5)
+
+### 검증방법
+```bash
+./gradlew build -x test
+./gradlew test --tests "*AuthServiceTest*login*"
+```
+
+### 관련커밋
+- feature/recaptcha-login-validation-v2 브랜치
+
+### 생성/수정 파일
+```
+src/main/java/.../global/config/RecaptchaConfig.java (신규)
+src/main/java/.../domain/auth/service/RecaptchaService.java (신규)
+src/main/java/.../dto/auth/login/LoginRequest.java (recaptchaToken 추가)
+src/main/java/.../domain/auth/service/AuthService.java (검증 로직 추가)
+src/main/java/.../global/error/ErrorCode.java (CAPTCHA_001, CAPTCHA_002 추가)
+src/main/resources/application.yaml (recaptcha 설정 추가)
+src/test/java/.../domain/auth/service/AuthServiceTest.java (mock 추가)
+```
+
+---
+
 ## 2026-02-03: 캠페인/기안/회원가입 버그 수정 (#134)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/auth/service/AuthService.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/service/AuthService.java
@@ -55,6 +55,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final EmailService emailService;
+    private final RecaptchaService recaptchaService;
 
     private static final String GUEST_ROLE_CODE = "GUEST";
     private static final int VERIFICATION_CODE_LENGTH = 6;
@@ -128,6 +129,9 @@ public class AuthService {
 
     @Transactional
     public LoginResponse login(LoginRequest request) {
+        // 0. reCAPTCHA 검증
+        recaptchaService.verify(request.getRecaptchaToken(), "login");
+
         // 1. 사용자 조회
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_CREDENTIALS));

--- a/src/main/java/com/smartchain/platform/domain/auth/service/RecaptchaService.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/service/RecaptchaService.java
@@ -1,0 +1,94 @@
+package com.smartchain.platform.domain.auth.service;
+
+import com.smartchain.platform.global.config.RecaptchaConfig;
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecaptchaService {
+
+    private static final String VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify";
+
+    private final RecaptchaConfig recaptchaConfig;
+    private final RestClient restClient = RestClient.create();
+
+    /**
+     * reCAPTCHA v3 토큰 검증
+     * @param token 프론트엔드에서 전달받은 reCAPTCHA 토큰
+     * @param expectedAction 예상 action (예: "login")
+     */
+    public void verify(String token, String expectedAction) {
+        if (!recaptchaConfig.isEnabled()) {
+            log.debug("reCAPTCHA verification is disabled");
+            return;
+        }
+
+        if (token == null || token.isBlank()) {
+            log.warn("reCAPTCHA token is missing");
+            throw new CustomException(ErrorCode.RECAPTCHA_FAILED);
+        }
+
+        try {
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add("secret", recaptchaConfig.getSecretKey());
+            formData.add("response", token);
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> response = restClient.post()
+                    .uri(VERIFY_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .body(Map.class);
+
+            if (response == null) {
+                log.error("reCAPTCHA API returned null response");
+                throw new CustomException(ErrorCode.RECAPTCHA_FAILED);
+            }
+
+            log.debug("reCAPTCHA response: {}", response);
+
+            // success 검증
+            Boolean success = (Boolean) response.get("success");
+            if (!Boolean.TRUE.equals(success)) {
+                log.warn("reCAPTCHA verification failed: success=false, error-codes={}",
+                        response.get("error-codes"));
+                throw new CustomException(ErrorCode.RECAPTCHA_FAILED);
+            }
+
+            // action 검증 (변조 방지)
+            String action = (String) response.get("action");
+            if (expectedAction != null && !expectedAction.equals(action)) {
+                log.warn("reCAPTCHA action mismatch: expected={}, actual={}", expectedAction, action);
+                throw new CustomException(ErrorCode.RECAPTCHA_FAILED);
+            }
+
+            // score 검증
+            Double score = ((Number) response.get("score")).doubleValue();
+            if (score < recaptchaConfig.getScoreThreshold()) {
+                log.warn("reCAPTCHA low score: score={}, threshold={}",
+                        score, recaptchaConfig.getScoreThreshold());
+                throw new CustomException(ErrorCode.RECAPTCHA_LOW_SCORE);
+            }
+
+            log.info("reCAPTCHA verification passed: score={}, action={}", score, action);
+
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("reCAPTCHA verification error", e);
+            throw new CustomException(ErrorCode.RECAPTCHA_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/auth/login/LoginRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/auth/login/LoginRequest.java
@@ -19,4 +19,6 @@ public class LoginRequest {
     
     @NotBlank(message = "비밀번호를 입력해주세요")
     private String password;
+
+    private String recaptchaToken;
 }

--- a/src/main/java/com/smartchain/platform/global/config/RecaptchaConfig.java
+++ b/src/main/java/com/smartchain/platform/global/config/RecaptchaConfig.java
@@ -1,0 +1,17 @@
+package com.smartchain.platform.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "recaptcha")
+public class RecaptchaConfig {
+
+    private String secretKey;
+    private double scoreThreshold = 0.5;
+    private boolean enabled = true;
+}

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -20,6 +20,10 @@ public enum ErrorCode {
     VERIFICATION_RATE_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "U010", "잠시 후 다시 시도해주세요"),
     COMPANY_NOT_ASSIGNED(HttpStatus.BAD_REQUEST, "U011", "소속 회사가 지정되지 않았습니다"),
 
+    // reCAPTCHA
+    RECAPTCHA_FAILED(HttpStatus.BAD_REQUEST, "CAPTCHA_001", "보안 검증에 실패했습니다. 다시 시도해주세요."),
+    RECAPTCHA_LOW_SCORE(HttpStatus.BAD_REQUEST, "CAPTCHA_002", "비정상적인 접근이 감지되었습니다."),
+
     // 401 Unauthorized
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A001", "유효하지 않은 토큰입니다"),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "만료된 토큰입니다"),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -60,6 +60,12 @@ logging:
     com.smartchain.platform: DEBUG
     org.hibernate.SQL: DEBUG
 
+# reCAPTCHA v3 설정
+recaptcha:
+  secret-key: ${RECAPTCHA_SECRET_KEY:6LcC-V8sAAAAAHpYoUj5q31vQh9hDduj-4m7hvGc}
+  score-threshold: ${RECAPTCHA_SCORE_THRESHOLD:0.5}
+  enabled: ${RECAPTCHA_ENABLED:true}
+
 # 파일 저장소 설정 (로컬)
 file:
   storage:

--- a/src/test/java/com/smartchain/platform/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/auth/service/AuthServiceTest.java
@@ -78,6 +78,9 @@ class AuthServiceTest {
     @Mock
     private EmailService emailService;
 
+    @Mock
+    private RecaptchaService recaptchaService;
+
     private Role guestRole;
 
     @BeforeEach


### PR DESCRIPTION
## 변경 요약
로그인 API에 Google reCAPTCHA v3 보안 검증을 추가하여 봇/자동화 공격을 방지합니다.

### 주요 변경사항
- `RecaptchaConfig`: reCAPTCHA 설정 클래스 (secretKey, scoreThreshold, enabled)
- `RecaptchaService`: Google reCAPTCHA API 검증 서비스
- `LoginRequest`: `recaptchaToken` 필드 추가
- `AuthService.login()`: reCAPTCHA 검증 로직 추가 (비밀번호 검증 전 수행)
- `ErrorCode`: `RECAPTCHA_FAILED` (CAPTCHA_001), `RECAPTCHA_LOW_SCORE` (CAPTCHA_002) 추가
- `application.yaml`: recaptcha 설정 추가

## 관련 이슈
- 프론트엔드 reCAPTCHA v3 연동 요청

## 테스트 방법
```bash
# 빌드 확인
./gradlew build -x test

# 로그인 테스트
./gradlew test --tests "*AuthServiceTest*login*"
```

### API 테스트
```bash
# 로그인 요청 (reCAPTCHA 토큰 포함)
curl -X POST http://localhost:8080/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{
    "email": "test@test.com",
    "password": "Password123!",
    "recaptchaToken": "프론트엔드에서_받은_토큰"
  }'
```

## 명세 준수 체크
- [x] reCAPTCHA v3 토큰 검증 (success, action, score)
- [x] Score 임계값 0.5 적용 (환경변수로 조정 가능)
- [x] Action 검증으로 변조 방지 ("login" 액션 확인)
- [x] 에러 코드 정의 (CAPTCHA_001: 검증 실패, CAPTCHA_002: 낮은 점수)
- [x] 환경변수 지원 (RECAPTCHA_SECRET_KEY, RECAPTCHA_SCORE_THRESHOLD, RECAPTCHA_ENABLED)

## 리뷰 포인트
1. **검증 순서**: reCAPTCHA 검증을 비밀번호 검증 전에 수행하여 불필요한 DB 조회 방지
2. **enabled 플래그**: 개발/테스트 환경에서 reCAPTCHA 비활성화 가능
3. **Score 임계값**: 기본 0.5, 필요시 환경변수로 조정 가능 (0.3~0.7 권장)

## TODO / 질문
- [ ] 프론트엔드 Site Key 공유 필요
- [ ] Score 임계값 0.5가 적절한지 운영 데이터 기반 조정 필요
- [ ] 추가 인증(이메일 OTP 등) 필요 시 0.3~0.7 구간 처리 로직 추가 검토

## 설정값
```yaml
recaptcha:
  secret-key: ${RECAPTCHA_SECRET_KEY:6LcC-V8sAAAAAHpYoUj5q31vQh9hDduj-4m7hvGc}
  score-threshold: ${RECAPTCHA_SCORE_THRESHOLD:0.5}
  enabled: ${RECAPTCHA_ENABLED:true}
```