### PR TITLE
feat(review): 심사 목록/상세 응답에 diagnostic.title 필드 추가 (#164)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -232,6 +232,7 @@ public class ReviewService {
         DiagnosticDetailInfoDto diagnosticDto = DiagnosticDetailInfoDto.builder()
                 .diagnosticId(review.getDiagnostic().getDiagnosticId())
                 .diagnosticCode(review.getDiagnostic().getDiagnosticCode())
+                .title(review.getDiagnostic().getTitle())
                 .qualitativeData(null)
                 .quantitativeData(null)
                 .aiAnalysis(null)
@@ -452,6 +453,7 @@ public class ReviewService {
         DiagnosticSimpleDto diagnosticDto = DiagnosticSimpleDto.builder()
                 .diagnosticId(review.getDiagnostic().getDiagnosticId())
                 .diagnosticCode(review.getDiagnostic().getDiagnosticCode())
+                .title(review.getDiagnostic().getTitle())
                 .build();
 
         CompanySimpleDto companyDto = CompanySimpleDto.builder()

--- a/src/main/java/com/smartchain/platform/dto/review/common/DiagnosticSimpleDto.java
+++ b/src/main/java/com/smartchain/platform/dto/review/common/DiagnosticSimpleDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class DiagnosticSimpleDto {
     private Long diagnosticId;
     private String diagnosticCode;
+    private String title;
 }

--- a/src/main/java/com/smartchain/platform/dto/review/detail/DiagnosticDetailInfoDto.java
+++ b/src/main/java/com/smartchain/platform/dto/review/detail/DiagnosticDetailInfoDto.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class DiagnosticDetailInfoDto {
     private Long diagnosticId;
     private String diagnosticCode;
+    private String title;
     private Object qualitativeData;      // 정성적 데이터
     private Object quantitativeData;     // 정량적 데이터
     private Object aiAnalysis;           // AI 분석 결과


### PR DESCRIPTION
## 변경 요약
- Review 목록/상세 API 응답의 `diagnostic` 객체에 `title` 필드 추가
- 프론트에서 진단 제목이 `-`로 표시되던 문제 해결

| 파일 | 변경 내용 |
|------|----------|
| `DiagnosticSimpleDto.java` | `title` 필드 추가 (목록 API) |
| `DiagnosticDetailInfoDto.java` | `title` 필드 추가 (상세 API) |
| `ReviewService.java` | 두 매핑 로직에 `.title(review.getDiagnostic().getTitle())` 추가 |

## 관련 이슈
- Closes #164

## 테스트 방법
1. `./gradlew test --tests "*ReviewServiceTest" --tests "*ReviewIntegrationTest"` — 모두 통과 확인
2. `GET /api/v1/reviews` 호출 → 응답 `content[].diagnostic.title` 필드 존재 확인
3. `GET /api/v1/reviews/{id}` 호출 → 응답 `diagnostic.title` 필드 존재 확인
4. title이 null인 진단도 정상 응답되는지 확인 (null로 내려감)

## 명세 준수 체크
- [x] `DiagnosticSimpleDto`에 `title: String` 추가
- [x] `DiagnosticDetailInfoDto`에 `title: String` 추가
- [x] 기존 필드(`diagnosticId`, `diagnosticCode`) 변경 없음 — 하위 호환 유지
- [x] Lombok `@Builder` 패턴 준수

## 리뷰 포인트
- DTO 필드 추가만으로 충분한 변경이며, 기존 응답 구조를 깨뜨리지 않음
- `title`이 null인 경우(레거시 데이터) JSON에서 `null`로 직렬화 — 프론트에서 옵셔널 처리 완료

## TODO / 질문
- [ ] `period` 필드도 Review 응답에 필요한지 FE와 확인 필요
- [ ] 향후 `DiagnosticSimpleDto`에 추가 필드(`status`, `campaignName` 등)가 필요하면 별도 이슈로 추적