### PR TITLE
feat(chat): AI Chatbot 기반 구조 구현 (#140)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/chat/client/AiChatApiClient.java
+++ b/src/main/java/com/smartchain/platform/domain/chat/client/AiChatApiClient.java
@@ -1,0 +1,208 @@
+package com.smartchain.platform.domain.chat.client;
+
+import com.smartchain.platform.domain.chat.config.AiChatConfig;
+import com.smartchain.platform.dto.chat.AdminInspectResponse;
+import com.smartchain.platform.dto.chat.AdminSyncResponse;
+import com.smartchain.platform.dto.chat.ChatRequest;
+import com.smartchain.platform.dto.chat.ChatResponse;
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import io.netty.channel.ConnectTimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * AI Chat API 클라이언트
+ * FastAPI AI 서버와 통신
+ */
+@Component
+public class AiChatApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(AiChatApiClient.class);
+    private static final String ADMIN_API_KEY_HEADER = "X-API-KEY";
+
+    private final WebClient webClient;
+    private final String adminApiKey;
+
+    public AiChatApiClient(
+        @Qualifier("aiChatWebClient") WebClient webClient,
+        AiChatConfig config
+    ) {
+        this.webClient = webClient;
+        this.adminApiKey = config.getAdminApiKey();
+    }
+
+    /**
+     * 채팅 API 호출
+     */
+    public Mono<ChatResponse> chat(ChatRequest request) {
+        log.info("AI Chat API 호출 - message: {}, domain: {}",
+            truncateMessage(request.message()), request.domain());
+
+        return webClient.post()
+            .uri("/api/chat")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(ChatResponse.class)
+            .onErrorMap(this::mapToCustomException)
+            .doOnSuccess(response ->
+                log.info("AI Chat API 성공 - confidence: {}", response.confidence()))
+            .doOnError(error -> {
+                if (!(error instanceof CustomException)) {
+                    log.error("AI Chat API 실패", error);
+                }
+            });
+    }
+
+    /**
+     * 채팅 API 동기 호출
+     */
+    public ChatResponse chatSync(ChatRequest request) {
+        return chat(request).block();
+    }
+
+    /**
+     * Admin 데이터 동기화 API 호출
+     */
+    public Mono<AdminSyncResponse> syncData() {
+        log.info("AI Chat Admin Sync API 호출");
+
+        return webClient.post()
+            .uri("/api/admin/sync")
+            .header(ADMIN_API_KEY_HEADER, adminApiKey)
+            .contentType(MediaType.APPLICATION_JSON)
+            .retrieve()
+            .bodyToMono(AdminSyncResponse.class)
+            .onErrorMap(this::mapToCustomException)
+            .doOnSuccess(response ->
+                log.info("AI Chat Admin Sync API 성공 - status: {}", response.status()))
+            .doOnError(error -> {
+                if (!(error instanceof CustomException)) {
+                    log.error("AI Chat Admin Sync API 실패", error);
+                }
+            });
+    }
+
+    /**
+     * Admin 데이터 동기화 API 동기 호출
+     */
+    public AdminSyncResponse syncDataSync() {
+        return syncData().block();
+    }
+
+    /**
+     * Admin DB 현황 조회 API 호출
+     */
+    public Mono<AdminInspectResponse> inspectDb() {
+        log.info("AI Chat Admin Inspect API 호출");
+
+        return webClient.get()
+            .uri("/api/admin/inspect")
+            .header(ADMIN_API_KEY_HEADER, adminApiKey)
+            .retrieve()
+            .bodyToMono(AdminInspectResponse.class)
+            .onErrorMap(this::mapToCustomException)
+            .doOnSuccess(response ->
+                log.info("AI Chat Admin Inspect API 성공 - totalDocuments: {}", response.totalDocuments()))
+            .doOnError(error -> {
+                if (!(error instanceof CustomException)) {
+                    log.error("AI Chat Admin Inspect API 실패", error);
+                }
+            });
+    }
+
+    /**
+     * Admin DB 현황 조회 API 동기 호출
+     */
+    public AdminInspectResponse inspectDbSync() {
+        return inspectDb().block();
+    }
+
+    /**
+     * 에러를 CustomException으로 매핑
+     */
+    private Throwable mapToCustomException(Throwable throwable) {
+        if (throwable instanceof CustomException) {
+            return throwable;
+        }
+
+        // HTTP 에러 응답 처리
+        if (throwable instanceof WebClientResponseException ex) {
+            logErrorResponseBody(ex);
+
+            if (ex.getStatusCode().is4xxClientError()) {
+                log.warn("AI Chat 서비스 4xx 에러 - status: {}", ex.getStatusCode());
+                return new CustomException(ErrorCode.AI_CHAT_SERVICE_ERROR);
+            }
+            if (ex.getStatusCode().is5xxServerError()) {
+                log.error("AI Chat 서비스 5xx 에러 - status: {}", ex.getStatusCode());
+                return new CustomException(ErrorCode.AI_CHAT_SERVICE_ERROR);
+            }
+        }
+
+        // 타임아웃/네트워크 에러 처리
+        if (isNetworkOrTimeoutError(throwable)) {
+            log.error("AI Chat 서비스 연결 실패 - {}: {}",
+                throwable.getClass().getSimpleName(), throwable.getMessage());
+            return new CustomException(ErrorCode.AI_CHAT_TIMEOUT);
+        }
+
+        log.error("AI Chat 서비스 알 수 없는 에러 - {}: {}",
+            throwable.getClass().getSimpleName(), throwable.getMessage());
+        return new CustomException(ErrorCode.AI_CHAT_SERVICE_ERROR);
+    }
+
+    /**
+     * 네트워크 또는 타임아웃 에러인지 확인
+     */
+    private boolean isNetworkOrTimeoutError(Throwable throwable) {
+        if (throwable instanceof ConnectException ||
+            throwable instanceof ConnectTimeoutException ||
+            throwable instanceof SocketTimeoutException ||
+            throwable instanceof TimeoutException) {
+            return true;
+        }
+        if (throwable instanceof WebClientRequestException requestEx) {
+            Throwable cause = requestEx.getCause();
+            return cause instanceof ConnectException ||
+                   cause instanceof ConnectTimeoutException ||
+                   cause instanceof SocketTimeoutException ||
+                   cause instanceof TimeoutException;
+        }
+        return false;
+    }
+
+    /**
+     * AI 서비스 에러 응답 body 로깅
+     */
+    private void logErrorResponseBody(WebClientResponseException ex) {
+        try {
+            String responseBody = ex.getResponseBodyAsString();
+            if (responseBody != null && !responseBody.isBlank()) {
+                log.error("AI Chat 서비스 에러 응답 body: {}", responseBody);
+            }
+        } catch (Exception e) {
+            log.debug("AI Chat 서비스 에러 응답 body 파싱 실패", e);
+        }
+    }
+
+    /**
+     * 로깅용 메시지 truncate (100자)
+     */
+    private String truncateMessage(String message) {
+        if (message == null) return null;
+        return message.length() > 100 ? message.substring(0, 100) + "..." : message;
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/chat/config/AiChatConfig.java
+++ b/src/main/java/com/smartchain/platform/domain/chat/config/AiChatConfig.java
@@ -1,0 +1,58 @@
+package com.smartchain.platform.domain.chat.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+/**
+ * AI Chat API 설정
+ */
+@Configuration
+@ConfigurationProperties(prefix = "ai.chat")
+public class AiChatConfig {
+
+    private String baseUrl = "http://127.0.0.1:8001";
+    private String adminApiKey;
+    private int timeoutSeconds = 30;
+
+    @Bean
+    public WebClient aiChatWebClient() {
+        HttpClient httpClient = HttpClient.create()
+            .responseTimeout(Duration.ofSeconds(timeoutSeconds));
+
+        return WebClient.builder()
+            .baseUrl(baseUrl)
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .build();
+    }
+
+    // Getters and Setters
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getAdminApiKey() {
+        return adminApiKey;
+    }
+
+    public void setAdminApiKey(String adminApiKey) {
+        this.adminApiKey = adminApiKey;
+    }
+
+    public int getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public void setTimeoutSeconds(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/chat/AdminInspectResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/chat/AdminInspectResponse.java
@@ -1,0 +1,16 @@
+package com.smartchain.platform.dto.chat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * AI Chat Admin DB 현황 조회 API 응답 DTO
+ */
+public record AdminInspectResponse(
+    @JsonProperty("total_documents")
+    Integer totalDocuments,     // Vector DB에 저장된 문서 개수
+
+    List<String> samples        // 샘플 데이터 목록
+) {
+}

--- a/src/main/java/com/smartchain/platform/dto/chat/AdminSyncResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/chat/AdminSyncResponse.java
@@ -1,0 +1,10 @@
+package com.smartchain.platform.dto.chat;
+
+/**
+ * AI Chat Admin 동기화 API 응답 DTO
+ */
+public record AdminSyncResponse(
+    String status,      // "accepted" 등
+    String message      // 상태 메시지
+) {
+}

--- a/src/main/java/com/smartchain/platform/dto/chat/ChatMessage.java
+++ b/src/main/java/com/smartchain/platform/dto/chat/ChatMessage.java
@@ -1,0 +1,11 @@
+package com.smartchain.platform.dto.chat;
+
+/**
+ * 채팅 히스토리 메시지 DTO
+ * AI Chat API와 통신 시 이전 대화 기록을 전달하는 데 사용
+ */
+public record ChatMessage(
+    String role,    // "user" 또는 "assistant"
+    String content
+) {
+}

--- a/src/main/java/com/smartchain/platform/dto/chat/ChatRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/chat/ChatRequest.java
@@ -1,0 +1,43 @@
+package com.smartchain.platform.dto.chat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+/**
+ * AI Chat API 요청 DTO
+ */
+public record ChatRequest(
+    @NotBlank(message = "메시지는 필수입니다")
+    String message,
+
+    List<ChatMessage> history,
+
+    String domain,
+
+    @JsonProperty("doc_name")
+    String docName,
+
+    @Min(value = 1, message = "topK는 1 이상이어야 합니다")
+    @Max(value = 30, message = "topK는 30 이하여야 합니다")
+    @JsonProperty("top_k")
+    Integer topK,
+
+    @JsonProperty("session_id")
+    String sessionId
+) {
+    public ChatRequest {
+        if (history == null) {
+            history = List.of();
+        }
+        if (domain == null || domain.isBlank()) {
+            domain = "all";
+        }
+        if (topK == null) {
+            topK = 8;
+        }
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/chat/ChatResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/chat/ChatResponse.java
@@ -1,0 +1,14 @@
+package com.smartchain.platform.dto.chat;
+
+import java.util.List;
+
+/**
+ * AI Chat API 응답 DTO
+ */
+public record ChatResponse(
+    String answer,              // AI가 생성한 최종 답변
+    String confidence,          // 답변 신뢰도: "high", "medium", "low"
+    String notes,               // 비고 (예: "근거 자료 없음")
+    List<SourceItem> sources    // 답변에 사용된 근거 자료 목록
+) {
+}

--- a/src/main/java/com/smartchain/platform/dto/chat/SourceItem.java
+++ b/src/main/java/com/smartchain/platform/dto/chat/SourceItem.java
@@ -1,0 +1,13 @@
+package com.smartchain.platform.dto.chat;
+
+/**
+ * 채팅 응답의 근거 자료 DTO
+ */
+public record SourceItem(
+    String title,           // 문서 제목 또는 파일명
+    String type,            // 자료 유형: "manual", "code", "law"
+    String snippet,         // 실제 참고한 본문 내용 (일부)
+    Double score,           // 검색 유사도 점수 (0.0 ~ 1.0)
+    SourceLocation loc      // 위치 정보 (page, lineStart)
+) {
+}

--- a/src/main/java/com/smartchain/platform/dto/chat/SourceLocation.java
+++ b/src/main/java/com/smartchain/platform/dto/chat/SourceLocation.java
@@ -1,0 +1,14 @@
+package com.smartchain.platform.dto.chat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 근거 자료 위치 정보 DTO
+ */
+public record SourceLocation(
+    Integer page,
+
+    @JsonProperty("line_start")
+    Integer lineStart
+) {
+}

--- a/src/main/java/com/smartchain/platform/global/config/SecurityConfig.java
+++ b/src/main/java/com/smartchain/platform/global/config/SecurityConfig.java
@@ -51,8 +51,11 @@ public class SecurityConfig {
                                 "/api/v1/campaigns/**",
                                 "/api/v1/domains/**",
                                 "/api/v1/management/**",
-                                "/api/v1/jobs/**"
+                                "/api/v1/jobs/**",
+                                "/api/v1/chat/**"
                         ).hasAnyRole("DRAFTER", "APPROVER", "REVIEWER")
+                        // Admin Chat API는 REVIEWER만 접근 가능
+                        .requestMatchers("/api/v1/admin/chat/**").hasRole("REVIEWER")
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -97,7 +97,12 @@ public enum ErrorCode {
     AI_INVALID_VERDICT(HttpStatus.BAD_GATEWAY, "AI005", "AI 서비스의 verdict 값이 유효하지 않습니다"),
     AI_INVALID_RISK_LEVEL(HttpStatus.BAD_GATEWAY, "AI006", "AI 서비스의 riskLevel 값이 유효하지 않습니다"),
     AI_BAD_REQUEST(HttpStatus.BAD_REQUEST, "AI007", "AI 서비스 요청 파라미터가 올바르지 않습니다"),
-    AI_MISSING_REQUIRED_SLOTS(HttpStatus.UNPROCESSABLE_ENTITY, "AI008", "필수 슬롯에 해당하는 파일이 제출되지 않았습니다");
+    AI_MISSING_REQUIRED_SLOTS(HttpStatus.UNPROCESSABLE_ENTITY, "AI008", "필수 슬롯에 해당하는 파일이 제출되지 않았습니다"),
+
+    // AI Chat Service
+    AI_CHAT_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT001", "AI 채팅 서비스 오류가 발생했습니다"),
+    AI_CHAT_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "CHAT002", "AI 채팅 서비스 응답 시간이 초과되었습니다"),
+    AI_CHAT_INVALID_DOMAIN(HttpStatus.BAD_REQUEST, "CHAT003", "유효하지 않은 도메인입니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -78,6 +78,10 @@ ai:
     url: http://127.0.0.1:8000
     timeout-seconds: 180
     max-retry: 3
+  chat:
+    base-url: http://127.0.0.1:8001
+    admin-api-key: ${AI_CHAT_ADMIN_KEY:test-key}
+    timeout-seconds: 30
   slots:
     # 슬롯 정의: docs/API_CONTRACT_SSOT.md §8.6 기준
     domains:
@@ -211,6 +215,13 @@ azure:
 logging:
   level:
     com.smartchain.platform: INFO
+
+# AI Chat API 설정 (dev)
+ai:
+  chat:
+    base-url: ${AI_CHAT_URL:http://127.0.0.1:8001}
+    admin-api-key: ${AI_CHAT_ADMIN_KEY}
+    timeout-seconds: 30
 
 # 이메일 설정 (SMTP)
 spring.mail:


### PR DESCRIPTION
## Summary
- AI Chatbot API 연동을 위한 DTO 7개 생성 (ChatRequest, ChatMessage, ChatResponse, SourceItem, SourceLocation, AdminSyncResponse, AdminInspectResponse)
- ErrorCode 3개 추가 (AI_CHAT_SERVICE_ERROR, AI_CHAT_TIMEOUT, AI_CHAT_INVALID_DOMAIN)
- SecurityConfig에 채팅 API 경로 설정 추가
- application.yaml에 ai.chat 설정 추가 (local, dev 프로필)
- AiChatConfig 및 AiChatApiClient 구현 (WebClient 기반)

## Test plan
- [x] `./gradlew build` 성공 확인
- [ ] Issue #141 (비즈니스 로직) 구현 후 통합 테스트

## Related Issue
Closes #140

## Changes
| 파일 | 설명 |
|------|------|
| `dto/chat/*.java` | 7개 DTO record 생성 |
| `domain/chat/config/AiChatConfig.java` | WebClient 설정 |
| `domain/chat/client/AiChatApiClient.java` | AI Chat API 호출 클라이언트 |
| `global/error/ErrorCode.java` | 3개 에러코드 추가 |
| `global/config/SecurityConfig.java` | 채팅 API 경로 권한 설정 |
| `application.yaml` | ai.chat 설정 (local, dev) |