### PR TITLE
fix(compliance): 심사 상세 조회 시 AI 분석 결과 슬롯별 상세 포함 (#153)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -1,5 +1,7 @@
 package com.smartchain.platform.domain.review.service;
 
+import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
+import com.smartchain.platform.domain.ai.repository.AiAnalysisResultRepository;
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
@@ -8,6 +10,7 @@ import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.domain.user.repository.CompanyRepository;
 import com.smartchain.platform.domain.user.repository.DomainRepository;
 import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.dto.ai.AiAnalysisResultDetailResponse;
 import com.smartchain.platform.dto.review.common.*;
 import com.smartchain.platform.dto.review.dashboard.*;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionRequest;
@@ -29,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -40,6 +44,7 @@ public class ReviewService {
     private final UserRepository userRepository;
     private final CompanyRepository companyRepository;
     private final DomainRepository domainRepository;
+    private final AiAnalysisResultRepository aiAnalysisResultRepository;
 
     private static final Map<String, String> RISK_LEVEL_LABEL_MAP = Map.of(
             "HIGH", "고위험군",
@@ -228,14 +233,18 @@ public class ReviewService {
 
         validateDomainReviewerAccess(currentUser, review);
 
+        // AI 분석 결과 조회 (있는 경우에만)
+        Long diagnosticId = review.getDiagnostic().getDiagnosticId();
+        Object aiAnalysisData = fetchAiAnalysisResult(diagnosticId);
+
         // Diagnostic Info
         DiagnosticDetailInfoDto diagnosticDto = DiagnosticDetailInfoDto.builder()
-                .diagnosticId(review.getDiagnostic().getDiagnosticId())
+                .diagnosticId(diagnosticId)
                 .diagnosticCode(review.getDiagnostic().getDiagnosticCode())
                 .title(review.getDiagnostic().getTitle())
                 .qualitativeData(null)
                 .quantitativeData(null)
-                .aiAnalysis(null)
+                .aiAnalysis(aiAnalysisData)
                 .build();
 
         // Company Info
@@ -366,6 +375,19 @@ public class ReviewService {
         if (!user.hasRoleInDomain(domainCode, "REVIEWER")) {
             throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);
         }
+    }
+
+    /**
+     * 진단의 최신 AI 분석 결과를 조회하여 상세 응답으로 반환
+     * 결과가 없으면 null 반환
+     */
+    private Object fetchAiAnalysisResult(Long diagnosticId) {
+        Optional<AiAnalysisResult> latestResult = aiAnalysisResultRepository
+                .findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(diagnosticId);
+
+        return latestResult
+                .map(AiAnalysisResultDetailResponse::from)
+                .orElse(null);
     }
 
     private Page<Review> findReviewsWithDomainFilters(List<Domain> domains, String status, String riskLevel, Long companyId, Pageable pageable) {

--- a/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
@@ -1,5 +1,7 @@
 package com.smartchain.platform.domain.review.service;
 
+import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
+import com.smartchain.platform.domain.ai.repository.AiAnalysisResultRepository;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.review.repository.ReviewRepository;
@@ -11,6 +13,7 @@ import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.domain.user.repository.CompanyRepository;
 import com.smartchain.platform.domain.user.repository.DomainRepository;
 import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.dto.ai.AiAnalysisResultDetailResponse;
 import com.smartchain.platform.dto.review.dashboard.ReviewDashboardResponse;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionRequest;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionResponse;
@@ -60,6 +63,9 @@ class ReviewServiceTest {
 
     @Mock
     private DomainRepository domainRepository;
+
+    @Mock
+    private AiAnalysisResultRepository aiAnalysisResultRepository;
 
     @Mock
     private User reviewerUser;
@@ -401,6 +407,72 @@ class ReviewServiceTest {
                         CustomException ce = (CustomException) ex;
                         assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
                     });
+        }
+
+        @Test
+        @DisplayName("AI 분석 결과가 있는 경우 aiAnalysis 필드에 포함")
+        void getReviewDetail_WithAiAnalysisResult_IncludesSlotResults() {
+            // given
+            String resultJson = """
+                {
+                    "slotResults": [
+                        {"slotName": "compliance.contract.sample", "verdict": "PASS", "reasons": ["검토 완료"]}
+                    ],
+                    "clarifications": [
+                        {"slotName": "compliance.fair.trade", "message": "추가 자료 필요"}
+                    ]
+                }
+                """;
+
+            AiAnalysisResult aiResult = AiAnalysisResult.builder()
+                    .diagnostic(testDiagnostic)
+                    .domainCode("COMPLIANCE")
+                    .packageId("PKG_001")
+                    .riskLevel("MEDIUM")
+                    .verdict("WARN")
+                    .whySummary("일부 항목 보완 필요")
+                    .resultJson(resultJson)
+                    .analyzedAt(LocalDateTime.now())
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(1L)).willReturn(Optional.of(testReview));
+            given(aiAnalysisResultRepository.findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(100L))
+                    .willReturn(Optional.of(aiResult));
+
+            // when
+            ReviewDetailResponse response = reviewService.getReviewDetail(1L, 1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getDiagnostic().getAiAnalysis()).isNotNull();
+
+            // AI 분석 결과가 AiAnalysisResultDetailResponse 타입으로 반환됨
+            AiAnalysisResultDetailResponse aiAnalysis =
+                    (AiAnalysisResultDetailResponse) response.getDiagnostic().getAiAnalysis();
+            assertThat(aiAnalysis.verdict()).isEqualTo("WARN");
+            assertThat(aiAnalysis.riskLevel()).isEqualTo("MEDIUM");
+            assertThat(aiAnalysis.slotResults()).hasSize(1);
+            assertThat(aiAnalysis.slotResults().get(0).slotName()).isEqualTo("compliance.contract.sample");
+            assertThat(aiAnalysis.clarifications()).hasSize(1);
+            assertThat(aiAnalysis.clarifications().get(0).message()).isEqualTo("추가 자료 필요");
+        }
+
+        @Test
+        @DisplayName("AI 분석 결과가 없는 경우 aiAnalysis 필드는 null")
+        void getReviewDetail_WithoutAiAnalysisResult_NullAiAnalysis() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(1L)).willReturn(Optional.of(testReview));
+            given(aiAnalysisResultRepository.findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(100L))
+                    .willReturn(Optional.empty());
+
+            // when
+            ReviewDetailResponse response = reviewService.getReviewDetail(1L, 1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getDiagnostic().getAiAnalysis()).isNull();
         }
     }
 


