### PR TITLE
fix(esg): 기안/캠페인 상태 불일치 수정 (#156)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,43 @@
 # Claude Code Learnings
 
+## 2026-02-04: 기안 상태 불일치 - 심사중/완료 동시 존재 (#156)
+
+### 원인
+- 기안 목록에서 기안(Diagnostic) 상태는 실제 진행 상태(REVIEWING 등) 표시
+- 캠페인(Campaign) 상태는 날짜 기반으로 동적 계산(DRAFT/ACTIVE/CLOSED)
+- CampaignSimpleDto에 status 필드가 없어 프론트엔드에서 별도 계산
+- 캠페인 종료일 지났으나 기안이 아직 심사 중이면 상태 불일치 발생
+
+### 해결
+- **CampaignSimpleDto**: `status`, `statusLabel` 필드 추가
+- **DiagnosticService.mapToListItemDto()**: 기안 상태 기반으로 캠페인 상태 결정
+  - 기안 COMPLETED → 캠페인 "COMPLETED" (완료)
+  - 그 외 상태 → 캠페인 "ACTIVE" (진행중)
+- 기안 목록 응답에서 기안/캠페인 상태가 일관되게 표시됨
+
+### 재발방지
+- DTO 간 상태 표시 로직이 다를 경우 불일치 발생 가능
+- 관련 엔티티 상태를 표시할 때는 단일 소스(기안 상태)를 기준으로 결정
+- 날짜 기반 상태 계산은 캠페인 목록에서만 사용, 기안 목록에서는 기안 상태 기반 사용
+
+### 검증방법
+```bash
+./gradlew test --tests "DiagnosticServiceTest"
+./gradlew build -x test
+```
+
+### 관련커밋
+- feature/156-campaign-status-consistency 브랜치
+
+### 생성/수정 파일
+```
+src/main/java/.../dto/diagnostic/common/CampaignSimpleDto.java (+status, +statusLabel)
+src/main/java/.../domain/diagnostic/service/DiagnosticService.java (+determineCampaignStatusByDiagnostic, +getCampaignStatusLabel)
+src/test/java/.../domain/diagnostic/service/DiagnosticServiceTest.java (+3 테스트 케이스)
+```
+
+---
+
 ## 2026-02-04: 반려→재승인 시 상태 처리 오류 수정 (#155)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -657,10 +657,15 @@ public class DiagnosticService {
         CampaignSimpleDto campaignDto = null;
         if (diagnostic.getCampaign() != null) {
             Campaign campaign = diagnostic.getCampaign();
+            // 기안 상태 기반으로 캠페인 상태 결정 (Issue #156)
+            String campaignStatus = determineCampaignStatusByDiagnostic(diagnostic.getStatus());
+            String campaignStatusLabel = getCampaignStatusLabel(campaignStatus);
             campaignDto = CampaignSimpleDto.builder()
                     .campaignId(campaign.getCampaignId())
                     .campaignCode(campaign.getCampaignCode())
                     .title(campaign.getTitle())
+                    .status(campaignStatus)
+                    .statusLabel(campaignStatusLabel)
                     .build();
         }
 
@@ -723,5 +728,25 @@ public class DiagnosticService {
                 .comment(history.getComment())
                 .timestamp(history.getCreatedAt())
                 .build();
+    }
+
+    /**
+     * 기안 상태 기반으로 캠페인 상태 결정 (Issue #156)
+     * - 기안이 COMPLETED면 캠페인도 "COMPLETED" (완료)
+     * - 그 외의 경우 "ACTIVE" (진행중)
+     */
+    private String determineCampaignStatusByDiagnostic(DiagnosticStatus diagnosticStatus) {
+        if (diagnosticStatus == DiagnosticStatus.COMPLETED) {
+            return "COMPLETED";
+        }
+        return "ACTIVE";
+    }
+
+    private String getCampaignStatusLabel(String campaignStatus) {
+        return switch (campaignStatus) {
+            case "COMPLETED" -> "완료";
+            case "ACTIVE" -> "진행중";
+            default -> "알 수 없음";
+        };
     }
 }

--- a/src/main/java/com/smartchain/platform/dto/diagnostic/common/CampaignSimpleDto.java
+++ b/src/main/java/com/smartchain/platform/dto/diagnostic/common/CampaignSimpleDto.java
@@ -13,4 +13,6 @@ public class CampaignSimpleDto {
     private Long campaignId;
     private String campaignCode;         // "CMP-2026-001"
     private String title;                // "2025년도 상반기 ESG 자가진단"
+    private String status;               // "ACTIVE", "COMPLETED" - 기안 상태 기반
+    private String statusLabel;          // "진행중", "완료"
 }

