### PR TITLE
fix(routing): 전체 결재 페이지 제거 - domainCode 필수화 (#162)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,40 @@
 # Claude Code Learnings
 
+## 2026-02-04: 전체 결재 페이지 제거 - domainCode 필수화 (#162)
+
+### 원인
+- 결재 목록 조회 API에서 `domainCode` 없이 호출 시 "전체 결재" 조회 가능
+- 기획상 도메인별 결재 페이지만 존재해야 함
+- 전체 결재 페이지는 존재하면 안 됨
+
+### 해결
+- `ApprovalService.getApprovalList()`에서 `domainCode` 필수 검증 추가
+- `domainCode`가 null이거나 비어있으면 `DOMAIN_CODE_REQUIRED` 에러 반환
+- ErrorCode에 `DOMAIN_CODE_REQUIRED` (AP005) 추가
+- 레거시 모드에서도 `domainCode` 유효성 검증 수행
+
+### 재발방지
+- 목록 조회 API에서 필수 필터 파라미터는 서비스 레이어에서 검증
+- 기획에서 "존재하면 안 되는 페이지"는 API 레벨에서 차단
+
+### 검증방법
+```bash
+./gradlew test --tests "ApprovalServiceTest"
+```
+
+### 관련커밋
+- fix/162-approval-domain-required 브랜치
+
+### 생성/수정 파일
+```
+src/main/java/.../domain/approval/service/ApprovalService.java (domainCode 필수 검증)
+src/main/java/.../global/error/ErrorCode.java (DOMAIN_CODE_REQUIRED 추가)
+src/test/java/.../domain/approval/service/ApprovalServiceTest.java (테스트 수정)
+docs/claude/LEARNINGS.md (엔트리 추가)
+```
+
+---
+
 ## 2026-02-04: 권한 요청 반려 API 오류 (#154)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
+++ b/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
@@ -66,6 +66,11 @@ public class ApprovalService {
             throw new CustomException(ErrorCode.PERMISSION_DENIED_RESOURCE);
         }
 
+        // domainCode 필수 검증 - 전체 결재 페이지 제거 (#162)
+        if (domainCode == null || domainCode.isEmpty()) {
+            throw new CustomException(ErrorCode.DOMAIN_CODE_REQUIRED);
+        }
+
         // APPROVER 권한을 가진 도메인 목록 조회
         List<Domain> approverDomains = currentUser.getDomainsWithRole("APPROVER");
 
@@ -78,47 +83,29 @@ public class ApprovalService {
         Page<Approval> approvalPage;
         ApprovalStatsDto stats;
 
-        // domainCode가 지정된 경우 단일 도메인 필터링
-        if (domainCode != null && !domainCode.isEmpty()) {
-            Domain filterDomain = domainRepository.findByCode(domainCode)
-                    .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
+        // 단일 도메인 필터링 (domainCode 필수)
+        Domain filterDomain = domainRepository.findByCode(domainCode)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
 
-            // 사용자가 해당 도메인에서 APPROVER 역할이 있는지 확인
-            if (!currentUser.hasRoleInDomain(domainCode, "APPROVER")) {
-                throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);
-            }
-
-            if (status != null && !status.isEmpty()) {
-                ApprovalStatus approvalStatus = parseStatus(status);
-                approvalPage = approvalRepository.findByDomainAndCompanyAndStatusOrderByCreatedAtDesc(
-                        filterDomain, userCompany, approvalStatus, pageable);
-            } else {
-                approvalPage = approvalRepository.findByDomainAndCompanyOrderByCreatedAtDesc(
-                        filterDomain, userCompany, pageable);
-            }
-
-            stats = ApprovalStatsDto.builder()
-                    .waiting(approvalRepository.countByDomainAndCompanyAndStatus(filterDomain, userCompany, ApprovalStatus.WAITING))
-                    .approved(approvalRepository.countByDomainAndCompanyAndStatus(filterDomain, userCompany, ApprovalStatus.APPROVED))
-                    .rejected(approvalRepository.countByDomainAndCompanyAndStatus(filterDomain, userCompany, ApprovalStatus.REJECTED))
-                    .build();
-        } else {
-            // 전체 도메인 조회 (기존 로직)
-            if (status != null && !status.isEmpty()) {
-                ApprovalStatus approvalStatus = parseStatus(status);
-                approvalPage = approvalRepository.findByDomainsAndCompanyAndStatusOrderByCreatedAtDesc(
-                        approverDomains, userCompany, approvalStatus, pageable);
-            } else {
-                approvalPage = approvalRepository.findByDomainsAndCompanyOrderByCreatedAtDesc(
-                        approverDomains, userCompany, pageable);
-            }
-
-            stats = ApprovalStatsDto.builder()
-                    .waiting(approvalRepository.countByDomainsAndCompanyAndStatus(approverDomains, userCompany, ApprovalStatus.WAITING))
-                    .approved(approvalRepository.countByDomainsAndCompanyAndStatus(approverDomains, userCompany, ApprovalStatus.APPROVED))
-                    .rejected(approvalRepository.countByDomainsAndCompanyAndStatus(approverDomains, userCompany, ApprovalStatus.REJECTED))
-                    .build();
+        // 사용자가 해당 도메인에서 APPROVER 역할이 있는지 확인
+        if (!currentUser.hasRoleInDomain(domainCode, "APPROVER")) {
+            throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);
         }
+
+        if (status != null && !status.isEmpty()) {
+            ApprovalStatus approvalStatus = parseStatus(status);
+            approvalPage = approvalRepository.findByDomainAndCompanyAndStatusOrderByCreatedAtDesc(
+                    filterDomain, userCompany, approvalStatus, pageable);
+        } else {
+            approvalPage = approvalRepository.findByDomainAndCompanyOrderByCreatedAtDesc(
+                    filterDomain, userCompany, pageable);
+        }
+
+        stats = ApprovalStatsDto.builder()
+                .waiting(approvalRepository.countByDomainAndCompanyAndStatus(filterDomain, userCompany, ApprovalStatus.WAITING))
+                .approved(approvalRepository.countByDomainAndCompanyAndStatus(filterDomain, userCompany, ApprovalStatus.APPROVED))
+                .rejected(approvalRepository.countByDomainAndCompanyAndStatus(filterDomain, userCompany, ApprovalStatus.REJECTED))
+                .build();
 
         List<ApprovalListItemDto> content = approvalPage.getContent().stream()
                 .map(this::mapToListItemDto)
@@ -140,7 +127,7 @@ public class ApprovalService {
 
     /**
      * 레거시: 도메인 역할이 없는 사용자용 결재 목록 조회
-     * Note: domainCode 필터는 레거시 모드에서는 지원하지 않음 (도메인 정보가 없는 데이터)
+     * Note: 레거시 모드에서도 domainCode 필수 - 도메인별 필터링은 불가하지만 유효성 검증 수행
      */
     private ApprovalListResponse getApprovalListLegacy(User currentUser, Company userCompany,
                                                         String domainCode, String status, int page, int size) {
@@ -149,10 +136,11 @@ public class ApprovalService {
             throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);
         }
 
-        // 레거시 모드에서 domainCode 필터는 무시 (경고 로그만 출력)
-        if (domainCode != null && !domainCode.isEmpty()) {
-            log.warn("domainCode filter '{}' ignored in legacy mode for user {}", domainCode, currentUser.getUserId());
-        }
+        // 레거시 모드에서도 domainCode 유효성 검증 (도메인 존재 확인)
+        domainRepository.findByCode(domainCode)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT));
+
+        log.info("Legacy mode: domainCode '{}' validated but filter not applied for user {}", domainCode, currentUser.getUserId());
 
         Pageable pageable = PageRequest.of(page, size);
         Page<Approval> approvalPage;

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
     ALREADY_PROCESSED_REQUEST(HttpStatus.CONFLICT, "PERM_003", "이미 처리된 권한 요청입니다"),
     INVALID_DECISION(HttpStatus.BAD_REQUEST, "R005", "유효하지 않은 처리 결과입니다"),
     ALREADY_PROCESSED_APPROVAL(HttpStatus.CONFLICT, "AP002", "이미 처리된 결재 요청입니다"),