### PR DESCRIPTION
## 변경 요약
- 심사 상세 조회 API(`GET /api/v1/reviews/{reviewId}`)에서 AI 분석 결과의 `slotResults`, `clarifications` 필드가 누락되던 문제 수정
- `ReviewService`에서 `AiAnalysisResultRepository`를 통해 최신 AI 분석 결과를 조회
- `AiAnalysisResultDetailResponse`를 통해 구조화된 슬롯별 상세 분석 정보 제공

## 관련 이슈
- Closes #153

## 테스트 방법
1. 컴플라이언스 수신자로 로그인
2. AI 분석이 완료된 진단의 심사 상세 페이지 이동
3. `diagnostic.aiAnalysis` 필드에 다음 정보 포함 확인:
   - `slotResults`: 슬롯별 검증 결과 배열
   - `clarifications`: 보완 요청 메시지 배열
   - `verdict`, `riskLevel`, `whySummary`

```bash
# 단위 테스트 실행
./gradlew test --tests "ReviewServiceTest"
```

## 명세 준수 체크
- [x] API Contract SSOT 8.5 `AiAnalysisResultDetailResponse` 스키마 준수
- [x] `slotResults`에 `slotName`, `verdict`, `reasons`, `fileIds`, `fileNames` 포함
- [x] `clarifications`에 `slotName`, `message`, `fileIds` 포함

## 리뷰 포인트
- `fetchAiAnalysisResult()` 메서드에서 `AiAnalysisResultDetailResponse.from()`을 사용해 JSON 파싱 로직 재사용
- AI 분석 결과가 없는 경우 `null` 반환 (프론트에서 optional chaining으로 처리)

## TODO / 질문
- 없음