### PR TITLE
fix(diagnostic): DiagnosticStatus enum에 displayName/description 추가 (#160)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -50,7 +50,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Service
@@ -67,15 +66,6 @@ public class DiagnosticService {
     private final DomainRepository domainRepository;
 
     private static final List<String> ALLOWED_ROLES = Arrays.asList("DRAFTER", "APPROVER");
-
-    private static final Map<String, String> STATUS_LABEL_MAP = Map.of(
-            "WRITING", "작성중",
-            "SUBMITTED", "제출됨",
-            "RETURNED", "반려됨",
-            "APPROVED", "내부승인",
-            "REVIEWING", "심사중",
-            "COMPLETED", "완료"
-    );
 
     public DiagnosticListResponse getDiagnosticList(Long userId, String domainCode, String statuses,
                                                      String keyword, LocalDate deadlineFrom,
@@ -257,7 +247,7 @@ public class DiagnosticService {
                 .period(periodDto)
                 .deadline(diagnostic.getDeadline())
                 .status(diagnostic.getStatus().name())
-                .statusLabel(STATUS_LABEL_MAP.getOrDefault(diagnostic.getStatus().name(), diagnostic.getStatus().name()))
+                .statusLabel(diagnostic.getStatus().getDisplayName())
                 .qualitativeProgress(diagnostic.getQualitativeProgress())
                 .quantitativeProgress(diagnostic.getQuantitativeProgress())
                 .overallProgress(diagnostic.getOverallProgress())
@@ -700,7 +690,7 @@ public class DiagnosticService {
                 .period(periodDto)
                 .deadline(diagnostic.getDeadline())
                 .status(diagnostic.getStatus().name())
-                .statusLabel(STATUS_LABEL_MAP.getOrDefault(diagnostic.getStatus().name(), diagnostic.getStatus().name()))
+                .statusLabel(diagnostic.getStatus().getDisplayName())
                 .progress(progressDto)
                 .createdAt(diagnostic.getCreatedAt())
                 .updatedAt(diagnostic.getUpdatedAt())

--- a/src/main/java/com/smartchain/platform/global/enums/DiagnosticStatus.java
+++ b/src/main/java/com/smartchain/platform/global/enums/DiagnosticStatus.java
@@ -1,10 +1,45 @@
 package com.smartchain.platform.global.enums;
 
+/**
+ * 진단 상태 (DiagnosticStatus)
+ *
+ * <p>상태 전이 흐름:
+ * <pre>
+ * WRITING → SUBMITTED → RETURNED (반려 시)
+ *                     ↓
+ *                APPROVED → REVIEWING → COMPLETED
+ * </pre>
+ *
+ * @see <a href="docs/STATUS_AND_ERROR_CODES.md">상태 코드 문서</a>
+ */
 public enum DiagnosticStatus {
-    WRITING,     // 작성중
-    SUBMITTED,   // 제출됨 (결재자에게 제출)
-    RETURNED,    // 반려됨 (보완 요청으로 반려)
-    APPROVED,    // 내부승인 (협력사 내부 승인)
-    REVIEWING,   // 심사중 (원청 심사 중)
-    COMPLETED    // 완료 (최종 완료)
+
+    WRITING("작성중", "기안자가 진단 작성 중"),
+    SUBMITTED("제출됨", "결재자에게 제출됨"),
+    RETURNED("반려됨", "결재자가 반려함 (보완 요청)"),
+    APPROVED("내부승인", "협력사 내부 승인 완료"),
+    REVIEWING("심사중", "원청에서 심사 진행 중"),
+    COMPLETED("완료", "심사 완료 (최종 상태)");
+
+    private final String displayName;
+    private final String description;
+
+    DiagnosticStatus(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    /**
+     * 프론트엔드 표시용 한글명
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * 상태 설명
+     */
+    public String getDescription() {
+        return description;
+    }
 }

--- a/src/test/java/com/smartchain/platform/global/enums/DiagnosticStatusTest.java
+++ b/src/test/java/com/smartchain/platform/global/enums/DiagnosticStatusTest.java
@@ -1,0 +1,63 @@
+package com.smartchain.platform.global.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DiagnosticStatus Enum 테스트")
+class DiagnosticStatusTest {
+
+    @Test
+    @DisplayName("모든 상태에 displayName이 정의됨")
+    void diagnosticStatus_AllHaveDisplayName() {
+        for (DiagnosticStatus status : DiagnosticStatus.values()) {
+            assertThat(status.getDisplayName())
+                    .as("Status %s should have displayName", status.name())
+                    .isNotNull()
+                    .isNotBlank();
+        }
+    }
+
+    @Test
+    @DisplayName("상태별 displayName이 올바르게 정의됨")
+    void diagnosticStatus_DisplayNameIsCorrect() {
+        assertThat(DiagnosticStatus.WRITING.getDisplayName()).isEqualTo("작성중");
+        assertThat(DiagnosticStatus.SUBMITTED.getDisplayName()).isEqualTo("제출됨");
+        assertThat(DiagnosticStatus.RETURNED.getDisplayName()).isEqualTo("반려됨");
+        assertThat(DiagnosticStatus.APPROVED.getDisplayName()).isEqualTo("내부승인");
+        assertThat(DiagnosticStatus.REVIEWING.getDisplayName()).isEqualTo("심사중");
+        assertThat(DiagnosticStatus.COMPLETED.getDisplayName()).isEqualTo("완료");
+    }
+
+    @Test
+    @DisplayName("모든 상태에 description이 정의됨")
+    void diagnosticStatus_AllHaveDescription() {
+        for (DiagnosticStatus status : DiagnosticStatus.values()) {
+            assertThat(status.getDescription())
+                    .as("Status %s should have description", status.name())
+                    .isNotNull()
+                    .isNotBlank();
+        }
+    }
+
+    @Test
+    @DisplayName("상태 개수가 6개임 (워크플로우 일관성 검증)")
+    void diagnosticStatus_CountIsSix() {
+        assertThat(DiagnosticStatus.values()).hasSize(6);
+    }
+
+    @Test
+    @DisplayName("상태 순서가 워크플로우와 일치함")
+    void diagnosticStatus_OrderMatchesWorkflow() {
+        DiagnosticStatus[] expected = {
+                DiagnosticStatus.WRITING,
+                DiagnosticStatus.SUBMITTED,
+                DiagnosticStatus.RETURNED,
+                DiagnosticStatus.APPROVED,
+                DiagnosticStatus.REVIEWING,
+                DiagnosticStatus.COMPLETED
+        };
+        assertThat(DiagnosticStatus.values()).containsExactly(expected);
+    }
+}


### PR DESCRIPTION
## 변경 요약
- DiagnosticStatus enum에 `displayName`, `description` 필드 추가
- FE/BE 상태 표시명 통일을 위한 중앙 집중 관리 방식 적용
- DiagnosticService의 하드코딩된 `STATUS_LABEL_MAP` 제거
- `enum.getDisplayName()` 메서드로 대체

## 관련 이슈
- Closes #160 (상태 카테고리 FE/BE 통일)

## 테스트 방법
```bash
./gradlew test --tests "DiagnosticStatusTest"
./gradlew test --tests "DiagnosticServiceTest"
```

### 확인 사항
- [x] DiagnosticStatus enum 테스트 통과
- [x] DiagnosticService 테스트 통과
- [x] 빌드 성공

## 명세 준수 체크
- [x] `docs/STATUS_AND_ERROR_CODES.md`와 일치하는 displayName
- [x] 상태 전이 흐름 주석 추가 (WRITING → SUBMITTED → RETURNED/APPROVED → REVIEWING → COMPLETED)
- [x] API 응답의 `statusLabel` 필드에 `getDisplayName()` 값 사용

## 리뷰 포인트
1. enum에 필드 추가하는 방식이 기존 코드 호환성에 영향 없음
2. `getDisplayName()`과 `getDescription()` 메서드 네이밍
3. 테스트 커버리지 충분한지

## TODO/질문
- FE에서 `status` 대신 `statusLabel`을 UI에 표시하면 됨
- 추후 상태 그룹(대시보드용 카테고리) 추가 필요시 enum에 `statusGroup` 필드 추가 고려