### PR TITLE
fix(review): 도메인별 심사 승인 폼 분리 (#163)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -59,6 +59,12 @@ public class ReviewService {
             "REVISION_REQUIRED", "보완요청"
     );
 
+    private static final Map<String, List<String>> DOMAIN_CATEGORY_KEYS = Map.of(
+            "ESG", List.of("E", "S", "G"),
+            "SAFETY", List.of(),
+            "COMPLIANCE", List.of()
+    );
+
     /**
      * 진단 현황 대시보드 조회
      * - domainCode가 지정된 경우 해당 도메인만 통계에 포함
@@ -257,6 +263,8 @@ public class ReviewService {
         String domainCode = domain != null ? domain.getCode() : null;
         String domainName = domain != null ? domain.getName() : null;
 
+        List<String> allowedCategoryKeys = getAllowedCategoryKeys(domainCode);
+
         return ReviewDetailResponse.builder()
                 .reviewId(review.getReviewId())
                 .reviewIdLabel("심사 ID: REVIEW-" + String.format("%04d", review.getReviewId()))
@@ -264,6 +272,7 @@ public class ReviewService {
                 .company(companyDto)
                 .domainCode(domainCode)
                 .domainName(domainName)
+                .allowedCategoryKeys(allowedCategoryKeys)
                 .score(review.getScore() != null ? review.getScore() : 0)
                 .riskLevel(riskLevelStr)
                 .riskLevelLabel(riskLevelStr != null ? RISK_LEVEL_LABEL_MAP.get(riskLevelStr) : null)
@@ -295,14 +304,23 @@ public class ReviewService {
             throw new CustomException(ErrorCode.ALREADY_PROCESSED_REVIEW);
         }
 
+        // 도메인별 categoryComments 키 검증
+        String reviewDomainCode = review.getDomain() != null ? review.getDomain().getCode() : null;
+        validateCategoryComments(reviewDomainCode, request.getCategoryComments());
+
         String decision = request.getDecision().toUpperCase();
         String message;
         String nextStep;
 
         if ("APPROVED".equals(decision)) {
-            String commentE = request.getCategoryComments() != null ? request.getCategoryComments().get("E") : null;
-            String commentS = request.getCategoryComments() != null ? request.getCategoryComments().get("S") : null;
-            String commentG = request.getCategoryComments() != null ? request.getCategoryComments().get("G") : null;
+            String commentE = null;
+            String commentS = null;
+            String commentG = null;
+            if ("ESG".equals(reviewDomainCode) && request.getCategoryComments() != null) {
+                commentE = request.getCategoryComments().get("E");
+                commentS = request.getCategoryComments().get("S");
+                commentG = request.getCategoryComments().get("G");
+            }
 
             review.approve(currentUser, request.getComment(), commentE, commentS, commentG);
             review.getDiagnostic().complete();
@@ -356,6 +374,28 @@ public class ReviewService {
             throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);
         }
         return domains;
+    }
+
+    private List<String> getAllowedCategoryKeys(String domainCode) {
+        if (domainCode == null) {
+            return List.of();
+        }
+        return DOMAIN_CATEGORY_KEYS.getOrDefault(domainCode, List.of());
+    }
+
+    private void validateCategoryComments(String domainCode, Map<String, String> categoryComments) {
+        if (categoryComments == null || categoryComments.isEmpty()) {
+            return;
+        }
+        List<String> allowedKeys = getAllowedCategoryKeys(domainCode);
+        if (allowedKeys.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_CATEGORY_FOR_DOMAIN);
+        }
+        for (String key : categoryComments.keySet()) {
+            if (!allowedKeys.contains(key)) {
+                throw new CustomException(ErrorCode.INVALID_CATEGORY_FOR_DOMAIN);
+            }
+        }
     }
 
     private void validateDomainReviewerAccess(User user, Review review) {

--- a/src/main/java/com/smartchain/platform/dto/review/detail/ReviewDetailResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/review/detail/ReviewDetailResponse.java
@@ -19,6 +19,7 @@ public class ReviewDetailResponse {
     private CompanyDetailInfoDto company;        // v3.0: 회사 정보 구조화
     private String domainCode;           // 도메인 코드 (ESG, SAFETY, COMPLIANCE)
     private String domainName;           // 도메인 이름
+    private List<String> allowedCategoryKeys; // 도메인별 허용 카테고리 키 (ESG: [E,S,G], SAFETY/COMPLIANCE: [])
     private int score;                   // v3.0: 점수
     private String riskLevel;            // HIGH, MEDIUM, LOW
     private String riskLevelLabel;

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -80,6 +80,7 @@ public enum ErrorCode {
     DIAGNOSTIC_NOT_APPROVED(HttpStatus.CONFLICT, "AP004", "승인된 진단만 원청에 제출할 수 있습니다"),
     ALREADY_PROCESSED_REVIEW(HttpStatus.CONFLICT, "RV002", "이미 처리된 심사입니다"),
     INVALID_REVIEW_DECISION(HttpStatus.BAD_REQUEST, "RV003", "유효하지 않은 심사 결과입니다"),
+    INVALID_CATEGORY_FOR_DOMAIN(HttpStatus.BAD_REQUEST, "RV004", "해당 도메인에서 허용되지 않는 카테고리입니다"),
     JOB_NOT_RETRYABLE(HttpStatus.BAD_REQUEST, "JOB002", "재시도할 수 없는 작업입니다"),
     JOB_NOT_FAILED(HttpStatus.BAD_REQUEST, "JOB003", "실패한 작업만 재시도할 수 있습니다"),
 

--- a/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
@@ -34,6 +34,7 @@ import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -94,6 +95,12 @@ class ReviewServiceTest {
     @Mock
     private Domain socDomain;
 
+    @Mock
+    private Domain esgDomain;
+
+    @Mock
+    private Domain safetyDomain;
+
     @BeforeEach
     void setUp() {
         lenient().when(reviewerRole.getCode()).thenReturn("REVIEWER");
@@ -107,6 +114,14 @@ class ReviewServiceTest {
         lenient().when(socDomain.getName()).thenReturn("사회");
         lenient().when(socDomain.getDomainId()).thenReturn(2L);
 
+        lenient().when(esgDomain.getCode()).thenReturn("ESG");
+        lenient().when(esgDomain.getName()).thenReturn("ESG 실사");
+        lenient().when(esgDomain.getDomainId()).thenReturn(3L);
+
+        lenient().when(safetyDomain.getCode()).thenReturn("SAFETY");
+        lenient().when(safetyDomain.getName()).thenReturn("안전보건");
+        lenient().when(safetyDomain.getDomainId()).thenReturn(4L);
+
         lenient().when(reviewerUser.getUserId()).thenReturn(1L);
         lenient().when(reviewerUser.getName()).thenReturn("심사자");
         lenient().when(reviewerUser.getEmail()).thenReturn("reviewer@test.com");
@@ -114,6 +129,8 @@ class ReviewServiceTest {
         lenient().when(reviewerUser.getDomainsWithRole("REVIEWER")).thenReturn(List.of(envDomain));
         lenient().when(reviewerUser.hasRoleInDomain("ENV", "REVIEWER")).thenReturn(true);
         lenient().when(reviewerUser.hasRoleInDomain("SOC", "REVIEWER")).thenReturn(false);
+        lenient().when(reviewerUser.hasRoleInDomain("ESG", "REVIEWER")).thenReturn(true);
+        lenient().when(reviewerUser.hasRoleInDomain("SAFETY", "REVIEWER")).thenReturn(true);
 
         lenient().when(guestUser.getUserId()).thenReturn(2L);
         lenient().when(guestUser.getName()).thenReturn("게스트");
@@ -527,6 +544,196 @@ class ReviewServiceTest {
                         CustomException ce = (CustomException) ex;
                         assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.INVALID_DECISION);
                     });
+        }
+    }
+
+    @Nested
+    @DisplayName("도메인별 카테고리 코멘트 검증 테스트")
+    class DomainCategoryValidationTest {
+
+        @Test
+        @DisplayName("SAFETY 도메인에서 ESG 카테고리 코멘트 전송 시 RV004 에러")
+        void processReview_SafetyDomain_WithEsgCategoryComments_ThrowsException() {
+            // given
+            Review safetyReview = mock(Review.class);
+            lenient().when(safetyReview.getDomain()).thenReturn(safetyDomain);
+            lenient().when(safetyReview.isReviewing()).thenReturn(true);
+            lenient().when(safetyReview.getReviewId()).thenReturn(10L);
+
+            ReviewDecisionRequest request = ReviewDecisionRequest.builder()
+                    .decision("APPROVED")
+                    .comment("안전보건 검토 완료")
+                    .categoryComments(Map.of("E", "환경 의견", "S", "사회 의견"))
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(10L)).willReturn(Optional.of(safetyReview));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.processReview(1L, 10L, request))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.INVALID_CATEGORY_FOR_DOMAIN);
+                    });
+        }
+
+        @Test
+        @DisplayName("ESG 도메인에서 유효한 카테고리 코멘트로 승인 성공")
+        void processReview_EsgDomain_WithValidCategoryComments_Success() {
+            // given
+            Review esgReview = mock(Review.class);
+            Diagnostic esgDiagnostic = mock(Diagnostic.class);
+            lenient().when(esgReview.getDomain()).thenReturn(esgDomain);
+            lenient().when(esgReview.isReviewing()).thenReturn(true);
+            lenient().when(esgReview.getReviewId()).thenReturn(20L);
+            lenient().when(esgReview.getDiagnostic()).thenReturn(esgDiagnostic);
+            lenient().when(esgReview.getStatus()).thenReturn(ReviewStatus.APPROVED);
+            lenient().when(esgReview.getProcessedAt()).thenReturn(LocalDateTime.now());
+
+            ReviewDecisionRequest request = ReviewDecisionRequest.builder()
+                    .decision("APPROVED")
+                    .comment("ESG 전체 양호")
+                    .categoryComments(Map.of("E", "환경 우수", "S", "사회 양호", "G", "지배구조 개선 필요"))
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(20L)).willReturn(Optional.of(esgReview));
+
+            // when
+            ReviewDecisionResponse response = reviewService.processReview(1L, 20L, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getStatus()).isEqualTo("APPROVED");
+            verify(esgReview).approve(eq(reviewerUser), eq("ESG 전체 양호"),
+                    eq("환경 우수"), eq("사회 양호"), eq("지배구조 개선 필요"));
+            verify(esgDiagnostic).complete();
+        }
+
+        @Test
+        @DisplayName("ESG 도메인에서 허용되지 않는 카테고리 키 전송 시 RV004 에러")
+        void processReview_EsgDomain_WithInvalidCategoryKey_ThrowsException() {
+            // given
+            Review esgReview = mock(Review.class);
+            lenient().when(esgReview.getDomain()).thenReturn(esgDomain);
+            lenient().when(esgReview.isReviewing()).thenReturn(true);
+            lenient().when(esgReview.getReviewId()).thenReturn(21L);
+
+            ReviewDecisionRequest request = ReviewDecisionRequest.builder()
+                    .decision("APPROVED")
+                    .categoryComments(Map.of("E", "환경", "INVALID_KEY", "잘못된 키"))
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(21L)).willReturn(Optional.of(esgReview));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.processReview(1L, 21L, request))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.INVALID_CATEGORY_FOR_DOMAIN);
+                    });
+        }
+
+        @Test
+        @DisplayName("SAFETY 도메인에서 카테고리 코멘트 없이 승인 성공")
+        void processReview_SafetyDomain_WithoutCategoryComments_Success() {
+            // given
+            Review safetyReview = mock(Review.class);
+            Diagnostic safetyDiagnostic = mock(Diagnostic.class);
+            lenient().when(safetyReview.getDomain()).thenReturn(safetyDomain);
+            lenient().when(safetyReview.isReviewing()).thenReturn(true);
+            lenient().when(safetyReview.getReviewId()).thenReturn(30L);
+            lenient().when(safetyReview.getDiagnostic()).thenReturn(safetyDiagnostic);
+            lenient().when(safetyReview.getStatus()).thenReturn(ReviewStatus.APPROVED);
+            lenient().when(safetyReview.getProcessedAt()).thenReturn(LocalDateTime.now());
+
+            ReviewDecisionRequest request = ReviewDecisionRequest.builder()
+                    .decision("APPROVED")
+                    .comment("안전보건 검토 완료")
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(30L)).willReturn(Optional.of(safetyReview));
+
+            // when
+            ReviewDecisionResponse response = reviewService.processReview(1L, 30L, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getStatus()).isEqualTo("APPROVED");
+            verify(safetyReview).approve(eq(reviewerUser), eq("안전보건 검토 완료"),
+                    isNull(), isNull(), isNull());
+        }
+
+        @Test
+        @DisplayName("ESG 도메인 상세 조회 시 allowedCategoryKeys로 [E, S, G] 반환")
+        void getReviewDetail_EsgDomain_ReturnsAllowedCategoryKeys() {
+            // given
+            Review esgReview = mock(Review.class);
+            Diagnostic esgDiagnostic = mock(Diagnostic.class);
+            Company esgCompany = mock(Company.class);
+            lenient().when(esgReview.getDomain()).thenReturn(esgDomain);
+            lenient().when(esgReview.getReviewId()).thenReturn(40L);
+            lenient().when(esgReview.getDiagnostic()).thenReturn(esgDiagnostic);
+            lenient().when(esgReview.getCompany()).thenReturn(esgCompany);
+            lenient().when(esgReview.getStatus()).thenReturn(ReviewStatus.REVIEWING);
+            lenient().when(esgReview.getScore()).thenReturn(80);
+            lenient().when(esgReview.getRiskLevel()).thenReturn(RiskLevel.LOW);
+            lenient().when(esgReview.getSubmittedAt()).thenReturn(LocalDateTime.now());
+            lenient().when(esgDiagnostic.getDiagnosticId()).thenReturn(200L);
+            lenient().when(esgDiagnostic.getDiagnosticCode()).thenReturn("DG-2026-00002");
+            lenient().when(esgDiagnostic.getTitle()).thenReturn("ESG 진단");
+            lenient().when(esgCompany.getCompanyId()).thenReturn(20L);
+            lenient().when(esgCompany.getName()).thenReturn("ESG회사");
+            lenient().when(esgCompany.getIndustry()).thenReturn(null);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(40L)).willReturn(Optional.of(esgReview));
+
+            // when
+            ReviewDetailResponse response = reviewService.getReviewDetail(1L, 40L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getDomainCode()).isEqualTo("ESG");
+            assertThat(response.getAllowedCategoryKeys()).containsExactly("E", "S", "G");
+        }
+
+        @Test
+        @DisplayName("SAFETY 도메인 상세 조회 시 allowedCategoryKeys로 빈 리스트 반환")
+        void getReviewDetail_SafetyDomain_ReturnsEmptyAllowedCategoryKeys() {
+            // given
+            Review safetyReview = mock(Review.class);
+            Diagnostic safetyDiagnostic = mock(Diagnostic.class);
+            Company safetyCompany = mock(Company.class);
+            lenient().when(safetyReview.getDomain()).thenReturn(safetyDomain);
+            lenient().when(safetyReview.getReviewId()).thenReturn(50L);
+            lenient().when(safetyReview.getDiagnostic()).thenReturn(safetyDiagnostic);
+            lenient().when(safetyReview.getCompany()).thenReturn(safetyCompany);
+            lenient().when(safetyReview.getStatus()).thenReturn(ReviewStatus.REVIEWING);
+            lenient().when(safetyReview.getScore()).thenReturn(60);
+            lenient().when(safetyReview.getRiskLevel()).thenReturn(RiskLevel.MEDIUM);
+            lenient().when(safetyReview.getSubmittedAt()).thenReturn(LocalDateTime.now());
+            lenient().when(safetyDiagnostic.getDiagnosticId()).thenReturn(300L);
+            lenient().when(safetyDiagnostic.getDiagnosticCode()).thenReturn("DG-2026-00003");
+            lenient().when(safetyDiagnostic.getTitle()).thenReturn("안전보건 진단");
+            lenient().when(safetyCompany.getCompanyId()).thenReturn(30L);
+            lenient().when(safetyCompany.getName()).thenReturn("안전회사");
+            lenient().when(safetyCompany.getIndustry()).thenReturn(null);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(50L)).willReturn(Optional.of(safetyReview));
+
+            // when
+            ReviewDetailResponse response = reviewService.getReviewDetail(1L, 50L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getDomainCode()).isEqualTo("SAFETY");
+            assertThat(response.getAllowedCategoryKeys()).isEmpty();
         }
     }
 }


### PR DESCRIPTION
## 변경 요약
- SAFETY/COMPLIANCE 수신자가 심사 승인 시 ESG 카테고리(E/S/G) 의견 필드가 표시되는 버그 수정
- `processReview()`에서 도메인별 `categoryComments` 키 검증 로직 추가
- `ReviewDetailResponse`에 `allowedCategoryKeys` 필드 추가 (FE가 도메인별 폼 렌더링 가능)
- `ErrorCode.INVALID_CATEGORY_FOR_DOMAIN` (RV004) 에러 코드 추가

## 관련 이슈
- Closes #163

## 테스트 방법
```bash
./gradlew test --tests "ReviewServiceTest"
```
### 검증 시나리오
1. SAFETY 도메인 심사에서 `categoryComments: {"E": "...", "S": "..."}` 전송 → 400 RV004 에러
2. ESG 도메인 심사에서 `categoryComments: {"E": "...", "S": "...", "G": "..."}` 전송 → 정상 승인
3. ESG 도메인 심사에서 `categoryComments: {"E": "...", "INVALID": "..."}` 전송 → 400 RV004 에러
4. SAFETY 도메인 심사에서 `categoryComments` 없이 승인 → 정상 처리
5. ESG 상세 조회 시 `allowedCategoryKeys: ["E", "S", "G"]` 반환
6. SAFETY 상세 조회 시 `allowedCategoryKeys: []` 반환

## 명세 준수 체크
- [x] API_CONTRACT_SSOT.md 에러코드 체계(RV004) 준수
- [x] ErrorCode enum 패턴 준수 (HttpStatus.BAD_REQUEST)
- [x] ReviewDetailResponse에 도메인 정보 필드 포함
- [x] 기존 ESG 워크플로우 하위 호환성 유지

## 리뷰 포인트
1. `DOMAIN_CATEGORY_KEYS` 상수 정의 - ESG만 E/S/G, SAFETY/COMPLIANCE는 빈 리스트
2. `validateCategoryComments()` 검증 시점 - 도메인 접근 검증 후, decision 분기 전
3. 비-ESG 도메인에서 categoryComments가 null/empty면 검증 통과 (기존 동작 유지)

## TODO/질문
- [ ] SAFETY/COMPLIANCE 도메인에 고유 카테고리 필드 필요 시 `DOMAIN_CATEGORY_KEYS`에 추가 예정
- [ ] FE에서 `allowedCategoryKeys` 기반 폼 동적 렌더링 구현 필요 (#163 FE 작업)

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `ErrorCode.java` | `INVALID_CATEGORY_FOR_DOMAIN` (RV004) 추가 |
| `ReviewDetailResponse.java` | `allowedCategoryKeys` 필드 추가 |
| `ReviewService.java` | 도메인별 categoryComments 검증 + allowedCategoryKeys 반환 |
| `ReviewServiceTest.java` | 도메인별 카테고리 검증 테스트 6건 추가 |