+    DOMAIN_CODE_REQUIRED(HttpStatus.BAD_REQUEST, "AP005", "도메인 코드가 필요합니다"),
     APPROVAL_NOT_APPROVED(HttpStatus.CONFLICT, "AP003", "승인된 결재만 원청에 제출할 수 있습니다"),
     DIAGNOSTIC_NOT_APPROVED(HttpStatus.CONFLICT, "AP004", "승인된 진단만 원청에 제출할 수 있습니다"),
     ALREADY_PROCESSED_REVIEW(HttpStatus.CONFLICT, "RV002", "이미 처리된 심사입니다"),

--- a/src/test/java/com/smartchain/platform/domain/approval/service/ApprovalServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/approval/service/ApprovalServiceTest.java
@@ -121,13 +121,53 @@ class ApprovalServiceTest {
     @DisplayName("결재 대기 목록 조회 테스트")
     class GetApprovalListTest {
 
+        @Mock
+        private Domain esgDomain;
+
+        @BeforeEach
+        void setUpDomain() {
+            lenient().when(esgDomain.getCode()).thenReturn("ESG");
+            lenient().when(esgDomain.getName()).thenReturn("ESG 실사");
+        }
+
         @Test
-        @DisplayName("APPROVER가 결재 목록 조회 성공")
-        void getApprovalList_AsApprover_Success() {
+        @DisplayName("domainCode 없이 조회 시 실패")
+        void getApprovalList_WithoutDomainCode_ThrowsException() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(approverUser));
+
+            // when & then
+            assertThatThrownBy(() -> approvalService.getApprovalList(1L, null, null, 0, 10))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.DOMAIN_CODE_REQUIRED);
+                    });
+        }
+
+        @Test
+        @DisplayName("빈 domainCode로 조회 시 실패")
+        void getApprovalList_WithEmptyDomainCode_ThrowsException() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(approverUser));
+
+            // when & then
+            assertThatThrownBy(() -> approvalService.getApprovalList(1L, "", null, 0, 10))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.DOMAIN_CODE_REQUIRED);
+                    });
+        }
+
+        @Test
+        @DisplayName("레거시 APPROVER가 도메인 지정하여 결재 목록 조회 성공")
+        void getApprovalList_AsLegacyApprover_Success() {
             // given
             Page<Approval> approvalPage = new PageImpl<>(List.of(testApproval), PageRequest.of(0, 10), 1);
 
             given(userRepository.findById(1L)).willReturn(Optional.of(approverUser));
+            given(domainRepository.findByCode("ESG")).willReturn(Optional.of(esgDomain));
             given(approvalRepository.findByCompanyOrderByCreatedAtDesc(eq(testCompany), any()))
                     .willReturn(approvalPage);
             given(approvalRepository.countByCompanyAndStatus(testCompany, ApprovalStatus.WAITING)).willReturn(3);
@@ -135,7 +175,7 @@ class ApprovalServiceTest {
             given(approvalRepository.countByCompanyAndStatus(testCompany, ApprovalStatus.REJECTED)).willReturn(2);
 
             // when
-            ApprovalListResponse response = approvalService.getApprovalList(1L, null, null, 0, 10);
+            ApprovalListResponse response = approvalService.getApprovalList(1L, "ESG", null, 0, 10);
 
             // then
             assertThat(response).isNotNull();
@@ -156,9 +196,11 @@ class ApprovalServiceTest {
             when(guestUser.getDomainsWithRole("APPROVER")).thenReturn(new ArrayList<>());
 
             given(userRepository.findById(3L)).willReturn(Optional.of(guestUser));
+            // 레거시 모드에서 domainCode 유효성 검증을 위해 호출됨
+            lenient().when(domainRepository.findByCode("ESG")).thenReturn(Optional.of(esgDomain));
 
             // when & then
-            assertThatThrownBy(() -> approvalService.getApprovalList(3L, null, null, 0, 10))
+            assertThatThrownBy(() -> approvalService.getApprovalList(3L, "ESG", null, 0, 10))
                     .isInstanceOf(CustomException.class)
                     .satisfies(ex -> {
                         CustomException ce = (CustomException) ex;
@@ -177,7 +219,7 @@ class ApprovalServiceTest {
             given(userRepository.findById(4L)).willReturn(Optional.of(noCompanyApprover));
 
             // when & then
-            assertThatThrownBy(() -> approvalService.getApprovalList(4L, null, null, 0, 10))
+            assertThatThrownBy(() -> approvalService.getApprovalList(4L, "ESG", null, 0, 10))
                     .isInstanceOf(CustomException.class)
                     .satisfies(ex -> {
                         CustomException ce = (CustomException) ex;
@@ -192,6 +234,7 @@ class ApprovalServiceTest {
             Page<Approval> approvalPage = new PageImpl<>(List.of(testApproval), PageRequest.of(0, 10), 1);
 
             given(userRepository.findById(1L)).willReturn(Optional.of(approverUser));
+            given(domainRepository.findByCode("ESG")).willReturn(Optional.of(esgDomain));
             given(approvalRepository.findByCompanyAndStatusOrderByCreatedAtDesc(eq(testCompany), eq(ApprovalStatus.WAITING), any()))
                     .willReturn(approvalPage);
             given(approvalRepository.countByCompanyAndStatus(testCompany, ApprovalStatus.WAITING)).willReturn(3);
@@ -199,7 +242,7 @@ class ApprovalServiceTest {
             given(approvalRepository.countByCompanyAndStatus(testCompany, ApprovalStatus.REJECTED)).willReturn(2);
 
             // when
-            ApprovalListResponse response = approvalService.getApprovalList(1L, null, "WAITING", 0, 10);
+            ApprovalListResponse response = approvalService.getApprovalList(1L, "ESG", "WAITING", 0, 10);
 
             // then
             assertThat(response).isNotNull();
@@ -214,9 +257,10 @@ class ApprovalServiceTest {
         void getApprovalList_InvalidStatus_ThrowsException() {
             // given
             given(userRepository.findById(1L)).willReturn(Optional.of(approverUser));
+            given(domainRepository.findByCode("ESG")).willReturn(Optional.of(esgDomain));
 
             // when & then
-            assertThatThrownBy(() -> approvalService.getApprovalList(1L, null, "INVALID_STATUS", 0, 10))
+            assertThatThrownBy(() -> approvalService.getApprovalList(1L, "ESG", "INVALID_STATUS", 0, 10))
                     .isInstanceOf(CustomException.class)
                     .satisfies(ex -> {
                         CustomException ce = (CustomException) ex;


### PR DESCRIPTION
## Summary
- 결재 목록 조회 API에서 `domainCode` 파라미터 필수화
- `domainCode` 없이 호출 시 `DOMAIN_CODE_REQUIRED` (AP005) 에러 반환
- 전체 결재 페이지가 더 이상 존재하지 않도록 API 레벨에서 차단

## 변경 사항
- `ApprovalService.getApprovalList()`: domainCode null/empty 검증 추가
- `ErrorCode.java`: `DOMAIN_CODE_REQUIRED` 에러 코드 추가
- 레거시 모드에서도 domainCode 유효성 검증 수행

## Test plan
- [x] `./gradlew test --tests "ApprovalServiceTest"` 통과
- [x] domainCode 없이 호출 시 AP005 에러 반환 확인

Closes #162