### PR TITLE
feat(ai): AI 분석 결과에 슬롯 display_name 포함

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/ai/config/SlotConfigProperties.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/config/SlotConfigProperties.java
@@ -22,6 +22,7 @@ public class SlotConfigProperties {
     @Setter
     public static class SlotDefinition {
         private String name;
+        private String displayName;  // 한글 표시명
         private List<String> keywords = new ArrayList<>();
         private boolean required;
     }
@@ -49,5 +50,16 @@ public class SlotConfigProperties {
         }
 
         return domainCode.toLowerCase() + ".other";
+    }
+
+    /**
+     * 슬롯명으로 표시명 조회
+     */
+    public String getDisplayName(String slotName, String domainCode) {
+        return getSlotsForDomain(domainCode).stream()
+            .filter(s -> s.getName().equals(slotName))
+            .findFirst()
+            .map(SlotDefinition::getDisplayName)
+            .orElse(slotName);  // displayName이 없으면 slotName 반환
     }
 }

--- a/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
@@ -145,8 +145,53 @@ public class AiAnalysisService {
         // AI API 호출
         RunSubmitResponse response = aiRunApiClient.submitSync(request);
 
+        // slotResults에 displayName 매핑
+        RunSubmitResponse enrichedResponse = enrichWithDisplayNames(response, slotHints, domainCode);
+
         // 결과 저장
-        return saveAnalysisResult(diagnostic, domainCode, response);
+        return saveAnalysisResult(diagnostic, domainCode, enrichedResponse);
+    }
+
+    /**
+     * AI 응답의 slotResults에 displayName 추가
+     * 프론트에서 보낸 slotHints의 displayName 우선, 없으면 설정에서 조회
+     */
+    private RunSubmitResponse enrichWithDisplayNames(RunSubmitResponse response,
+                                                      List<SlotHint> slotHints,
+                                                      String domainCode) {
+        if (response.slotResults() == null || response.slotResults().isEmpty()) {
+            return response;
+        }
+
+        // 프론트에서 보낸 displayName 매핑 (slotName -> displayName)
+        Map<String, String> frontendDisplayNames = slotHints.stream()
+            .filter(h -> h.displayName() != null && !h.displayName().isBlank())
+            .collect(Collectors.toMap(
+                SlotHint::slotName,
+                SlotHint::displayName,
+                (a, b) -> a  // 중복 시 첫 번째 우선
+            ));
+
+        // slotResults에 displayName 추가
+        List<SlotResult> enrichedResults = response.slotResults().stream()
+            .map(result -> {
+                String displayName = frontendDisplayNames.getOrDefault(
+                    result.slotName(),
+                    slotConfigProperties.getDisplayName(result.slotName(), domainCode)
+                );
+                return result.withDisplayName(displayName);
+            })
+            .toList();
+
+        return new RunSubmitResponse(
+            response.packageId(),
+            response.riskLevel(),
+            response.verdict(),
+            response.why(),
+            enrichedResults,
+            response.clarifications(),
+            response.extras()
+        );
     }
 
     /**

--- a/src/main/java/com/smartchain/platform/dto/ai/run/SlotResult.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/SlotResult.java
@@ -11,6 +11,9 @@ public record SlotResult(
     @JsonProperty("slot_name")
     String slotName,
 
+    @JsonProperty("display_name")
+    String displayName,
+
     String verdict,  // PASS, NEED_CLARIFY, NEED_FIX
 
     List<String> reasons,
@@ -22,4 +25,19 @@ public record SlotResult(
     List<String> fileNames,
 
     Map<String, String> extras
-) {}
+) {
+    /**
+     * displayName 없이 생성하는 생성자 (AI 서버 응답 역직렬화용)
+     */
+    public SlotResult(String slotName, String verdict, List<String> reasons,
+                      List<String> fileIds, List<String> fileNames, Map<String, String> extras) {
+        this(slotName, null, verdict, reasons, fileIds, fileNames, extras);
+    }
+
+    /**
+     * displayName을 추가한 새 SlotResult 반환
+     */
+    public SlotResult withDisplayName(String displayName) {
+        return new SlotResult(slotName, displayName, verdict, reasons, fileIds, fileNames, extras);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,97 +88,127 @@ ai:
       # ESG 도메인 (15개 슬롯, 필수 4개)
       esg:
         - name: esg.energy.electricity.usage
+          display-name: 전기 사용량
           keywords: [전기, electricity, 전력사용, 전기사용, 전력량, kwh]
           required: true
         - name: esg.energy.electricity.bill
+          display-name: 전기 고지서
           keywords: [전기고지서, 전기요금, electricity bill, 전기청구]
           required: false
         - name: esg.energy.gas.usage
+          display-name: 가스 사용량
           keywords: [가스, gas, 도시가스, 가스사용, 가스량]
           required: true
         - name: esg.energy.gas.bill
+          display-name: 가스 고지서
           keywords: [가스고지서, 가스요금, gas bill, 가스청구]
           required: false
         - name: esg.energy.water.usage
+          display-name: 용수 사용량
           keywords: [수도, water, 용수, 수도사용, 용수량]
           required: false
         - name: esg.energy.water.bill
+          display-name: 수도 고지서
           keywords: [수도고지서, 수도요금, water bill, 수도청구]
           required: false
         - name: esg.energy.ghg.evidence
+          display-name: 온실가스 배출 증빙
           keywords: [ghg, 온실가스, greenhouse, 탄소, carbon, 배출량]
           required: false
         - name: esg.hazmat.msds
+          display-name: MSDS (물질안전보건자료)
           keywords: [msds, sds, 물질안전, 유해물질, 화학물질, hazmat]
           required: true
         - name: esg.hazmat.inventory
+          display-name: 유해물질 목록
           keywords: [유해물질목록, 화학물질목록, hazmat inventory, 물질목록]
           required: false
         - name: esg.hazmat.disposal.list
+          display-name: 폐기물 처리 목록
           keywords: [폐기목록, 처리목록, disposal list, 폐기물]
           required: false
         - name: esg.hazmat.disposal.evidence
+          display-name: 폐기물 처리 증빙
           keywords: [폐기증빙, 처리증빙, disposal evidence, 폐기확인]
           required: false
         - name: esg.ethics.code
+          display-name: 윤리강령
           keywords: [윤리강령, 행동강령, ethics, code of conduct, 윤리규정]
           required: true
         - name: esg.ethics.distribution.log
+          display-name: 윤리강령 배포 확인
           keywords: [배포확인, 수신확인, distribution, 서명명단]
           required: false
         - name: esg.ethics.pledge
+          display-name: 윤리 서약서
           keywords: [서약서, pledge, 서약, 윤리서약]
           required: false
         - name: esg.ethics.poster.image
+          display-name: 윤리 포스터
           keywords: [포스터, poster, 윤리포스터, 게시물]
           required: false
       # Safety 도메인 (8개 슬롯, 필수 4개)
       safety:
         - name: safety.education.status
+          display-name: 안전교육 이수 현황
           keywords: [교육이수, 안전교육, education status, 교육현황, 수료]
           required: true
         - name: safety.fire.inspection
+          display-name: 소방점검 결과
           keywords: [소방점검, fire inspection, 소화기, 방화, 소방]
           required: true
         - name: safety.risk.assessment
+          display-name: 위험성 평가서
           keywords: [위험성평가, risk assessment, 위험평가, 리스크]
           required: true
         - name: safety.management.system
+          display-name: 안전보건 관리체계
           keywords: [안전보건관리, management system, 안전매뉴얼, 관리체계]
           required: true
         - name: safety.site.photos
+          display-name: 현장 사진
           keywords: [현장사진, site photo, 현장, 사진, image]
           required: false
         - name: safety.education.attendance
+          display-name: 교육 출석부
           keywords: [출석부, attendance, 교육출석, 참석명단]
           required: false
         - name: safety.education.photo
+          display-name: 교육 사진
           keywords: [교육사진, education photo, 교육일사진]
           required: false
         - name: safety.tbm
+          display-name: TBM (작업전 안전회의)
           keywords: [tbm, toolbox, 작업전회의, 안전회의, 작업전미팅]
           required: false
       # Compliance 도메인 (7개 슬롯, 필수 3개)
       compliance:
         - name: compliance.contract.sample
+          display-name: 표준 계약서
           keywords: [표준계약, 하도급계약, contract sample, 근로계약, 계약서]
           required: true
         - name: compliance.education.privacy
+          display-name: 개인정보 보호교육
           keywords: [개인정보교육, privacy education, 개인정보보호, 정보보호교육]
           required: true
         - name: compliance.fair.trade
+          display-name: 공정거래 자율점검
           keywords: [공정거래, fair trade, 자율점검, 공정거래점검]
           required: true
         - name: compliance.ethics.report
+          display-name: 윤리신고 현황
           keywords: [내부신고, ethics report, 윤리신고, 신고현황]
           required: false
         - name: compliance.education.plan
+          display-name: 법정교육 계획
           keywords: [교육계획, education plan, 법정교육, 교육일정]
           required: false
         - name: compliance.education.attendance
+          display-name: 교육 출석부
           keywords: [출석부, attendance, 교육출석, 참석명단]
           required: false
         - name: compliance.education.photo
+          display-name: 교육 사진
           keywords: [교육사진, education photo, 교육일사진]
           required: false
 


### PR DESCRIPTION
## 변경 요약
프론트엔드에서 보낸 `slotHints[].display_name`을 저장하고, AI 분석 결과 응답의 `slot_results[].display_name`에 포함

**변경 파일:**
- `SlotResult`: `displayName` 필드 추가
- `SlotConfigProperties`: `displayName` 설정 및 조회 메서드 추가
- `AiAnalysisService`: AI 응답에 `displayName` 매핑 로직 추가
- `application.yaml`: 모든 슬롯(30개)에 한글 표시명 설정

## 관련 이슈
- #145 (AI Preview API 개선)

## 테스트 방법
1. 서버 재시작
2. Submit API 호출 시 slotHints에 display_name 포함:
```json
POST /api/v1/ai/run/diagnostics/{id}/submit
{
  "slotHints": [
    { "file_id": "1", "slot_name": "esg.energy.electricity.usage", "display_name": "전기 사용량" }
  ]
}
```
3. Result API 응답 확인:
```json
GET /api/v1/ai/run/diagnostics/{id}/result
{
  "slotResults": [
    { "slot_name": "esg.energy.electricity.usage", "display_name": "전기 사용량", ... }
  ]
}
```

## 명세 준수 체크
- [x] SlotResult DTO에 display_name 필드 추가 (@JsonProperty 적용)
- [x] 프론트 slotHints의 displayName 우선 사용
- [x] 설정 파일 fallback (슬롯별 기본 표시명)
- [x] 기존 API 하위 호환성 유지 (displayName 없어도 동작)

## 리뷰 포인트
1. `enrichWithDisplayNames()`: 프론트 매핑 우선, 없으면 설정에서 조회
2. `SlotResult.withDisplayName()`: 불변 객체 패턴 적용
3. 슬롯별 한글 표시명이 적절한지 확인 필요

## TODO / 질문
- [ ] 프론트엔드에서 displayName 미전송 시 설정 파일의 기본값 사용됨
- [ ] 새 슬롯 추가 시 application.yaml에 display-name 필수 설정