### PR TITLE
feat(review): AI 보완요청 초안 조회 API 구현 (#161)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/smartchain/platform/domain/review/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.smartchain.platform.domain.review.service.ReviewService;
 import com.smartchain.platform.dto.review.dashboard.ReviewDashboardResponse;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionRequest;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionResponse;
+import com.smartchain.platform.dto.review.decision.RevisionDraftResponse;
 import com.smartchain.platform.dto.review.detail.ReviewDetailResponse;
 import com.smartchain.platform.dto.review.export.ExportRequest;
 import com.smartchain.platform.dto.review.export.ExportResponse;
@@ -82,6 +83,17 @@ public class ReviewController {
             @PathVariable Long reviewId) {
         Long userId = extractUserIdFromRequest(request);
         ReviewDetailResponse response = reviewService.getReviewDetail(userId, reviewId);
+        return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @Operation(summary = "AI 보완요청 초안 조회", description = "AI가 생성한 보완요청 초안을 조회합니다. 보완요청 작성 시 자동 입력을 위해 사용합니다. REVIEWER 권한이 필요합니다.")
+    @GetMapping("/{reviewId}/revision-draft")
+    public ResponseEntity<BaseResponse<RevisionDraftResponse>> getRevisionDraft(
+            HttpServletRequest request,
+            @Parameter(description = "심사 ID")
+            @PathVariable Long reviewId) {
+        Long userId = extractUserIdFromRequest(request);
+        RevisionDraftResponse response = reviewService.getRevisionDraft(userId, reviewId);
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 

--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -15,6 +15,7 @@ import com.smartchain.platform.dto.review.common.*;
 import com.smartchain.platform.dto.review.dashboard.*;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionRequest;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionResponse;
+import com.smartchain.platform.dto.review.decision.RevisionDraftResponse;
 import com.smartchain.platform.dto.review.detail.*;
 import com.smartchain.platform.dto.review.list.*;
 import com.smartchain.platform.global.enums.ReviewStatus;
@@ -360,6 +361,54 @@ public class ReviewService {
                 .processedBy(processedByDto)
                 .message(message)
                 .nextStep(nextStep)
+                .build();
+    }
+
+    /**
+     * AI 보완요청 초안 조회
+     * - 해당 심사의 도메인에 REVIEWER 권한이 있는지 검증
+     * - AI 분석 결과의 clarifications를 보완요청 초안으로 변환
+     */
+    public RevisionDraftResponse getRevisionDraft(Long userId, Long reviewId) {
+        User currentUser = validateReviewerRole(userId);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+
+        validateDomainReviewerAccess(currentUser, review);
+
+        Long diagnosticId = review.getDiagnostic().getDiagnosticId();
+
+        // AI 분석 결과에서 clarifications 추출
+        Optional<AiAnalysisResult> latestResult = aiAnalysisResultRepository
+                .findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(diagnosticId);
+
+        if (latestResult.isEmpty()) {
+            return RevisionDraftResponse.empty(reviewId, diagnosticId);
+        }
+
+        AiAnalysisResult result = latestResult.get();
+        AiAnalysisResultDetailResponse detailResponse = AiAnalysisResultDetailResponse.from(result);
+
+        // clarifications를 RevisionDraftItemDto로 변환
+        List<RevisionDraftResponse.RevisionDraftItemDto> draftItems = detailResponse.clarifications() != null
+                ? detailResponse.clarifications().stream()
+                    .map(RevisionDraftResponse.RevisionDraftItemDto::from)
+                    .toList()
+                : List.of();
+
+        // why 필드를 초안 코멘트로 사용
+        String draftComment = detailResponse.whySummary();
+
+        return RevisionDraftResponse.builder()
+                .reviewId(reviewId)
+                .diagnosticId(diagnosticId)
+                .hasDraft(!draftItems.isEmpty() || (draftComment != null && !draftComment.isBlank()))
+                .riskLevel(detailResponse.riskLevel())
+                .verdict(detailResponse.verdict())
+                .draftComment(draftComment)
+                .draftItems(draftItems)
+                .analyzedAt(detailResponse.analyzedAt())
                 .build();
     }
 

--- a/src/main/java/com/smartchain/platform/dto/review/decision/RevisionDraftResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/review/decision/RevisionDraftResponse.java
@@ -1,0 +1,54 @@
+package com.smartchain.platform.dto.review.decision;
+
+import com.smartchain.platform.dto.ai.run.Clarification;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * AI 보완요청 초안 응답 DTO
+ * Review 상세 화면에서 보완요청 작성 시 AI가 생성한 초안을 제공
+ */
+@Builder
+public record RevisionDraftResponse(
+    Long reviewId,
+    Long diagnosticId,
+    boolean hasDraft,
+    String riskLevel,
+    String verdict,
+    String draftComment,
+    List<RevisionDraftItemDto> draftItems,
+    LocalDateTime analyzedAt
+) {
+    /**
+     * AI 분석 결과가 없을 때 빈 응답 생성
+     */
+    public static RevisionDraftResponse empty(Long reviewId, Long diagnosticId) {
+        return RevisionDraftResponse.builder()
+            .reviewId(reviewId)
+            .diagnosticId(diagnosticId)
+            .hasDraft(false)
+            .draftItems(List.of())
+            .build();
+    }
+
+    /**
+     * 보완요청 초안 항목 DTO
+     * AI clarifications를 프론트에서 사용하기 쉬운 형태로 변환
+     */
+    @Builder
+    public record RevisionDraftItemDto(
+        String slotName,
+        String message,
+        List<String> fileIds
+    ) {
+        public static RevisionDraftItemDto from(Clarification clarification) {
+            return RevisionDraftItemDto.builder()
+                .slotName(clarification.slotName())
+                .message(clarification.message())
+                .fileIds(clarification.fileIds() != null ? clarification.fileIds() : List.of())
+                .build();
+        }
+    }
+}

--- a/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
@@ -17,6 +17,7 @@ import com.smartchain.platform.dto.ai.AiAnalysisResultDetailResponse;
 import com.smartchain.platform.dto.review.dashboard.ReviewDashboardResponse;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionRequest;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionResponse;
+import com.smartchain.platform.dto.review.decision.RevisionDraftResponse;
 import com.smartchain.platform.dto.review.detail.ReviewDetailResponse;
 import com.smartchain.platform.dto.review.list.ReviewListResponse;
 import com.smartchain.platform.global.enums.ReviewStatus;
@@ -806,6 +807,130 @@ class ReviewServiceTest {
             assertThat(response).isNotNull();
             assertThat(response.getDomainCode()).isEqualTo("SAFETY");
             assertThat(response.getAllowedCategoryKeys()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("AI 보완요청 초안 조회 테스트")
+    class GetRevisionDraftTest {
+
+        @Test
+        @DisplayName("AI 분석 결과가 있는 경우 초안 조회 성공")
+        void getRevisionDraft_WithAiAnalysisResult_Success() {
+            // given
+            String resultJson = """
+                {
+                    "slotResults": [
+                        {"slotName": "esg.energy.electricity.usage", "verdict": "PASS", "reasons": ["검토 완료"]}
+                    ],
+                    "clarifications": [
+                        {"slotName": "esg.hazmat.msds", "message": "MSDS 문서가 누락되었습니다"},
+                        {"slotName": "esg.ethics.code", "message": "윤리강령 최신 버전 필요"}
+                    ]
+                }
+                """;
+
+            AiAnalysisResult aiResult = AiAnalysisResult.builder()
+                    .diagnostic(testDiagnostic)
+                    .domainCode("ESG")
+                    .packageId("PKG_001")
+                    .riskLevel("MEDIUM")
+                    .verdict("WARN")
+                    .whySummary("일부 필수 문서가 누락되었습니다")
+                    .resultJson(resultJson)
+                    .analyzedAt(LocalDateTime.now())
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(1L)).willReturn(Optional.of(testReview));
+            given(aiAnalysisResultRepository.findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(100L))
+                    .willReturn(Optional.of(aiResult));
+
+            // when
+            RevisionDraftResponse response = reviewService.getRevisionDraft(1L, 1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.reviewId()).isEqualTo(1L);
+            assertThat(response.diagnosticId()).isEqualTo(100L);
+            assertThat(response.hasDraft()).isTrue();
+            assertThat(response.riskLevel()).isEqualTo("MEDIUM");
+            assertThat(response.verdict()).isEqualTo("WARN");
+            assertThat(response.draftComment()).isEqualTo("일부 필수 문서가 누락되었습니다");
+            assertThat(response.draftItems()).hasSize(2);
+            assertThat(response.draftItems().get(0).slotName()).isEqualTo("esg.hazmat.msds");
+            assertThat(response.draftItems().get(0).message()).isEqualTo("MSDS 문서가 누락되었습니다");
+            assertThat(response.draftItems().get(1).slotName()).isEqualTo("esg.ethics.code");
+        }
+
+        @Test
+        @DisplayName("AI 분석 결과가 없는 경우 빈 응답 반환")
+        void getRevisionDraft_WithoutAiAnalysisResult_ReturnsEmptyResponse() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(1L)).willReturn(Optional.of(testReview));
+            given(aiAnalysisResultRepository.findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(100L))
+                    .willReturn(Optional.empty());
+
+            // when
+            RevisionDraftResponse response = reviewService.getRevisionDraft(1L, 1L);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.reviewId()).isEqualTo(1L);
+            assertThat(response.diagnosticId()).isEqualTo(100L);
+            assertThat(response.hasDraft()).isFalse();
+            assertThat(response.draftItems()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("권한 없는 도메인의 심사 초안 조회 시 403 에러")
+        void getRevisionDraft_WithoutDomainPermission_ThrowsException() {
+            // given
+            Review socReview = mock(Review.class);
+            when(socReview.getDomain()).thenReturn(socDomain);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(2L)).willReturn(Optional.of(socReview));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.getRevisionDraft(1L, 2L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_ACTION);
+                    });
+        }
+
+        @Test
+        @DisplayName("REVIEWER가 아닌 사용자가 초안 조회 시 403 에러")
+        void getRevisionDraft_AsGuest_ThrowsException() {
+            // given
+            given(userRepository.findById(2L)).willReturn(Optional.of(guestUser));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.getRevisionDraft(2L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_ACTION);
+                    });
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 심사 초안 조회 시 404 에러")
+        void getRevisionDraft_ReviewNotFound_ThrowsException() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.getRevisionDraft(1L, 999L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.REVIEW_NOT_FOUND);
+                    });
         }
     }
 }


