### PR TITLE
fix(wording): DiagnosticStatus.APPROVED displayName '내부승인' → '승인됨' (#178)

### DIFF
--- a/src/main/java/com/smartchain/platform/global/enums/DiagnosticStatus.java
+++ b/src/main/java/com/smartchain/platform/global/enums/DiagnosticStatus.java
@@ -17,7 +17,7 @@ public enum DiagnosticStatus {
     WRITING("작성중", "기안자가 진단 작성 중"),
     SUBMITTED("제출됨", "결재자에게 제출됨"),
     RETURNED("반려됨", "결재자가 반려함 (보완 요청)"),
-    APPROVED("내부승인", "협력사 내부 승인 완료"),
+    APPROVED("승인됨", "협력사 내부 승인 완료"),
     REVIEWING("심사중", "원청에서 심사 진행 중"),
     COMPLETED("완료", "심사 완료 (최종 상태)");
 

--- a/src/test/java/com/smartchain/platform/global/enums/DiagnosticStatusTest.java
+++ b/src/test/java/com/smartchain/platform/global/enums/DiagnosticStatusTest.java
@@ -25,7 +25,7 @@ class DiagnosticStatusTest {
         assertThat(DiagnosticStatus.WRITING.getDisplayName()).isEqualTo("작성중");
         assertThat(DiagnosticStatus.SUBMITTED.getDisplayName()).isEqualTo("제출됨");
         assertThat(DiagnosticStatus.RETURNED.getDisplayName()).isEqualTo("반려됨");
-        assertThat(DiagnosticStatus.APPROVED.getDisplayName()).isEqualTo("내부승인");
+        assertThat(DiagnosticStatus.APPROVED.getDisplayName()).isEqualTo("승인됨");
         assertThat(DiagnosticStatus.REVIEWING.getDisplayName()).isEqualTo("심사중");
         assertThat(DiagnosticStatus.COMPLETED.getDisplayName()).isEqualTo("완료");
     }


### PR DESCRIPTION
## 변경 요약
- `DiagnosticStatus.APPROVED`의 `displayName`을 "내부승인"에서 "승인됨"으로 변경
- 프론트엔드와 워딩 통일

## 관련 이슈
- Closes #178
- Frontend PR: https://github.com/SmartChain-HD/Frontend/pull/289

## 테스트 방법
- [x] `DiagnosticStatusTest` 테스트 통과 확인
- [x] `./gradlew test && ./gradlew build` 전체 통과

## 명세 준수 체크
- [x] displayName이 "승인됨"으로 변경됨
- [x] description은 기존 유지 ("협력사 내부 승인 완료")

## 리뷰 포인트
- 단순 워딩 변경으로 영향 범위 제한적

## TODO / 질문
- 없음