### PR TITLE
fix(review): 반려→재승인 시 상태 처리 오류 수정 (#155)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,261 @@
 # Claude Code Learnings
 
+## 2026-02-04: 반려→재승인 시 상태 처리 오류 수정 (#155)
+
+### 원인
+- 수신자(REVIEWER)가 반려(REVISION_REQUIRED)한 심사를 대시보드에서 다시 승인하려 할 때
+- 기존 `processReview()` 메서드가 `REVIEWING` 상태에서만 처리 가능하도록 구현됨
+- `REVISION_REQUIRED` 상태의 심사를 재승인하는 기능이 없어 의도치 않은 동작 발생
+
+### 해결
+- **Review 엔티티**: `isRevisionRequired()` 메서드 추가, `revertToReviewing()` 메서드 추가
+- **ReviewService.processReview()**: `REVISION_REQUIRED` 상태에서도 재승인(APPROVED) 가능하도록 수정
+  - `REVISION_REQUIRED` + `APPROVED` 요청 → 기안 상태를 REVIEWING으로 되돌린 후 COMPLETED 처리
+  - `REVISION_REQUIRED` + `REVISION_REQUIRED` 요청 → 중복 방지 에러 반환
+- **테스트 추가**: 재승인 성공 케이스, 중복 보완요청 실패 케이스
+
+### 재발방지
+- 상태 전이 로직 구현 시 모든 가능한 상태 조합 검토 필요
+- 특히 "취소/롤백" 시나리오가 필요한지 기획 단계에서 확인
+- 심사 워크플로우 변경 시 Review/Diagnostic 상태 동기화 주의
+
+### 검증방법
+```bash
+./gradlew test --tests "ReviewServiceTest"
+./gradlew build -x test
+```
+
+### 관련커밋
+- PR #168 (반려→재승인 상태 처리 오류 수정)
+
+### 생성/수정 파일
+```
+src/main/java/.../domain/review/entity/Review.java (+isRevisionRequired, +revertToReviewing)
+src/main/java/.../domain/review/service/ReviewService.java (processReview 로직 수정)
+src/test/java/.../domain/review/service/ReviewServiceTest.java (+2 테스트 케이스)
+```
+
+---
+
+## 2026-02-04: AI Chatbot 백엔드 통합 구현 (#140, #141)
+
+### 원인
+- AI 팀에서 FastAPI 기반 RAG 챗봇 서비스 개발 완료
+- 백엔드에서 AI Chat API를 래핑하여 프론트엔드에 통합 API 제공 필요
+- 인증/권한 관리, 에러 핸들링, 세션 관리 등 백엔드 레이어 추가 필요
+
+### 해결
+- **Issue #140 (기반 구조)**:
+  - DTO 7개 생성: ChatRequest, ChatMessage, ChatResponse, SourceItem, SourceLocation, AdminSyncResponse, AdminInspectResponse
+  - AiChatConfig: WebClient 설정 (@ConfigurationProperties)
+  - AiChatApiClient: AI FastAPI 서버 통신 (chat, syncData, inspectDb)
+  - ErrorCode 3개 추가: AI_CHAT_SERVICE_ERROR, AI_CHAT_TIMEOUT, AI_CHAT_INVALID_DOMAIN
+  - SecurityConfig: /api/v1/chat/**, /api/v1/admin/chat/** 경로 권한 설정
+
+- **Issue #141 (비즈니스 로직)**:
+  - ChatService: 채팅 처리, 도메인 검증, REVIEWER 권한 검증
+  - ChatController: REST API 엔드포인트 3개
+  - ChatServiceTest: 단위 테스트 10개
+
+### 재발방지
+- 외부 AI 서비스 연동 시 WebClient 기반 클라이언트 + Config 분리 패턴 사용
+- Admin API는 REVIEWER 권한으로 제한, SecurityConfig에서 경로별 권한 명시
+- 도메인 유효성 검증 (safety, compliance, esg, all)은 서비스 레이어에서 수행
+- sessionId 자동 생성으로 클라이언트 부담 감소
+
+### 검증방법
+```bash
+./gradlew test --tests "ChatServiceTest"
+./gradlew build -x test
+```
+
+### 관련커밋
+- PR #142 (기반 구조), PR #143 (비즈니스 로직)
+
+### 생성/수정 파일
+```
+src/main/java/.../dto/chat/ (7개 DTO)
+src/main/java/.../domain/chat/config/AiChatConfig.java
+src/main/java/.../domain/chat/client/AiChatApiClient.java
+src/main/java/.../domain/chat/service/ChatService.java
+src/main/java/.../domain/chat/controller/ChatController.java
+src/main/java/.../global/error/ErrorCode.java (CHAT001-003 추가)
+src/main/java/.../global/config/SecurityConfig.java (경로 추가)
+src/main/resources/application.yaml (ai.chat 설정 추가)
+src/test/java/.../domain/chat/service/ChatServiceTest.java
+docs/FE_AI_CHATBOT_INTEGRATION.md (FE 통합 가이드)
+```
+
+### API 엔드포인트
+| Method | Path | 설명 | 권한 |
+|--------|------|------|------|
+| POST | `/api/v1/chat` | AI 채팅 | DRAFTER, APPROVER, REVIEWER |
+| POST | `/api/v1/admin/chat/sync` | Vector DB 동기화 | REVIEWER |
+| GET | `/api/v1/admin/chat/inspect` | DB 현황 조회 | REVIEWER |
+
+---
+
+## 2026-02-04: 계정 잠금 기능 구현 (로그인 실패 제한)
+
+### 원인
+- 로그인 시도 무제한으로 브루트포스 공격에 취약
+- 프론트엔드 요청: 5회 실패 시 임시 잠금, 10회 실패 시 영구 잠금
+
+### 해결
+- **User 엔티티 수정**:
+  - `failedLoginAttempts`: 로그인 실패 횟수
+  - `lockedUntil`: 임시 잠금 해제 시간
+  - `permanentlyLocked`: 영구 잠금 여부
+- **잠금 정책**:
+  - 5회 연속 실패 → 15분 임시 잠금 (A006)
+  - 10회 연속 실패 → 영구 잠금 (A005)
+- **ErrorCode 변경**:
+  - A005: `ACCOUNT_PERMANENTLY_LOCKED` (영구 잠금)
+  - A006: `ACCOUNT_TEMPORARILY_LOCKED` (임시 잠금)
+  - A009: `ACCOUNT_NOT_VERIFIED` (기존 A005에서 이동)
+- **응답에 잠금 정보 포함**:
+  - `lockedUntil`, `remainingMinutes`, `remainingAttempts`
+- **CustomException, ErrorResponse에 data 필드 추가**
+
+### 재발방지
+- 보안 관련 에러 코드는 프론트엔드와 사전 협의 필수
+- 계정 상태 관련 검증은 비밀번호 검증보다 먼저 수행
+
+### 검증방법
+```bash
+./gradlew test --tests "*AuthServiceTest*login*"
+```
+
+### 관련커밋
+- dev 브랜치 직접 푸시
+
+### 생성/수정 파일
+```
+User.java (잠금 필드 및 메서드 추가)
+AuthService.java (잠금 처리 로직)
+ErrorCode.java (A005, A006, A009 변경)
+CustomException.java (data 필드 추가)
+ErrorResponse.java (data 필드 추가)
+GlobalExceptionHandler.java (data 포함 응답)
+LoginResponse.java (경고 메시지 필드)
+AccountLockInfo.java (신규 - 잠금 정보 DTO)
+AuthServiceTest.java (테스트 수정)
+```
+
+---
+
+## 2026-02-04: Google reCAPTCHA v3 로그인 보안 검증 구현
+
+### 원인
+- 로그인 API에 봇/자동화 공격 방지 보안 레이어 부재
+- 프론트엔드에서 reCAPTCHA v3 구현 요청에 따른 백엔드 검증 필요
+
+### 해결
+- `RecaptchaConfig`: reCAPTCHA 설정 (secretKey, scoreThreshold, enabled)
+- `RecaptchaService`: Google reCAPTCHA API 검증 서비스
+  - POST `https://www.google.com/recaptcha/api/siteverify`로 토큰 검증
+  - success 체크, action 변조 방지, score 임계값(0.5) 검증
+- `LoginRequest`에 `recaptchaToken` 필드 추가
+- `AuthService.login()`에 reCAPTCHA 검증 로직 추가 (비밀번호 검증 전 수행)
+- `ErrorCode`에 `RECAPTCHA_FAILED` (CAPTCHA_001), `RECAPTCHA_LOW_SCORE` (CAPTCHA_002) 추가
+
+### 재발방지
+- 보안 검증 로직은 주요 인증 로직 앞에 배치
+- 환경변수로 enabled 플래그 제공하여 개발/테스트 환경에서 비활성화 가능
+- score 임계값은 환경변수로 조정 가능 (기본 0.5)
+
+### 검증방법
+```bash
+./gradlew build -x test
+./gradlew test --tests "*AuthServiceTest*login*"
+```
+
+### 관련커밋
+- feature/recaptcha-login-validation-v2 브랜치
+
+### 생성/수정 파일
+```
+src/main/java/.../global/config/RecaptchaConfig.java (신규)
+src/main/java/.../domain/auth/service/RecaptchaService.java (신규)
+src/main/java/.../dto/auth/login/LoginRequest.java (recaptchaToken 추가)
+src/main/java/.../domain/auth/service/AuthService.java (검증 로직 추가)
+src/main/java/.../global/error/ErrorCode.java (CAPTCHA_001, CAPTCHA_002 추가)
+src/main/resources/application.yaml (recaptcha 설정 추가)
+src/test/java/.../domain/auth/service/AuthServiceTest.java (mock 추가)
+```
+
+---
+
+## 2026-02-03: 캠페인/기안/회원가입 버그 수정 (#134)
+
+### 원인
+1. **이메일 인증 버그**: 회원가입 전 이메일 인증 시 User가 없어서 `ifPresent()`가 동작 안함
+2. **회사 연결 버그**: `RoleRequestService.processRoleRequest()`에서 `user.company` 설정 누락
+3. **캠페인 필터링 버그**: `CampaignService.getCampaignList()`가 권한/상태 필터링 없이 전체 반환
+4. **종료 캠페인 진단 생성**: `DiagnosticService.createDiagnostic()`에서 캠페인 종료 검증 없음
+
+### 해결
+1. 회원가입 시 `findTopByEmailAndVerifiedTrueOrderByCreatedAtDesc()`로 인증 완료 여부 확인, `emailVerified=true`로 생성
+2. `User.changeCompany()` 메서드 추가, 승인 시 회사 연결 로직 추가
+3. `CampaignRepository`에 도메인/상태 필터링 쿼리 추가, 사용자 권한 기반 필터링 구현
+4. 캠페인 `periodEndDate` 검증 추가, `CAMPAIGN_CLOSED` 에러 코드 추가
+
+### 재발방지
+- 회원가입/인증 플로우에서 관련 엔티티 상태 동기화 체크리스트 확인
+- 권한 승인 시 연관 엔티티(User.company, UserDomainRole) 양방향 업데이트 확인
+- 목록 조회 API는 권한/상태 필터링 기본 적용
+
+### 검증방법
+1. 회원가입 → 이메일 인증 → 로그인 성공 확인
+2. 권한 요청 승인 → `/auth/me`에서 company 확인
+3. 캠페인 목록 → 권한에 따른 필터링 확인
+
+### 관련커밋
+- fix/campaign-auth-bugs 브랜치, PR #134
+
+### 생성/수정 파일
+```
+AuthService.java (회원가입 시 인증 확인)
+EmailVerificationCodeRepository.java (verified 조회 메서드)
+User.java (changeCompany 메서드)
+RoleRequestService.java (승인 시 회사 연결)
+CampaignRepository.java (필터링 쿼리)
+CampaignService.java (권한 기반 필터링)
+CampaignController.java (userId 기반 API)
+DiagnosticService.java (캠페인 종료 검증)
+ErrorCode.java (CAMPAIGN_CLOSED)
+```
+
+---
+
+## 2026-02-03: DataInitializer 데이터 정합성 수정 (#132)
+
+### 원인
+- SAFETY/COMPLIANCE 도메인에서도 APPROVER 역할 부여 (비즈니스 규칙 위반)
+- 캠페인 기간이 4개월 단위 규칙을 따르지 않음
+
+### 해결
+- APPROVER 역할을 ESG 도메인으로 제한
+- 캠페인 기간을 4개월 단위로 통일 (1~4월, 5~8월, 9~12월)
+
+### 재발방지
+- 도메인별 역할 정책: ESG만 결재자(APPROVER) 존재
+- 캠페인 기간 규칙: 4개월 단위, 첫달 1일 ~ 마지막달 말일
+
+### 검증방법
+- 로컬 실행 후 테스트 계정 권한 확인
+- 캠페인 기간 데이터 확인
+
+### 관련커밋
+- refactor/data-initializer-132 브랜치, PR #135
+
+### 생성/수정 파일
+```
+DataInitializer.java (UserDomainRole, Campaign 데이터 수정)
+```
+
+---
+
 ## 2026-02-02: 이메일 인증 코드 실제 발송 기능 구현 (#116)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
+++ b/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
@@ -104,6 +104,21 @@ public class Review extends BaseTimeEntity {
         return this.status == ReviewStatus.REVIEWING;
     }
 
+    public boolean isRevisionRequired() {
+        return this.status == ReviewStatus.REVISION_REQUIRED;
+    }
+
+    /**
+     * REVISION_REQUIRED 상태에서 다시 REVIEWING 상태로 되돌림
+     * 수신자가 반려 결정을 철회하고 재심사하려는 경우 사용
+     */
+    public void revertToReviewing() {
+        this.status = ReviewStatus.REVIEWING;
+        this.processedBy = null;
+        this.processedAt = null;
+        this.comment = null;
+    }
+
     public void updateScore(Integer score) {
         this.score = score;
         this.riskLevel = RiskLevel.fromScore(score);

--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -280,6 +280,7 @@ public class ReviewService {
     /**
      * 심사 결과 입력 (승인/보완요청)
      * - 해당 심사의 도메인에 REVIEWER 권한이 있는지 검증
+     * - REVISION_REQUIRED 상태의 심사도 재승인 가능 (반려→재승인 지원)
      */
     @Transactional
     public ReviewDecisionResponse processReview(Long userId, Long reviewId, ReviewDecisionRequest request) {
@@ -290,7 +291,9 @@ public class ReviewService {
 
         validateDomainReviewerAccess(currentUser, review);
 
-        if (!review.isReviewing()) {
+        // REVIEWING 또는 REVISION_REQUIRED 상태에서만 처리 가능
+        // REVISION_REQUIRED 상태에서는 재승인만 가능 (보완요청 중복 방지)
+        if (!review.isReviewing() && !review.isRevisionRequired()) {
             throw new CustomException(ErrorCode.ALREADY_PROCESSED_REVIEW);
         }
 
@@ -303,12 +306,23 @@ public class ReviewService {
             String commentS = request.getCategoryComments() != null ? request.getCategoryComments().get("S") : null;
             String commentG = request.getCategoryComments() != null ? request.getCategoryComments().get("G") : null;
 
+            // REVISION_REQUIRED 상태에서 재승인하는 경우
+            if (review.isRevisionRequired()) {
+                // 기안 상태를 REVIEWING으로 되돌린 후 완료 처리
+                review.getDiagnostic().markAsReviewing();
+                log.info("Review re-approved from REVISION_REQUIRED: reviewId={}, reapprovedBy={}", reviewId, userId);
+            }
+
             review.approve(currentUser, request.getComment(), commentE, commentS, commentG);
             review.getDiagnostic().complete();
             message = "심사가 승인되었습니다";
             nextStep = "보고서 발행이 가능합니다";
             log.info("Review approved: reviewId={}, approvedBy={}", reviewId, userId);
         } else if ("REVISION_REQUIRED".equals(decision)) {
+            // 이미 REVISION_REQUIRED 상태에서 다시 보완요청 시도하면 에러
+            if (review.isRevisionRequired()) {
+                throw new CustomException(ErrorCode.ALREADY_PROCESSED_REVIEW);
+            }
             review.requestRevision(currentUser, request.getComment());
             review.getDiagnostic().returnForRevision();
             message = "보완 요청이 완료되었습니다";

--- a/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
@@ -486,13 +486,69 @@ class ReviewServiceTest {
         }
 
         @Test
-        @DisplayName("이미 처리된 심사 재처리 시 실패")
-        void processReview_AlreadyProcessed_ThrowsException() {
-            // given
+        @DisplayName("이미 승인된 심사 재처리 시 실패")
+        void processReview_AlreadyApproved_ThrowsException() {
+            // given - 이미 APPROVED 상태인 심사
             when(testReview.isReviewing()).thenReturn(false);
+            when(testReview.isRevisionRequired()).thenReturn(false);
 
             ReviewDecisionRequest request = ReviewDecisionRequest.builder()
                     .decision("APPROVED")
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(1L)).willReturn(Optional.of(testReview));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.processReview(1L, 1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.ALREADY_PROCESSED_REVIEW);
+                    });
+        }
+
+        @Test
+        @DisplayName("REVISION_REQUIRED 상태에서 재승인 성공 (#155)")
+        void processReview_RevisionRequired_ReApprove_Success() {
+            // given - REVISION_REQUIRED 상태의 심사
+            when(testReview.isReviewing()).thenReturn(false);
+            when(testReview.isRevisionRequired()).thenReturn(true);
+            when(testReview.getStatus()).thenReturn(ReviewStatus.APPROVED);
+            when(testReview.getProcessedAt()).thenReturn(LocalDateTime.now());
+
+            ReviewDecisionRequest request = ReviewDecisionRequest.builder()
+                    .decision("APPROVED")
+                    .comment("재검토 결과 승인합니다")
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(1L)).willReturn(Optional.of(testReview));
+
+            // when
+            ReviewDecisionResponse response = reviewService.processReview(1L, 1L, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getStatus()).isEqualTo("APPROVED");
+            assertThat(response.getMessage()).isEqualTo("심사가 승인되었습니다");
+
+            // 기안 상태가 REVIEWING으로 되돌려진 후 완료 처리됨
+            verify(testDiagnostic).markAsReviewing();
+            verify(testReview).approve(eq(reviewerUser), eq("재검토 결과 승인합니다"), any(), any(), any());
+            verify(testDiagnostic).complete();
+        }
+
+        @Test
+        @DisplayName("REVISION_REQUIRED 상태에서 다시 보완요청 시 실패 (#155)")
+        void processReview_RevisionRequired_DoubleRevision_ThrowsException() {
+            // given - REVISION_REQUIRED 상태의 심사에서 또 보완요청 시도
+            when(testReview.isReviewing()).thenReturn(false);
+            when(testReview.isRevisionRequired()).thenReturn(true);
+
+            ReviewDecisionRequest request = ReviewDecisionRequest.builder()
+                    .decision("REVISION_REQUIRED")
+                    .comment("추가 보완 필요")
                     .build();
 
             given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));


### PR DESCRIPTION
## 변경 요약
- 수신자(REVIEWER)가 반려(REVISION_REQUIRED)한 심사를 대시보드에서 다시 승인 가능하도록 수정
- Review 엔티티에 `isRevisionRequired()`, `revertToReviewing()` 메서드 추가
- ReviewService.processReview()에서 REVISION_REQUIRED 상태 재승인 로직 처리
- 중복 보완요청 방지 로직 추가

## 관련 이슈
- Closes #155

## 테스트 방법
1. 수신자로 로그인하여 REVISION_REQUIRED 상태의 심사 선택
2. APPROVED 결정으로 심사 결과 입력
3. 기존 기안의 상태가 COMPLETED로 변경되는지 확인 (새 기안 생성 없음)

```bash
# 단위 테스트 실행
./gradlew test --tests "ReviewServiceTest"

# 빌드 확인
./gradlew build -x test
```

## 명세 준수 체크
- [x] API 엔드포인트 변경 없음 (기존 PATCH /api/v1/reviews/{id} 사용)
- [x] 응답 스키마 변경 없음
- [x] 도메인별 권한 검증 유지
- [x] 중복 처리 방지 (REVISION_REQUIRED 상태에서 또 보완요청 시 에러)

## 리뷰 포인트
1. **상태 전이 로직**: REVISION_REQUIRED → APPROVED 시 Diagnostic 상태를 REVIEWING으로 되돌린 후 COMPLETED 처리하는 방식이 적절한지
2. **중복 방지**: 이미 REVISION_REQUIRED 상태에서 다시 REVISION_REQUIRED 요청 시 에러 반환이 맞는지

## TODO/질문
- 프론트엔드에서 REVISION_REQUIRED 상태의 심사도 재처리 가능하도록 UI 업데이트 필요
- 재승인 시 별도 알림 발송 필요 여부 확인 필요 (현재 미구현)

🤖 Generated with [Claude Code](https://claude.com/claude-code)