### PR DESCRIPTION
## 변경 요약
- `GET /api/v1/reviews/{reviewId}/revision-draft` 엔드포인트 추가
- `RevisionDraftResponse` DTO 생성 (보완요청 초안 응답)
- AI 분석 결과의 `clarifications`를 보완요청 초안으로 변환하여 제공
- REVIEWER 권한 및 도메인 권한 검증 로직 적용

## 관련 이슈
- Closes #161 (feat: 보완요청 시 AI 초안 자동 적용)

## 테스트 방법
```bash
# 단위 테스트 실행
./gradlew test --tests "ReviewServiceTest"

# API 테스트 (Swagger)
GET /api/v1/reviews/{reviewId}/revision-draft
Authorization: Bearer {REVIEWER_TOKEN}
```

## 명세 준수 체크
- [x] API 엔드포인트 규칙 준수 (`/api/v1/reviews/{id}/...`)
- [x] BaseResponse<T> 응답 래핑
- [x] REVIEWER 역할 권한 검증
- [x] 도메인 기반 접근 권한 검증
- [x] 테스트 코드 추가 (5개)

## 리뷰 포인트
1. `RevisionDraftResponse` 구조가 프론트엔드 요구사항과 일치하는지
2. `hasDraft` 필드의 판단 로직 (clarifications 있거나 whySummary 있으면 true)
3. 권한 검증 로직 재사용 패턴

## 변경된 파일
| 파일 | 변경 내용 |
|------|----------|
| `RevisionDraftResponse.java` | 신규 - AI 보완요청 초안 응답 DTO |
| `ReviewController.java` | 엔드포인트 추가 |
| `ReviewService.java` | getRevisionDraft 메서드 추가 |
| `ReviewServiceTest.java` | 테스트 5개 추가 |

## TODO/질문
- [ ] 프론트엔드에서 초안 자동 입력 UI 구현 필요
- 질문: AI 초안이 없을 때 빈 응답 vs 에러 응답 중 어느 것이 더 나은가? (현재: 빈 응답)

---