### PR TITLE
fix(review): 반려→재승인 시 상태 처리 오류 수정 (#155)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,42 @@
 # Claude Code Learnings
 
+## 2026-02-04: 반려→재승인 시 상태 처리 오류 수정 (#155)
+
+### 원인
+- 수신자(REVIEWER)가 반려(REVISION_REQUIRED)한 심사를 대시보드에서 다시 승인하려 할 때
+- 기존 `processReview()` 메서드가 `REVIEWING` 상태에서만 처리 가능하도록 구현됨
+- `REVISION_REQUIRED` 상태의 심사를 재승인하는 기능이 없어 의도치 않은 동작 발생
+
+### 해결
+- **Review 엔티티**: `isRevisionRequired()` 메서드 추가, `revertToReviewing()` 메서드 추가
+- **ReviewService.processReview()**: `REVISION_REQUIRED` 상태에서도 재승인(APPROVED) 가능하도록 수정
+  - `REVISION_REQUIRED` + `APPROVED` 요청 → 기안 상태를 REVIEWING으로 되돌린 후 COMPLETED 처리
+  - `REVISION_REQUIRED` + `REVISION_REQUIRED` 요청 → 중복 방지 에러 반환
+- **테스트 추가**: 재승인 성공 케이스, 중복 보완요청 실패 케이스
+
+### 재발방지
+- 상태 전이 로직 구현 시 모든 가능한 상태 조합 검토 필요
+- 특히 "취소/롤백" 시나리오가 필요한지 기획 단계에서 확인
+- 심사 워크플로우 변경 시 Review/Diagnostic 상태 동기화 주의
+
+### 검증방법
+```bash
+./gradlew test --tests "ReviewServiceTest"
+./gradlew build -x test
+```
+
+### 관련커밋
+- feature/155-fix-compliance-reapproval-v3 브랜치
+
+### 생성/수정 파일
+```
+src/main/java/.../domain/review/entity/Review.java (+isRevisionRequired, +revertToReviewing)
+src/main/java/.../domain/review/service/ReviewService.java (processReview 로직 수정)
+src/test/java/.../domain/review/service/ReviewServiceTest.java (+2 테스트 케이스)
+```
+
+---
+
 ## 2026-02-04: 전체 결재 페이지 제거 - domainCode 필수화 (#162)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
+++ b/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
@@ -104,6 +104,21 @@ public class Review extends BaseTimeEntity {
         return this.status == ReviewStatus.REVIEWING;
     }
 
+    public boolean isRevisionRequired() {
+        return this.status == ReviewStatus.REVISION_REQUIRED;
+    }
+
+    /**
+     * REVISION_REQUIRED 상태에서 다시 REVIEWING 상태로 되돌림
+     * 수신자가 반려 결정을 철회하고 재심사하려는 경우 사용
+     */
+    public void revertToReviewing() {
+        this.status = ReviewStatus.REVIEWING;
+        this.processedBy = null;
+        this.processedAt = null;
+        this.comment = null;
+    }
+
     public void updateScore(Integer score) {
         this.score = score;
         this.riskLevel = RiskLevel.fromScore(score);

--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -300,6 +300,7 @@ public class ReviewService {
     /**
      * 심사 결과 입력 (승인/보완요청)
      * - 해당 심사의 도메인에 REVIEWER 권한이 있는지 검증
+     * - REVISION_REQUIRED 상태의 심사도 재승인 가능 (반려→재승인 지원)
      */
     @Transactional
     public ReviewDecisionResponse processReview(Long userId, Long reviewId, ReviewDecisionRequest request) {
@@ -310,7 +311,9 @@ public class ReviewService {
 
         validateDomainReviewerAccess(currentUser, review);
 
-        if (!review.isReviewing()) {
+        // REVIEWING 또는 REVISION_REQUIRED 상태에서만 처리 가능
+        // REVISION_REQUIRED 상태에서는 재승인만 가능 (보완요청 중복 방지)
+        if (!review.isReviewing() && !review.isRevisionRequired()) {
             throw new CustomException(ErrorCode.ALREADY_PROCESSED_REVIEW);
         }
 
@@ -332,12 +335,23 @@ public class ReviewService {
                 commentG = request.getCategoryComments().get("G");
             }
 
+            // REVISION_REQUIRED 상태에서 재승인하는 경우
+            if (review.isRevisionRequired()) {
+                // 기안 상태를 REVIEWING으로 되돌린 후 완료 처리
+                review.getDiagnostic().markAsReviewing();
+                log.info("Review re-approved from REVISION_REQUIRED: reviewId={}, reapprovedBy={}", reviewId, userId);
+            }
+
             review.approve(currentUser, request.getComment(), commentE, commentS, commentG);
             review.getDiagnostic().complete();
             message = "심사가 승인되었습니다";
             nextStep = "보고서 발행이 가능합니다";
             log.info("Review approved: reviewId={}, approvedBy={}", reviewId, userId);
         } else if ("REVISION_REQUIRED".equals(decision)) {
+            // 이미 REVISION_REQUIRED 상태에서 다시 보완요청 시도하면 에러
+            if (review.isRevisionRequired()) {
+                throw new CustomException(ErrorCode.ALREADY_PROCESSED_REVIEW);
+            }
             review.requestRevision(currentUser, request.getComment());
             review.getDiagnostic().returnForRevision();
             message = "보완 요청이 완료되었습니다";

--- a/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
@@ -576,13 +576,69 @@ class ReviewServiceTest {
         }
 
         @Test
-        @DisplayName("이미 처리된 심사 재처리 시 실패")
-        void processReview_AlreadyProcessed_ThrowsException() {
-            // given
+        @DisplayName("이미 승인된 심사 재처리 시 실패")
+        void processReview_AlreadyApproved_ThrowsException() {
+            // given - 이미 APPROVED 상태인 심사
             when(testReview.isReviewing()).thenReturn(false);
+            when(testReview.isRevisionRequired()).thenReturn(false);
 
             ReviewDecisionRequest request = ReviewDecisionRequest.builder()
                     .decision("APPROVED")
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(1L)).willReturn(Optional.of(testReview));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.processReview(1L, 1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.ALREADY_PROCESSED_REVIEW);
+                    });
+        }
+
+        @Test
+        @DisplayName("REVISION_REQUIRED 상태에서 재승인 성공 (#155)")
+        void processReview_RevisionRequired_ReApprove_Success() {
+            // given - REVISION_REQUIRED 상태의 심사
+            when(testReview.isReviewing()).thenReturn(false);
+            when(testReview.isRevisionRequired()).thenReturn(true);
+            when(testReview.getStatus()).thenReturn(ReviewStatus.APPROVED);
+            when(testReview.getProcessedAt()).thenReturn(LocalDateTime.now());
+
+            ReviewDecisionRequest request = ReviewDecisionRequest.builder()
+                    .decision("APPROVED")
+                    .comment("재검토 결과 승인합니다")
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));
+            given(reviewRepository.findById(1L)).willReturn(Optional.of(testReview));
+
+            // when
+            ReviewDecisionResponse response = reviewService.processReview(1L, 1L, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getStatus()).isEqualTo("APPROVED");
+            assertThat(response.getMessage()).isEqualTo("심사가 승인되었습니다");
+
+            // 기안 상태가 REVIEWING으로 되돌려진 후 완료 처리됨
+            verify(testDiagnostic).markAsReviewing();
+            verify(testReview).approve(eq(reviewerUser), eq("재검토 결과 승인합니다"), any(), any(), any());
+            verify(testDiagnostic).complete();
+        }
+
+        @Test
+        @DisplayName("REVISION_REQUIRED 상태에서 다시 보완요청 시 실패 (#155)")
+        void processReview_RevisionRequired_DoubleRevision_ThrowsException() {
+            // given - REVISION_REQUIRED 상태의 심사에서 또 보완요청 시도
+            when(testReview.isReviewing()).thenReturn(false);
+            when(testReview.isRevisionRequired()).thenReturn(true);
+
+            ReviewDecisionRequest request = ReviewDecisionRequest.builder()
+                    .decision("REVISION_REQUIRED")
+                    .comment("추가 보완 필요")
                     .build();
 
             given(userRepository.findById(1L)).willReturn(Optional.of(reviewerUser));


### PR DESCRIPTION
## 변경 요약
- 수신자(REVIEWER)가 반려(REVISION_REQUIRED)한 심사를 대시보드에서 다시 승인 가능하도록 수정
- Review 엔티티에 `isRevisionRequired()`, `revertToReviewing()` 메서드 추가
- ReviewService.processReview()에서 REVISION_REQUIRED 상태 재승인 로직 처리
- 중복 보완요청 방지 로직 추가

## 관련 이슈
- Closes #155

## 테스트 방법
1. 수신자로 로그인하여 REVISION_REQUIRED 상태의 심사 선택
2. APPROVED 결정으로 심사 결과 입력
3. 기존 기안의 상태가 COMPLETED로 변경되는지 확인 (새 기안 생성 없음)

```bash
# 단위 테스트 실행
./gradlew test --tests "ReviewServiceTest"

# 빌드 확인
./gradlew build -x test
```

## 명세 준수 체크
- [x] API 엔드포인트 변경 없음 (기존 PATCH /api/v1/reviews/{id} 사용)
- [x] 응답 스키마 변경 없음
- [x] 도메인별 권한 검증 유지
- [x] 중복 처리 방지 (REVISION_REQUIRED 상태에서 또 보완요청 시 에러)

## 리뷰 포인트
1. **상태 전이 로직**: REVISION_REQUIRED → APPROVED 시 Diagnostic 상태를 REVIEWING으로 되돌린 후 COMPLETED 처리하는 방식이 적절한지
2. **중복 방지**: 이미 REVISION_REQUIRED 상태에서 다시 REVISION_REQUIRED 요청 시 에러 반환이 맞는지

## TODO/질문
- 프론트엔드에서 REVISION_REQUIRED 상태의 심사도 재처리 가능하도록 UI 업데이트 필요
- 재승인 시 별도 알림 발송 필요 여부 확인 필요 (현재 미구현)

🤖 Generated with [Claude Code](https://claude.com/claude-code)