--- a/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
@@ -1200,4 +1200,122 @@ class DiagnosticServiceTest {
                     });
         }
     }
+
+    @Nested
+    @DisplayName("캠페인 상태 일관성 테스트 (Issue #156)")
+    class CampaignStatusConsistencyTest {
+
+        @Test
+        @DisplayName("기안이 REVIEWING 상태면 캠페인도 '진행중' 표시")
+        void getDiagnosticList_ReviewingStatus_CampaignShowsActive() {
+            // given
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            lenient().when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            lenient().when(diagnostic.getDiagnosticCode()).thenReturn("DG-2026-00001");
+            lenient().when(diagnostic.getTitle()).thenReturn("2026년 ESG 자가진단");
+            lenient().when(diagnostic.getCampaign()).thenReturn(testCampaign);
+            lenient().when(diagnostic.getCompany()).thenReturn(testCompany);
+            lenient().when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.REVIEWING);  // 심사중
+            lenient().when(diagnostic.getPeriodStartDate()).thenReturn(LocalDate.of(2026, 1, 1));
+            lenient().when(diagnostic.getPeriodEndDate()).thenReturn(LocalDate.of(2026, 12, 31));
+            lenient().when(diagnostic.getDeadline()).thenReturn(LocalDate.of(2026, 3, 31));
+            lenient().when(diagnostic.getQualitativeProgress()).thenReturn(100);
+            lenient().when(diagnostic.getQuantitativeProgress()).thenReturn(100);
+            lenient().when(diagnostic.getOverallProgress()).thenReturn(100);
+            lenient().when(diagnostic.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            Page<Diagnostic> diagnosticPage = new PageImpl<>(List.of(diagnostic), PageRequest.of(0, 10), 1);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findByDrafterIdAndFilters(eq(1L), eq(false), any(), eq(false), any(), any(), any(), any(), any()))
+                    .willReturn(diagnosticPage);
+
+            // when
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, null, null, null, null, null, 0, 10);
+
+            // then
+            assertThat(response.getContent()).hasSize(1);
+            assertThat(response.getContent().get(0).getStatus()).isEqualTo("REVIEWING");
+            assertThat(response.getContent().get(0).getStatusLabel()).isEqualTo("심사중");
+            // 캠페인 상태도 기안 상태와 일관되게 "진행중"이어야 함 (Issue #156)
+            assertThat(response.getContent().get(0).getCampaign()).isNotNull();
+            assertThat(response.getContent().get(0).getCampaign().getStatus()).isEqualTo("ACTIVE");
+            assertThat(response.getContent().get(0).getCampaign().getStatusLabel()).isEqualTo("진행중");
+        }
+
+        @Test
+        @DisplayName("기안이 COMPLETED 상태면 캠페인도 '완료' 표시")
+        void getDiagnosticList_CompletedStatus_CampaignShowsCompleted() {
+            // given
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            lenient().when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            lenient().when(diagnostic.getDiagnosticCode()).thenReturn("DG-2026-00001");
+            lenient().when(diagnostic.getTitle()).thenReturn("2026년 ESG 자가진단");
+            lenient().when(diagnostic.getCampaign()).thenReturn(testCampaign);
+            lenient().when(diagnostic.getCompany()).thenReturn(testCompany);
+            lenient().when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.COMPLETED);  // 완료
+            lenient().when(diagnostic.getPeriodStartDate()).thenReturn(LocalDate.of(2026, 1, 1));
+            lenient().when(diagnostic.getPeriodEndDate()).thenReturn(LocalDate.of(2026, 12, 31));
+            lenient().when(diagnostic.getDeadline()).thenReturn(LocalDate.of(2026, 3, 31));
+            lenient().when(diagnostic.getQualitativeProgress()).thenReturn(100);
+            lenient().when(diagnostic.getQuantitativeProgress()).thenReturn(100);
+            lenient().when(diagnostic.getOverallProgress()).thenReturn(100);
+            lenient().when(diagnostic.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            Page<Diagnostic> diagnosticPage = new PageImpl<>(List.of(diagnostic), PageRequest.of(0, 10), 1);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findByDrafterIdAndFilters(eq(1L), eq(false), any(), eq(false), any(), any(), any(), any(), any()))
+                    .willReturn(diagnosticPage);
+
+            // when
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, null, null, null, null, null, 0, 10);
+
+            // then
+            assertThat(response.getContent()).hasSize(1);
+            assertThat(response.getContent().get(0).getStatus()).isEqualTo("COMPLETED");
+            assertThat(response.getContent().get(0).getStatusLabel()).isEqualTo("완료");
+            // 캠페인 상태도 기안 상태와 일관되게 "완료"이어야 함 (Issue #156)
+            assertThat(response.getContent().get(0).getCampaign()).isNotNull();
+            assertThat(response.getContent().get(0).getCampaign().getStatus()).isEqualTo("COMPLETED");
+            assertThat(response.getContent().get(0).getCampaign().getStatusLabel()).isEqualTo("완료");
+        }
+
+        @Test
+        @DisplayName("기안이 WRITING 상태면 캠페인도 '진행중' 표시")
+        void getDiagnosticList_WritingStatus_CampaignShowsActive() {
+            // given
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            lenient().when(diagnostic.getDiagnosticId()).thenReturn(1L);
+            lenient().when(diagnostic.getDiagnosticCode()).thenReturn("DG-2026-00001");
+            lenient().when(diagnostic.getTitle()).thenReturn("2026년 ESG 자가진단");
+            lenient().when(diagnostic.getCampaign()).thenReturn(testCampaign);
+            lenient().when(diagnostic.getCompany()).thenReturn(testCompany);
+            lenient().when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.WRITING);  // 작성중
+            lenient().when(diagnostic.getPeriodStartDate()).thenReturn(LocalDate.of(2026, 1, 1));
+            lenient().when(diagnostic.getPeriodEndDate()).thenReturn(LocalDate.of(2026, 12, 31));
+            lenient().when(diagnostic.getDeadline()).thenReturn(LocalDate.of(2026, 3, 31));
+            lenient().when(diagnostic.getQualitativeProgress()).thenReturn(0);
+            lenient().when(diagnostic.getQuantitativeProgress()).thenReturn(0);
+            lenient().when(diagnostic.getOverallProgress()).thenReturn(0);
+            lenient().when(diagnostic.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            Page<Diagnostic> diagnosticPage = new PageImpl<>(List.of(diagnostic), PageRequest.of(0, 10), 1);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findByDrafterIdAndFilters(eq(1L), eq(false), any(), eq(false), any(), any(), any(), any(), any()))
+                    .willReturn(diagnosticPage);
+
+            // when
+            DiagnosticListResponse response = diagnosticService.getDiagnosticList(1L, null, null, null, null, null, 0, 10);
+
+            // then
+            assertThat(response.getContent()).hasSize(1);
+            assertThat(response.getContent().get(0).getStatus()).isEqualTo("WRITING");
+            // 캠페인 상태는 "진행중" (기안이 아직 완료되지 않음)
+            assertThat(response.getContent().get(0).getCampaign()).isNotNull();
+            assertThat(response.getContent().get(0).getCampaign().getStatus()).isEqualTo("ACTIVE");
+            assertThat(response.getContent().get(0).getCampaign().getStatusLabel()).isEqualTo("진행중");
+        }
+    }
 }


