### PR TITLE
feat(ai): AI Run API slotHints 전달 및 DTO 필드 확장

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/ai/controller/AiAnalysisController.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/controller/AiAnalysisController.java
@@ -57,10 +57,12 @@ public class AiAnalysisController {
         @PathVariable Long diagnosticId,
         @RequestBody(required = false) AiAnalysisRequest request
     ) {
-        log.info("AI 분석 요청 - diagnosticId: {}", diagnosticId);
+        log.info("AI 분석 요청 - diagnosticId: {}, slotHints: {}", diagnosticId,
+            request != null && request.slotHints() != null ? request.slotHints().size() : 0);
 
-        // 비동기로 분석 시작
-        aiAnalysisAsyncService.submitAsync(diagnosticId);
+        // 비동기로 분석 시작 (프론트에서 보낸 slotHints 전달)
+        aiAnalysisAsyncService.submitAsync(diagnosticId,
+            request != null ? request.slotHints() : null);
 
         Map<String, Object> response = Map.of(
             "diagnosticId", diagnosticId,

--- a/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisAsyncService.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisAsyncService.java
@@ -1,9 +1,12 @@
 package com.smartchain.platform.domain.ai.service;
 
+import com.smartchain.platform.dto.ai.run.SlotHint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class AiAnalysisAsyncService {
@@ -17,9 +20,9 @@ public class AiAnalysisAsyncService {
     }
 
     @Async
-    public void submitAsync(Long diagnosticId) {
+    public void submitAsync(Long diagnosticId, List<SlotHint> slotHints) {
         try {
-            aiAnalysisService.submit(diagnosticId);
+            aiAnalysisService.submit(diagnosticId, slotHints);
         } catch (Exception e) {
             log.error("AI 분석 실패 - diagnosticId: {}", diagnosticId, e);
         }

--- a/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
@@ -25,7 +25,9 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * AI 분석 서비스
@@ -96,7 +98,7 @@ public class AiAnalysisService {
      * Submit 호출 - 전체 검증 및 판정 (동기)
      */
     @Transactional
-    public AiAnalysisResult submit(Long diagnosticId) {
+    public AiAnalysisResult submit(Long diagnosticId, List<SlotHint> frontendSlotHints) {
         Diagnostic diagnostic = getDiagnostic(diagnosticId);
         String domainCode = getDomainCode(diagnostic);
 
@@ -115,13 +117,8 @@ public class AiAnalysisService {
             ))
             .toList();
 
-        // SlotHint 생성 (파일명 기반 자동 매핑)
-        List<SlotHint> slotHints = evidenceFiles.stream()
-            .map(ef -> new SlotHint(
-                ef.getResultFileId().toString(),
-                guessSlotName(ef.getOriginalFileName(), domainCode)
-            ))
-            .toList();
+        // SlotHint: 프론트에서 보낸 매핑 우선, 없는 파일만 파일명 기반 추측
+        List<SlotHint> slotHints = buildSlotHints(evidenceFiles, frontendSlotHints, domainCode);
 
         // TODO: 필수 슬롯 검증 임시 비활성화 (테스트용)
         List<String> missingRequiredSlots = validateRequiredSlots(slotHints, domainCode);
@@ -219,6 +216,41 @@ public class AiAnalysisService {
             ef.getFilePath(),
             ef.getOriginalFileName()
         );
+    }
+
+    /**
+     * 프론트에서 보낸 slotHints를 우선 사용하고, 매핑이 없는 파일만 파일명 기반 추측
+     */
+    private List<SlotHint> buildSlotHints(List<EvidenceFile> evidenceFiles,
+                                          List<SlotHint> frontendSlotHints,
+                                          String domainCode) {
+        // 프론트 매핑이 없으면 전부 파일명 기반 추측
+        if (frontendSlotHints == null || frontendSlotHints.isEmpty()) {
+            return evidenceFiles.stream()
+                .map(ef -> new SlotHint(
+                    ef.getResultFileId().toString(),
+                    guessSlotName(ef.getOriginalFileName(), domainCode)
+                ))
+                .toList();
+        }
+
+        // 프론트 매핑을 fileId 기준으로 인덱싱
+        Map<String, String> frontendMapping = frontendSlotHints.stream()
+            .collect(Collectors.toMap(
+                SlotHint::fileId,
+                SlotHint::slotName,
+                (a, b) -> b  // 중복 시 후자 우선
+            ));
+
+        // 프론트 매핑 우선, 없는 파일만 fallback
+        return evidenceFiles.stream()
+            .map(ef -> {
+                String fileId = ef.getResultFileId().toString();
+                String slotName = frontendMapping.getOrDefault(fileId,
+                    guessSlotName(ef.getOriginalFileName(), domainCode));
+                return new SlotHint(fileId, slotName);
+            })
+            .toList();
     }
 
     private String guessSlotName(String fileName, String domainCode) {

--- a/src/main/java/com/smartchain/platform/domain/file/service/FileService.java
+++ b/src/main/java/com/smartchain/platform/domain/file/service/FileService.java
@@ -20,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.Duration;
@@ -97,8 +99,17 @@ public class FileService {
 
         AsyncJob savedJob = asyncJobRepository.save(parsingJob);
 
-        // 비동기 파싱 실행
-        fileParsingJobService.executeParsingAsync(savedJob.getJobId());
+        // 트랜잭션 커밋 후 비동기 파싱 실행 (커밋 전에 실행하면 DB에서 job을 찾을 수 없음)
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    fileParsingJobService.executeParsingAsync(savedJob.getJobId());
+                }
+            });
+        } else {
+            fileParsingJobService.executeParsingAsync(savedJob.getJobId());
+        }
 
         log.info("File uploaded: fileId={}, diagnosticId={}, uploadedBy={}",
                 savedFile.getResultFileId(), diagnosticId, userId);

--- a/src/main/java/com/smartchain/platform/domain/job/service/AiAnalysisJobService.java
+++ b/src/main/java/com/smartchain/platform/domain/job/service/AiAnalysisJobService.java
@@ -98,7 +98,7 @@ public class AiAnalysisJobService {
             job.updateProgress(60, "AI 분석 수행 중");
             asyncJobRepository.save(job);
 
-            aiAnalysisService.submit(job.getTargetId());
+            aiAnalysisService.submit(job.getTargetId(), null);
 
             job.updateProgress(90, "결과 정리 중");
             asyncJobRepository.save(job);

--- a/src/main/java/com/smartchain/platform/domain/job/service/FileParsingJobService.java
+++ b/src/main/java/com/smartchain/platform/domain/job/service/FileParsingJobService.java
@@ -1,15 +1,10 @@
 package com.smartchain.platform.domain.job.service;
 
-import com.smartchain.platform.domain.ai.client.AiRunApiClient;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.evidence.entity.EvidenceFile;
 import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository;
 import com.smartchain.platform.domain.job.entity.AsyncJob;
 import com.smartchain.platform.domain.job.repository.AsyncJobRepository;
-import com.smartchain.platform.dto.ai.run.FileInfo;
-import com.smartchain.platform.dto.ai.run.RunPreviewRequest;
-import com.smartchain.platform.dto.ai.run.RunPreviewResponse;
-import com.smartchain.platform.dto.ai.run.SlotHint;
 import com.smartchain.platform.global.enums.PipelinePhase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,9 +12,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -28,7 +21,6 @@ public class FileParsingJobService {
 
     private final AsyncJobRepository asyncJobRepository;
     private final EvidenceFileRepository evidenceFileRepository;
-    private final AiRunApiClient aiRunApiClient;
 
     @Async("fileParsingExecutor")
     @Transactional
@@ -55,56 +47,15 @@ public class FileParsingJobService {
             evidenceFileRepository.save(file);
             log.info("File parsing started: jobId={}, fileId={}", jobId, file.getResultFileId());
 
-            // Phase 1: OCR
-            job.advancePhase(PipelinePhase.OCR, 25, "파일 OCR 처리 중");
+            // Phase 1: 파일 검증
+            job.advancePhase(PipelinePhase.VALIDATION, 50, "파일 검증 중");
             asyncJobRepository.save(job);
 
-            // AI preview API 호출 (파일 파싱)
             Diagnostic diagnostic = file.getDiagnostic();
             Long diagnosticId = diagnostic != null ? diagnostic.getDiagnosticId() : null;
 
-            String domainCode = "esg";
-            String periodStart = null;
-            String periodEnd = null;
-            if (diagnostic != null) {
-                if (diagnostic.getDomain() != null) {
-                    domainCode = diagnostic.getDomain().getCode().toLowerCase();
-                }
-                if (diagnostic.getPeriodStartDate() != null) {
-                    periodStart = diagnostic.getPeriodStartDate().format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                }
-                if (diagnostic.getPeriodEndDate() != null) {
-                    periodEnd = diagnostic.getPeriodEndDate().format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                }
-            }
-
-            RunPreviewRequest previewRequest = new RunPreviewRequest(
-                    domainCode,
-                    periodStart,
-                    periodEnd,
-                    null,  // packageId - 첫 호출이므로 null
-                    List.of(new FileInfo(
-                            file.getResultFileId().toString(),
-                            file.getFilePath(),
-                            file.getOriginalFileName()
-                    ))
-            );
-
-            RunPreviewResponse previewResponse = aiRunApiClient.previewSync(previewRequest);
-
-            // Phase 2: VALIDATION
-            job.advancePhase(PipelinePhase.VALIDATION, 50, "파싱 결과 검증 중");
-            asyncJobRepository.save(job);
-
-            // Phase 3: METRICS
-            job.advancePhase(PipelinePhase.METRICS, 75, "데이터 추출 완료");
-            asyncJobRepository.save(job);
-
-            // 파싱 결과를 EvidenceFile에 반영
-            String parsedText = extractSlotInfo(previewResponse);
-            String metaInfo = buildMetaInfo(previewResponse);
-
-            file.completeParsing(null, parsedText, metaInfo);
+            // 파일 업로드 완료 처리 (AI preview는 프론트엔드에서 수동 호출)
+            file.completeParsing(null, null, null);
             evidenceFileRepository.save(file);
 
             // 완료
@@ -126,20 +77,4 @@ public class FileParsingJobService {
         return CompletableFuture.completedFuture(null);
     }
 
-    private String extractSlotInfo(RunPreviewResponse response) {
-        if (response == null || response.slotHint() == null) return null;
-        return response.slotHint().stream()
-                .map(SlotHint::slotName)
-                .collect(Collectors.joining(", "));
-    }
-
-    private String buildMetaInfo(RunPreviewResponse response) {
-        if (response == null) return null;
-        int slotCount = response.slotHint() != null ? response.slotHint().size() : 0;
-        int missingCount = response.missingRequiredSlots() != null ? response.missingRequiredSlots().size() : 0;
-        return "{\"packageId\":\"" + response.packageId()
-                + "\",\"slotHintCount\":" + slotCount
-                + ",\"missingRequiredSlots\":" + missingCount
-                + "}";
-    }
 }

--- a/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisRequest.java
@@ -1,5 +1,7 @@
 package com.smartchain.platform.dto.ai;
 
+import com.smartchain.platform.dto.ai.run.SlotHint;
+
 import java.util.List;
 import java.util.Map;
 
@@ -8,5 +10,6 @@ import java.util.Map;
  */
 public record AiAnalysisRequest(
     List<Long> fileIds,
+    List<SlotHint> slotHints,
     Map<String, Object> options
 ) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/SlotHint.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/SlotHint.java
@@ -1,15 +1,29 @@
 package com.smartchain.platform.dto.ai.run;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * AI Run API 슬롯 힌트 DTO
  * 파일과 슬롯 매핑 정보
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SlotHint(
     @JsonProperty("file_id")
     String fileId,
 
     @JsonProperty("slot_name")
-    String slotName
-) {}
+    String slotName,
+
+    @JsonProperty("display_name")
+    String displayName,
+
+    Double confidence,
+
+    @JsonProperty("match_reason")
+    String matchReason
+) {
+    public SlotHint(String fileId, String slotName) {
+        this(fileId, slotName, null, null, null);
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/SlotStatus.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/SlotStatus.java
@@ -9,5 +9,12 @@ public record SlotStatus(
     @JsonProperty("slot_name")
     String slotName,
 
+    @JsonProperty("display_name")
+    String displayName,
+
     String status  // SUBMITTED, MISSING
-) {}
+) {
+    public SlotStatus(String slotName, String status) {
+        this(slotName, "", status);
+    }
+}

--- a/src/test/java/com/smartchain/platform/domain/ai/service/AiAnalysisServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/ai/service/AiAnalysisServiceTest.java
@@ -76,7 +76,7 @@ class AiAnalysisServiceTest {
             when(diagnosticRepository.findById(diagnosticId)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> aiAnalysisService.submit(diagnosticId))
+            assertThatThrownBy(() -> aiAnalysisService.submit(diagnosticId, null))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -97,7 +97,7 @@ class AiAnalysisServiceTest {
             when(evidenceFileRepository.findByDiagnosticId(diagnosticId)).thenReturn(List.of());
 
             // when & then
-            assertThatThrownBy(() -> aiAnalysisService.submit(diagnosticId))
+            assertThatThrownBy(() -> aiAnalysisService.submit(diagnosticId, null))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -124,7 +124,7 @@ class AiAnalysisServiceTest {
             ));
 
             // when & then
-            assertThatThrownBy(() -> aiAnalysisService.submit(diagnosticId))
+            assertThatThrownBy(() -> aiAnalysisService.submit(diagnosticId, null))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -174,7 +174,7 @@ class AiAnalysisServiceTest {
             when(resultRepository.save(any(AiAnalysisResult.class))).thenReturn(savedResult);
 
             // when
-            AiAnalysisResult result = aiAnalysisService.submit(diagnosticId);
+            AiAnalysisResult result = aiAnalysisService.submit(diagnosticId, null);
 
             // then
             assertThat(result).isNotNull();
@@ -213,7 +213,7 @@ class AiAnalysisServiceTest {
                 .thenThrow(new CustomException(ErrorCode.AI_SERVICE_ERROR));
 
             // when & then
-            assertThatThrownBy(() -> aiAnalysisService.submit(diagnosticId))
+            assertThatThrownBy(() -> aiAnalysisService.submit(diagnosticId, null))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;


### PR DESCRIPTION
## 변경 요약
- **Submit API**: 프론트엔드에서 보낸 `slotHints`를 받아서 AI 서버에 전달
- **SlotHint DTO**: `displayName`, `confidence`, `matchReason` 필드 추가
- **SlotStatus DTO**: `displayName` 필드 추가
- **FileService**: 트랜잭션 커밋 후 비동기 파싱 실행 (타이밍 버그 수정)
- **FileParsingJobService**: AI preview 호출 로직 간소화

## 관련 이슈
- #145 (AI Preview API - fileIds 기반 슬롯 상태 재계산 필요)

## 테스트 방법
1. 서버 재시작
2. 진단 상세 화면에서 파일 업로드
3. Submit API 호출 시 `slotHints` 포함하여 요청
```json
POST /api/v1/ai/run/diagnostics/{id}/submit
{
  "slotHints": [
    { "file_id": "1", "slot_name": "esg.ghg.report" }
  ]
}
```
4. 파일 업로드 후 비동기 파싱이 정상 시작되는지 확인

## 명세 준수 체크
- [x] AI Run API 명세 준수 (slotHints 파라미터)
- [x] DTO 필드 JSON snake_case 변환 (@JsonProperty)
- [x] 기존 API 하위 호환성 유지 (slotHints 없이도 동작)
- [x] 테스트 코드 수정 완료

## 리뷰 포인트
1. `buildSlotHints()` 메서드: 프론트 매핑 우선, 없는 파일만 파일명 기반 추측
2. `FileService`: TransactionSynchronization을 사용한 트랜잭션 커밋 후 실행

## TODO / 질문
- [ ] Preview API도 동일하게 프론트 slotHints 반영 필요한지 확인 (#145 관련)
- 현재는 Submit만 slotHints를 받고, Preview는 AI 서버 응답 그대로 반환