### PR TITLE
feat(data): drafter1 계정에 SAFETY 도메인 기안자 권한 추가

### DIFF
--- a/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
+++ b/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
@@ -193,10 +193,11 @@ public class DataInitializer implements CommandLineRunner {
         userDomainRoleRepository.save(UserDomainRole.builder().user(reviewerSafety).domain(safetyDomain).role(reviewerRole).build());
         userDomainRoleRepository.save(UserDomainRole.builder().user(reviewerCompliance).domain(complianceDomain).role(reviewerRole).build());
 
-        // 테크파트너: ESG(결재자+기안자) + COMPLIANCE(기안자만)
+        // 테크파트너: ESG(결재자+기안자) + COMPLIANCE(기안자만) + SAFETY(drafter1만)
         userDomainRoleRepository.save(UserDomainRole.builder().user(approver1).domain(esgDomain).role(approverRole).build());
         userDomainRoleRepository.save(UserDomainRole.builder().user(drafter1).domain(esgDomain).role(drafterRole).build());
         userDomainRoleRepository.save(UserDomainRole.builder().user(drafter1).domain(complianceDomain).role(drafterRole).build());
+        userDomainRoleRepository.save(UserDomainRole.builder().user(drafter1).domain(safetyDomain).role(drafterRole).build());
         userDomainRoleRepository.save(UserDomainRole.builder().user(drafter2).domain(esgDomain).role(drafterRole).build());
 
         // 그린매뉴팩처링: ESG(결재자+기안자) + SAFETY(기안자만)
@@ -668,9 +669,10 @@ public class DataInitializer implements CommandLineRunner {
         log.info("  안전건설:   approver@safebuild.co.kr (SAFETY)");
         log.info("");
         log.info("[협력사 기안자 - DRAFTER]");
-        log.info("  테크파트너: drafter1@techpartner.co.kr, drafter2@techpartner.co.kr");
-        log.info("  그린매뉴:   drafter@greenmanu.co.kr");
-        log.info("  안전건설:   drafter@safebuild.co.kr");
+        log.info("  테크파트너: drafter1@techpartner.co.kr (ESG, COMPLIANCE, SAFETY)");
+        log.info("              drafter2@techpartner.co.kr (ESG)");
+        log.info("  그린매뉴:   drafter@greenmanu.co.kr (ESG, SAFETY)");
+        log.info("  안전건설:   drafter@safebuild.co.kr (SAFETY)");
         log.info("");
         log.info("[게스트 - GUEST]");
         log.info("  정밀부품:   newbie1@precision.co.kr, newbie2@precision.co.kr");


### PR DESCRIPTION
## 변경 요약
테스트 계정 `drafter1@techpartner.co.kr`에 SAFETY 도메인 DRAFTER 권한 추가
- 기존: ESG, COMPLIANCE
- 변경: ESG, COMPLIANCE, **SAFETY**

## 관련 이슈
- #145 (AI Preview API 테스트를 위한 테스트 계정 권한 확장)

## 테스트 방법
1. DB 초기화 후 서버 재시작 (`./gradlew bootRun`)
2. `drafter1@techpartner.co.kr` / `Test1234!`로 로그인
3. 안전보건(SAFETY) 도메인 진단 목록 접근 가능 확인
4. 안전보건 도메인 신규 진단 작성 가능 확인

## 명세 준수 체크
- [x] DataInitializer 기존 패턴 준수
- [x] 로그 출력 형식 일관성 유지
- [x] 기존 테스트 계정 권한 변경 없음

## 리뷰 포인트
- 테스트 데이터 변경으로, 기존 DB가 있는 환경에서는 초기화 필요

## TODO / 질문
- 기존 데이터가 있는 환경에서는 SQL 직접 실행 또는 DB 초기화 필요
```sql
INSERT INTO user_domain_roles (user_id, domain_id, role_id)
SELECT u.user_id, d.domain_id, r.role_id
FROM "user" u, domain d, role r
WHERE u.email = 'drafter1@techpartner.co.kr'
  AND d.code = 'SAFETY'
  AND r.code = 'DRAFTER';
```