### PR TITLE
feat(diagnostic): 기안 삭제 API 구현 (#174)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/diagnostic/controller/DiagnosticController.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/controller/DiagnosticController.java
@@ -127,6 +127,16 @@ public class DiagnosticController {
         return ResponseEntity.ok(BaseResponse.success(response));
     }
 
+    @Operation(summary = "기안 삭제", description = "기안을 삭제합니다. 작성 중(WRITING) 상태인 본인 기안만 삭제 가능합니다.")
+    @DeleteMapping("/{diagnosticId}")
+    public ResponseEntity<BaseResponse<Void>> deleteDiagnostic(
+            HttpServletRequest request,
+            @PathVariable Long diagnosticId) {
+        Long userId = extractUserIdFromRequest(request);
+        diagnosticService.deleteDiagnostic(userId, diagnosticId);
+        return ResponseEntity.ok(BaseResponse.success("기안이 삭제되었습니다.", null));
+    }
+
     private Long extractUserIdFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -510,6 +510,35 @@ public class DiagnosticService {
     }
 
     /**
+     * 기안 삭제
+     * - WRITING 상태인 기안만 삭제 가능
+     * - 본인이 생성한 기안만 삭제 가능
+     */
+    @Transactional
+    public void deleteDiagnostic(Long userId, Long diagnosticId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Diagnostic diagnostic = diagnosticRepository.findById(diagnosticId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DIAGNOSTIC_NOT_FOUND));
+
+        // 본인 기안인지 확인
+        if (!diagnostic.getDrafterId().equals(userId)) {
+            throw new CustomException(ErrorCode.DIAGNOSTIC_NOT_OWNER);
+        }
+
+        // WRITING 상태인지 확인
+        if (diagnostic.getStatus() != DiagnosticStatus.WRITING) {
+            throw new CustomException(ErrorCode.DIAGNOSTIC_DELETE_NOT_ALLOWED);
+        }
+
+        // 삭제 실행 (연관 파일은 Cascade로 삭제됨)
+        diagnosticRepository.delete(diagnostic);
+
+        log.info("Diagnostic deleted: diagnosticId={}, deletedBy={}", diagnosticId, userId);
+    }
+
+    /**
      * 도메인 기반 접근 권한 검증 (DRAFTER 또는 APPROVER)
      */
     private void validateDomainAccess(User user, Diagnostic diagnostic) {

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -82,6 +82,10 @@ public enum ErrorCode {
     ALREADY_PROCESSED_REVIEW(HttpStatus.CONFLICT, "RV002", "이미 처리된 심사입니다"),
     INVALID_REVIEW_DECISION(HttpStatus.BAD_REQUEST, "RV003", "유효하지 않은 심사 결과입니다"),
     INVALID_CATEGORY_FOR_DOMAIN(HttpStatus.BAD_REQUEST, "RV004", "해당 도메인에서 허용되지 않는 카테고리입니다"),
+
+    // Diagnostic Delete
+    DIAGNOSTIC_NOT_OWNER(HttpStatus.FORBIDDEN, "DIAG001", "본인이 생성한 기안만 삭제할 수 있습니다"),
+    DIAGNOSTIC_DELETE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "DIAG002", "작성 중인 기안만 삭제할 수 있습니다"),
     JOB_NOT_RETRYABLE(HttpStatus.BAD_REQUEST, "JOB002", "재시도할 수 없는 작업입니다"),
     JOB_NOT_FAILED(HttpStatus.BAD_REQUEST, "JOB003", "실패한 작업만 재시도할 수 있습니다"),
 

--- a/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
@@ -1200,4 +1200,107 @@ class DiagnosticServiceTest {
                     });
         }
     }
