### PR TITLE
fix(esg): 결재자 제출 후 Review 엔티티 생성 (#158)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1602,3 +1602,39 @@ docs/STATUS_AND_ERROR_CODES.md (AI007 문서화)
 src/main/java/.../domain/review/service/ReviewService.java (AiAnalysisResultRepository 추가, fetchAiAnalysisResult 메서드)
 src/test/java/.../domain/review/service/ReviewServiceTest.java (AI 분석 결과 테스트 2건)
 ```
+
+---
+
+## 2026-02-04: 결재자 제출 후 수신자에게 서류 안 올라감 (#158)
+
+### 원인
+- `ApprovalService.submitToReviewer()` 메서드에서 Diagnostic 상태만 REVIEWING으로 변경
+- Review 엔티티를 생성하지 않아 수신자 대시보드/심사 목록에서 조회 불가
+- 주석에 "Review entity not yet created - will be created by Review API"라고 되어 있었으나 실제로 Review API에서 생성하는 로직 없음
+
+### 해결
+- `ApprovalService`에 `ReviewRepository` 의존성 추가
+- `submitToReviewer()` 메서드에서 Review 엔티티 생성 로직 추가:
+  - Diagnostic, Company, Domain, Score(overallScore), submittedAt 설정
+  - ReviewRepository.save() 호출
+- 응답의 reviewId에 생성된 Review ID 반환 (기존 null → 실제 ID)
+- 테스트 2건 추가: Review 생성 검증, Review 데이터 검증
+
+### 재발 방지
+- 엔티티 생성이 필요한 워크플로우 전이 시 실제 생성 로직 구현 확인
+- "will be created later" 주석은 실제 구현 여부를 별도 검증 필요
+- 연관 엔티티 생성 누락 시 조회 API에서 결과 없음으로 나타남
+
+### 검증방법
+```bash
+./gradlew test --tests "ApprovalServiceTest"
+```
+
+### 관련커밋
+- PR #158 (feature/158-review-creation-on-submit)
+
+### 생성/수정 파일
+```
+src/main/java/.../domain/approval/service/ApprovalService.java (ReviewRepository 추가, Review 생성 로직)
+src/test/java/.../domain/approval/service/ApprovalServiceTest.java (+2 테스트 케이스)
+```

--- a/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
+++ b/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
@@ -3,6 +3,8 @@ package com.smartchain.platform.domain.approval.service;
 import com.smartchain.platform.domain.approval.entity.Approval;
 import com.smartchain.platform.domain.approval.repository.ApprovalRepository;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.domain.review.entity.Review;
+import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.entity.User;
@@ -48,6 +50,7 @@ public class ApprovalService {
     private final ApprovalRepository approvalRepository;
     private final UserRepository userRepository;
     private final DomainRepository domainRepository;
+    private final ReviewRepository reviewRepository;
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
 
@@ -300,18 +303,29 @@ public class ApprovalService {
             throw new CustomException(ErrorCode.DIAGNOSTIC_NOT_APPROVED);
         }
 
-        String previousStatus = approval.getDiagnostic().getStatus().name();
+        Diagnostic diagnostic = approval.getDiagnostic();
+        String previousStatus = diagnostic.getStatus().name();
 
         approval.submitToReviewer();
-        approval.getDiagnostic().markAsReviewing();
+        diagnostic.markAsReviewing();
 
-        log.info("Submitted to reviewer: approvalId={}, diagnosticId={}, submittedBy={}",
-                approvalId, approval.getDiagnostic().getDiagnosticId(), userId);
+        // Review 엔티티 생성 (#158)
+        Review review = Review.builder()
+                .diagnostic(diagnostic)
+                .company(diagnostic.getCompany())
+                .domain(diagnostic.getDomain())
+                .score(diagnostic.getOverallScore())
+                .submittedAt(approval.getSubmittedToReviewerAt())
+                .build();
+        Review savedReview = reviewRepository.save(review);
+
+        log.info("Submitted to reviewer: approvalId={}, diagnosticId={}, reviewId={}, submittedBy={}",
+                approvalId, diagnostic.getDiagnosticId(), savedReview.getReviewId(), userId);
 
         return SubmitToReviewerResponse.builder()
                 .approvalId(approval.getApprovalId())
-                .diagnosticId(approval.getDiagnostic().getDiagnosticId())
-                .reviewId(null)  // Review entity not yet created - will be created by Review API
+                .diagnosticId(diagnostic.getDiagnosticId())
+                .reviewId(savedReview.getReviewId())
                 .previousStatus(previousStatus)
                 .newStatus(DiagnosticStatus.REVIEWING.name())
                 .submittedAt(approval.getSubmittedToReviewerAt())

--- a/src/test/java/com/smartchain/platform/domain/approval/service/ApprovalServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/approval/service/ApprovalServiceTest.java
@@ -3,6 +3,8 @@ package com.smartchain.platform.domain.approval.service;
 import com.smartchain.platform.domain.approval.entity.Approval;
 import com.smartchain.platform.domain.approval.repository.ApprovalRepository;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.domain.review.entity.Review;
+import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.entity.Role;
@@ -59,6 +61,9 @@ class ApprovalServiceTest {
 
     @Mock
     private DomainRepository domainRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
 
     @Mock
     private User approverUser;
@@ -444,13 +449,17 @@ class ApprovalServiceTest {
     class SubmitToReviewerTest {
 
         @Test
-        @DisplayName("원청 제출 성공")
+        @DisplayName("원청 제출 성공 - Review 엔티티 생성 검증 (#158)")
         void submitToReviewer_Success() {
             // given
+            LocalDateTime submittedAt = LocalDateTime.now();
             when(testApproval.isApproved()).thenReturn(true);
-            when(testApproval.getSubmittedToReviewerAt()).thenReturn(LocalDateTime.now());
+            when(testApproval.getSubmittedToReviewerAt()).thenReturn(submittedAt);
             when(testDiagnostic.isApproved()).thenReturn(true);
             when(testDiagnostic.getStatus()).thenReturn(DiagnosticStatus.APPROVED);
+
+            Review savedReview = mock(Review.class);
+            when(savedReview.getReviewId()).thenReturn(50L);
 
             SubmitToReviewerRequest request = SubmitToReviewerRequest.builder()
                     .submitComment("원청 제출합니다")
@@ -458,6 +467,7 @@ class ApprovalServiceTest {
 
             given(userRepository.findById(1L)).willReturn(Optional.of(approverUser));
             given(approvalRepository.findById(1L)).willReturn(Optional.of(testApproval));
+            given(reviewRepository.save(any(Review.class))).willReturn(savedReview);
 
             // when
             SubmitToReviewerResponse response = approvalService.submitToReviewer(1L, 1L, request);
@@ -466,11 +476,63 @@ class ApprovalServiceTest {
             assertThat(response).isNotNull();
             assertThat(response.getApprovalId()).isEqualTo(1L);
             assertThat(response.getDiagnosticId()).isEqualTo(100L);
+            assertThat(response.getReviewId()).isEqualTo(50L);  // Review 생성 확인
             assertThat(response.getPreviousStatus()).isEqualTo("APPROVED");
             assertThat(response.getNewStatus()).isEqualTo("REVIEWING");
             assertThat(response.getMessage()).isEqualTo("원청에 제출되었습니다");
             verify(testApproval).submitToReviewer();
             verify(testDiagnostic).markAsReviewing();
+            verify(reviewRepository).save(any(Review.class));  // Review 저장 호출 확인
+        }
+
+        @Test
+        @DisplayName("원청 제출 시 Review 엔티티에 Diagnostic/Company/Domain 정보가 올바르게 설정되는지 검증 (#158)")
+        void submitToReviewer_CreatesReviewWithCorrectData() {
+            // given
+            Domain esgDomain = mock(Domain.class);
+            when(esgDomain.getCode()).thenReturn("ESG");
+
+            // 도메인 기반 권한 설정
+            User domainApprover = mock(User.class);
+            lenient().when(domainApprover.getUserId()).thenReturn(1L);
+            lenient().when(domainApprover.getName()).thenReturn("도메인 결재자");
+            when(domainApprover.getCompany()).thenReturn(testCompany);
+            when(domainApprover.hasRoleInDomain("ESG", "APPROVER")).thenReturn(true);
+
+            LocalDateTime submittedAt = LocalDateTime.now();
+            lenient().when(testApproval.isApproved()).thenReturn(true);
+            lenient().when(testApproval.getSubmittedToReviewerAt()).thenReturn(submittedAt);
+            lenient().when(testDiagnostic.isApproved()).thenReturn(true);
+            lenient().when(testDiagnostic.getStatus()).thenReturn(DiagnosticStatus.APPROVED);
+            lenient().when(testDiagnostic.getDomain()).thenReturn(esgDomain);
+
+            Review savedReview = mock(Review.class);
+            when(savedReview.getReviewId()).thenReturn(51L);
+
+            SubmitToReviewerRequest request = SubmitToReviewerRequest.builder()
+                    .submitComment("원청 제출합니다")
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(domainApprover));
+            given(approvalRepository.findById(1L)).willReturn(Optional.of(testApproval));
+            given(reviewRepository.save(any(Review.class))).willAnswer(invocation -> {
+                Review review = invocation.getArgument(0);
+                // Review 엔티티에 설정된 값 검증
+                assertThat(review.getDiagnostic()).isEqualTo(testDiagnostic);
+                assertThat(review.getCompany()).isEqualTo(testCompany);
+                assertThat(review.getDomain()).isEqualTo(esgDomain);
+                assertThat(review.getScore()).isEqualTo(72);  // testDiagnostic.getOverallScore()
+                assertThat(review.getSubmittedAt()).isEqualTo(submittedAt);
+                return savedReview;
+            });
+
+            // when
+            SubmitToReviewerResponse response = approvalService.submitToReviewer(1L, 1L, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getReviewId()).isEqualTo(51L);
+            verify(reviewRepository).save(any(Review.class));
         }
 
         @Test


### PR DESCRIPTION
## 변경 요약
결재자가 원청 제출 시 Review 엔티티가 생성되지 않아 수신자 대시보드에서 심사 대기 서류가 표시되지 않는 버그 수정

### 주요 변경사항
- `ApprovalService`에 `ReviewRepository` 의존성 추가
- `submitToReviewer()` 메서드에서 Review 엔티티 생성 로직 추가
- 응답의 `reviewId` 필드에 생성된 Review ID 반환 (기존 `null` → 실제 ID)
- 테스트 2건 추가

### 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `ApprovalService.java` | ReviewRepository 주입, Review 생성 로직 추가 |
| `ApprovalServiceTest.java` | Review 생성 검증 테스트 2건 추가 |
| `docs/claude/LEARNINGS.md` | 학습 기록 추가 |

## 관련 이슈
- Closes #158

## 테스트 방법
```bash
# 단위 테스트
./gradlew test --tests "ApprovalServiceTest"

# 수동 테스트
1. ESG 결재자로 로그인
2. 대기중인 기안 승인 처리
3. 원청 제출 버튼 클릭
4. ESG 수신자로 로그인
5. 대시보드/심사 목록에서 해당 기안 확인
```

## 명세 준수 체크
- [x] Diagnostic 상태: APPROVED → REVIEWING 전이
- [x] Review 엔티티 생성 (diagnostic, company, domain, score, submittedAt 설정)
- [x] ReviewRepository 사용하여 저장
- [x] 응답에 reviewId 포함

## 리뷰 포인트
1. `Review.builder()` 호출 시 필수 필드 누락 여부
2. 테스트에서 mock 설정이 적절한지

## TODO/질문
- 기존 테스트 9건은 dev 브랜치에서도 동일하게 실패 (기존 이슈, 이번 PR과 무관)