### PR DESCRIPTION
## 변경 요약
- 기안 목록 조회 시 기안(Diagnostic)과 캠페인(Campaign) 상태가 일관되게 표시되도록 수정
- `CampaignSimpleDto`에 `status`, `statusLabel` 필드 추가
- 기안 상태 기반으로 캠페인 상태를 결정하는 로직 구현

## 관련 이슈
- Closes #156

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `CampaignSimpleDto.java` | `status`, `statusLabel` 필드 추가 |
| `DiagnosticService.java` | `determineCampaignStatusByDiagnostic()`, `getCampaignStatusLabel()` 메서드 추가 |
| `DiagnosticServiceTest.java` | 캠페인 상태 일관성 테스트 3개 추가 |
| `LEARNINGS.md` | 학습 내용 기록 |

## 테스트 방법
```bash
./gradlew test --tests "DiagnosticServiceTest"
./gradlew build -x test
```

## 명세 준수 체크
- [x] 기안 COMPLETED → 캠페인 "COMPLETED" (완료)
- [x] 기안 REVIEWING → 캠페인 "ACTIVE" (진행중)
- [x] 기안 WRITING → 캠페인 "ACTIVE" (진행중)

## 리뷰 포인트
1. 캠페인 상태 결정 로직이 기안 상태만 기준으로 하는 것이 적절한지
2. 캠페인 목록 조회 시에는 기존 날짜 기반 로직 유지 (변경 없음)

## TODO/질문
- 캠페인 목록 API에서의 상태 결정 로직은 현재 날짜 기반으로 유지됨
- 기안 목록에서만 기안 상태 기반으로 캠페인 상태 표시