+
+    @Nested
+    @DisplayName("기안 삭제 테스트")
+    class DeleteDiagnosticTest {
+
+        @Test
+        @DisplayName("WRITING 상태의 본인 기안 삭제 성공")
+        void deleteDiagnostic_WritingStatus_Success() {
+            // given
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            lenient().when(diagnostic.getDiagnosticId()).thenReturn(100L);
+            when(diagnostic.getDrafterId()).thenReturn(1L);
+            when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.WRITING);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(100L)).willReturn(Optional.of(diagnostic));
+
+            // when
+            diagnosticService.deleteDiagnostic(1L, 100L);
+
+            // then
+            verify(diagnosticRepository).delete(diagnostic);
+        }
+
+        @Test
+        @DisplayName("본인 기안이 아닌 경우 DIAGNOSTIC_NOT_OWNER 에러")
+        void deleteDiagnostic_NotOwner_ThrowsException() {
+            // given
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDrafterId()).thenReturn(999L); // 다른 사용자
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(100L)).willReturn(Optional.of(diagnostic));
+
+            // when & then
+            assertThatThrownBy(() -> diagnosticService.deleteDiagnostic(1L, 100L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.DIAGNOSTIC_NOT_OWNER);
+                    });
+
+            verify(diagnosticRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("SUBMITTED 상태 기안 삭제 시 DIAGNOSTIC_DELETE_NOT_ALLOWED 에러")
+        void deleteDiagnostic_SubmittedStatus_ThrowsException() {
+            // given
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDrafterId()).thenReturn(1L);
+            when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.SUBMITTED);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(100L)).willReturn(Optional.of(diagnostic));
+
+            // when & then
+            assertThatThrownBy(() -> diagnosticService.deleteDiagnostic(1L, 100L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.DIAGNOSTIC_DELETE_NOT_ALLOWED);
+                    });
+
+            verify(diagnosticRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 기안 삭제 시 DIAGNOSTIC_NOT_FOUND 에러")
+        void deleteDiagnostic_NotFound_ThrowsException() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> diagnosticService.deleteDiagnostic(1L, 999L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.DIAGNOSTIC_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("APPROVED 상태 기안 삭제 시 DIAGNOSTIC_DELETE_NOT_ALLOWED 에러")
+        void deleteDiagnostic_ApprovedStatus_ThrowsException() {
+            // given
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDrafterId()).thenReturn(1L);
+            when(diagnostic.getStatus()).thenReturn(DiagnosticStatus.APPROVED);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(100L)).willReturn(Optional.of(diagnostic));
+
+            // when & then
+            assertThatThrownBy(() -> diagnosticService.deleteDiagnostic(1L, 100L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException ce = (CustomException) ex;
+                        assertThat(ce.getErrorCode()).isEqualTo(ErrorCode.DIAGNOSTIC_DELETE_NOT_ALLOWED);
+                    });
+        }
+    }
 }


### PR DESCRIPTION
## 변경 요약
- `DELETE /api/v1/diagnostics/{diagnosticId}` 엔드포인트 추가
- WRITING 상태의 본인 기안만 삭제 가능
- 에러 코드 추가: `DIAGNOSTIC_NOT_OWNER` (DIAG001), `DIAGNOSTIC_DELETE_NOT_ALLOWED` (DIAG002)

## 관련 이슈
- Closes #174

## 테스트 방법
```bash
# 단위 테스트
./gradlew test --tests "*DiagnosticServiceTest*delete*"

# API 테스트
DELETE /api/v1/diagnostics/{id}
Authorization: Bearer {DRAFTER_TOKEN}
```

## 명세 준수 체크
- [x] 엔드포인트: `DELETE /api/v1/diagnostics/{diagnosticId}`
- [x] 성공 응답: 200 OK + BaseResponse
- [x] DIAG001: 본인 기안 아님 (403)
- [x] DIAG002: WRITING 상태 아님 (403)
- [x] D001: 기안 없음 (404) - 기존 코드 재사용

## 리뷰 포인트
1. Hard delete vs Soft delete - 현재 Hard delete로 구현
2. Cascade 삭제 동작 확인 필요 (EvidenceFile 등)

## 변경된 파일
| 파일 | 변경 내용 |
|------|----------|
| `ErrorCode.java` | DIAG001, DIAG002 추가 |
| `DiagnosticService.java` | deleteDiagnostic 메서드 추가 |
| `DiagnosticController.java` | DELETE 엔드포인트 추가 |
| `DiagnosticServiceTest.java` | 삭제 테스트 5개 추가 |

## TODO/질문
- [ ] RETURNED (반려됨) 상태도 삭제 허용할지? (현재: 불가)
- [ ] 프론트엔드 PR #281과 연동 테스트 필요