### PR TITLE
refactor: 초기 데이터(DataInitializer) 개선 및 정합성 수정

### DIFF
--- a/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
+++ b/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
@@ -70,6 +70,10 @@ public class DataInitializer implements CommandLineRunner {
 
         log.info("=== Starting Data Initialization ===");
 
+        // 날짜 동적 처리
+        int currentYear = LocalDate.now().getYear();
+        int lastYear = currentYear - 1;
+
         // ========================================
         // 1. 기본 데이터: Role, Domain, Industry
         // ========================================
@@ -134,7 +138,7 @@ public class DataInitializer implements CommandLineRunner {
         log.info("Companies created: 5 companies");
 
         // ========================================
-        // 3. 사용자 데이터 (12명)
+        // 3. 사용자 데이터 (14명) - 마스터 계정 추가
         // ========================================
         String encodedPassword = passwordEncoder.encode("Test1234!");
 
@@ -183,7 +187,17 @@ public class DataInitializer implements CommandLineRunner {
         User guest2 = userRepository.save(User.builder()
                 .name("신입2").email("newbie2@precision.co.kr").userPassword(encodedPassword)
                 .company(partnerCompany4).role(guestRole).emailVerified(true).build());
-        log.info("Users created: 12 users");
+
+        // [NEW] 마스터 계정 (모든 도메인 권한)
+        User masterReviewer = userRepository.save(User.builder()
+                .name("마스터심사").email("master.reviewer@hdhhi.co.kr").userPassword(encodedPassword)
+                .company(ownerCompany).role(reviewerRole).emailVerified(true).build());
+
+        User masterDrafter = userRepository.save(User.builder()
+                .name("마스터기안").email("master.drafter@techpartner.co.kr").userPassword(encodedPassword)
+                .company(partnerCompany1).role(drafterRole).emailVerified(true).build());
+
+        log.info("Users created: 14 users (including masters)");
 
         // ========================================
         // 4. UserDomainRole (도메인별 권한)
@@ -193,62 +207,76 @@ public class DataInitializer implements CommandLineRunner {
         userDomainRoleRepository.save(UserDomainRole.builder().user(reviewerSafety).domain(safetyDomain).role(reviewerRole).build());
         userDomainRoleRepository.save(UserDomainRole.builder().user(reviewerCompliance).domain(complianceDomain).role(reviewerRole).build());
 
-        // 테크파트너: ESG(결재자+기안자) + COMPLIANCE(기안자만) + SAFETY(drafter1만)
+        // [MODIFIED] 테크파트너: ESG(결재자+기안자) + COMPLIANCE(기안자만) + SAFETY(drafter1만)
+        // 결재자는 ESG만 권한 부여
         userDomainRoleRepository.save(UserDomainRole.builder().user(approver1).domain(esgDomain).role(approverRole).build());
+        
         userDomainRoleRepository.save(UserDomainRole.builder().user(drafter1).domain(esgDomain).role(drafterRole).build());
         userDomainRoleRepository.save(UserDomainRole.builder().user(drafter1).domain(complianceDomain).role(drafterRole).build());
         userDomainRoleRepository.save(UserDomainRole.builder().user(drafter1).domain(safetyDomain).role(drafterRole).build());
         userDomainRoleRepository.save(UserDomainRole.builder().user(drafter2).domain(esgDomain).role(drafterRole).build());
 
-        // 그린매뉴팩처링: ESG(결재자+기안자) + SAFETY(기안자만)
+        // [MODIFIED] 그린매뉴팩처링: ESG(결재자+기안자) + SAFETY(기안자만)
+        // 결재자는 ESG만 권한 부여
         userDomainRoleRepository.save(UserDomainRole.builder().user(approver2).domain(esgDomain).role(approverRole).build());
+        
         userDomainRoleRepository.save(UserDomainRole.builder().user(drafter3).domain(esgDomain).role(drafterRole).build());
         userDomainRoleRepository.save(UserDomainRole.builder().user(drafter3).domain(safetyDomain).role(drafterRole).build());
 
-        // 안전건설: ESG(결재자) + SAFETY(기안자만) - APPROVER는 ESG 도메인에서만 존재
+        // [MODIFIED] 안전건설: ESG(결재자) + SAFETY(기안자만)
+        // 결재자는 ESG만 권한 부여
         userDomainRoleRepository.save(UserDomainRole.builder().user(approver3).domain(esgDomain).role(approverRole).build());
+        
         userDomainRoleRepository.save(UserDomainRole.builder().user(drafter4).domain(safetyDomain).role(drafterRole).build());
+
+        // [NEW] 마스터 계정 권한 부여 (모든 도메인)
+        List<Domain> allDomains = List.of(esgDomain, safetyDomain, complianceDomain);
+        for (Domain domain : allDomains) {
+            userDomainRoleRepository.save(UserDomainRole.builder().user(masterReviewer).domain(domain).role(reviewerRole).build());
+            userDomainRoleRepository.save(UserDomainRole.builder().user(masterDrafter).domain(domain).role(drafterRole).build());
+        }
         log.info("UserDomainRoles created");
 
         // ========================================
-        // 5. Campaign (6개)
+        // 5. Campaign (6개) - 날짜 동적 적용
         // ========================================
-        // 캠페인 기간: 4개월 단위 (1~4월, 5~8월, 9~12월)
-        Campaign esgCampaign2026 = campaignRepository.save(Campaign.builder()
-                .campaignCode("CAMP-ESG-2026-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(esgDomain)
-                .title("2026년 1분기 ESG 공급망 진단").content("2026년도 1차 협력사 ESG 경영 현황 진단")
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 3, 31)).isActive(true).build());
+        // 현재 연도 캠페인 (1~4월)
+        Campaign esgCampaignCurrent = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-ESG-" + currentYear + "-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(esgDomain)
+                .title(currentYear + "년 1분기 ESG 공급망 진단").content(currentYear + "년도 1차 협력사 ESG 경영 현황 진단")
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 3, 31)).isActive(true).build());
 
-        Campaign esgCampaign2025 = campaignRepository.save(Campaign.builder()
-                .campaignCode("CAMP-ESG-2025-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(esgDomain)
-                .title("2025년 3분기 ESG 공급망 진단 (완료)").content("2025년도 협력사 ESG 경영 현황 진단 - 완료")
-                .periodStartDate(LocalDate.of(2025, 9, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2025, 11, 30)).isActive(false).build());
+        // 작년 캠페인 (9~12월)
+        Campaign esgCampaignPast = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-ESG-" + lastYear + "-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(esgDomain)
+                .title(lastYear + "년 3분기 ESG 공급망 진단 (완료)").content(lastYear + "년도 협력사 ESG 경영 현황 진단 - 완료")
+                .periodStartDate(LocalDate.of(lastYear, 9, 1)).periodEndDate(LocalDate.of(lastYear, 12, 31))
+                .deadline(LocalDate.of(lastYear, 11, 30)).isActive(false).build());
 
-        Campaign safetyCampaign2026 = campaignRepository.save(Campaign.builder()
-                .campaignCode("CAMP-SAFETY-2026-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(safetyDomain)
-                .title("2026년 1분기 안전보건 점검").content("2026년 1분기 협력사 안전보건 관리 현황 점검")
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 3, 31)).isActive(true).build());
+        Campaign safetyCampaignCurrent = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-SAFETY-" + currentYear + "-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(safetyDomain)
+                .title(currentYear + "년 1분기 안전보건 점검").content(currentYear + "년 1분기 협력사 안전보건 관리 현황 점검")
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 3, 31)).isActive(true).build());
 
-        Campaign safetyCampaign2025 = campaignRepository.save(Campaign.builder()
-                .campaignCode("CAMP-SAFETY-2025-002").ownerCompanyId(ownerCompany.getCompanyId()).domain(safetyDomain)
-                .title("2025년 3분기 안전보건 점검 (완료)").content("2025년 3분기 안전보건 점검 완료")
-                .periodStartDate(LocalDate.of(2025, 9, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2025, 11, 30)).isActive(false).build());
+        Campaign safetyCampaignPast = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-SAFETY-" + lastYear + "-002").ownerCompanyId(ownerCompany.getCompanyId()).domain(safetyDomain)
+                .title(lastYear + "년 3분기 안전보건 점검 (완료)").content(lastYear + "년 3분기 안전보건 점검 완료")
+                .periodStartDate(LocalDate.of(lastYear, 9, 1)).periodEndDate(LocalDate.of(lastYear, 12, 31))
+                .deadline(LocalDate.of(lastYear, 11, 30)).isActive(false).build());
 
-        Campaign complianceCampaign2026 = campaignRepository.save(Campaign.builder()
-                .campaignCode("CAMP-COMPL-2026-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(complianceDomain)
-                .title("2026년 1분기 하도급 컴플라이언스 점검").content("2026년도 협력사 하도급 계약 법규 준수 점검")
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 3, 31)).isActive(true).build());
+        Campaign complianceCampaignCurrent = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-COMPL-" + currentYear + "-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(complianceDomain)
+                .title(currentYear + "년 1분기 하도급 컴플라이언스 점검").content(currentYear + "년도 협력사 하도급 계약 법규 준수 점검")
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 3, 31)).isActive(true).build());
 
-        Campaign complianceCampaign2025 = campaignRepository.save(Campaign.builder()
-                .campaignCode("CAMP-COMPL-2025-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(complianceDomain)
-                .title("2025년 1분기 하도급 컴플라이언스 점검 (완료)").content("2025년도 하도급 점검 완료")
-                .periodStartDate(LocalDate.of(2025, 1, 1)).periodEndDate(LocalDate.of(2025, 4, 30))
-                .deadline(LocalDate.of(2025, 3, 31)).isActive(false).build());
+        Campaign complianceCampaignPast = campaignRepository.save(Campaign.builder()
+                .campaignCode("CAMP-COMPL-" + lastYear + "-001").ownerCompanyId(ownerCompany.getCompanyId()).domain(complianceDomain)
+                .title(lastYear + "년 1분기 하도급 컴플라이언스 점검 (완료)").content(lastYear + "년도 하도급 점검 완료")
+                .periodStartDate(LocalDate.of(lastYear, 1, 1)).periodEndDate(LocalDate.of(lastYear, 4, 30))
+                .deadline(LocalDate.of(lastYear, 3, 31)).isActive(false).build());
         log.info("Campaigns created: 6 campaigns");
 
         // ========================================
@@ -257,88 +285,88 @@ public class DataInitializer implements CommandLineRunner {
         // ESG 진단들
         // WRITING (작성중) - 2건
         Diagnostic esgWriting1 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2026-001").title("테크파트너 2026 ESG 진단")
-                .campaign(esgCampaign2026).company(partnerCompany1).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + currentYear + "-001").title("테크파트너 " + currentYear + " ESG 진단")
+                .campaign(esgCampaignCurrent).company(partnerCompany1).domain(esgDomain)
                 .drafterId(drafter1.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 3, 31)).build());
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 3, 31)).build());
 
         Diagnostic esgWriting2 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2026-002").title("그린매뉴 2026 ESG 진단")
-                .campaign(esgCampaign2026).company(partnerCompany2).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + currentYear + "-002").title("그린매뉴 " + currentYear + " ESG 진단")
+                .campaign(esgCampaignCurrent).company(partnerCompany2).domain(esgDomain)
                 .drafterId(drafter3.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 3, 31)).build());
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 3, 31)).build());
 
         // SUBMITTED (제출됨) - 2건
         Diagnostic esgSubmitted1 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2026-003").title("테크파트너 2026 ESG 진단 (제출)")
-                .campaign(esgCampaign2026).company(partnerCompany1).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + currentYear + "-003").title("테크파트너 " + currentYear + " ESG 진단 (제출)")
+                .campaign(esgCampaignCurrent).company(partnerCompany1).domain(esgDomain)
                 .drafterId(drafter2.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 3, 31)).build());
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 3, 31)).build());
         esgSubmitted1.submit();
         diagnosticRepository.save(esgSubmitted1);
 
         Diagnostic esgSubmitted2 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2026-004").title("정밀부품 2026 ESG 진단 (제출)")
-                .campaign(esgCampaign2026).company(partnerCompany4).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + currentYear + "-004").title("정밀부품 " + currentYear + " ESG 진단 (제출)")
+                .campaign(esgCampaignCurrent).company(partnerCompany4).domain(esgDomain)
                 .drafterId(guest1.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 3, 31)).build());
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 3, 31)).build());
         esgSubmitted2.submit();
         diagnosticRepository.save(esgSubmitted2);
 
         // RETURNED (반려됨) - 1건
         Diagnostic esgReturned = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2026-005").title("그린매뉴 2026 ESG 진단 (반려)")
-                .campaign(esgCampaign2026).company(partnerCompany2).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + currentYear + "-005").title("그린매뉴 " + currentYear + " ESG 진단 (반려)")
+                .campaign(esgCampaignCurrent).company(partnerCompany2).domain(esgDomain)
                 .drafterId(drafter3.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 3, 31)).build());
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 3, 31)).build());
         esgReturned.submit();
         esgReturned.returnForRevision();
         diagnosticRepository.save(esgReturned);
 
         // APPROVED (승인됨, 심사대기) - 2건
         Diagnostic esgApproved1 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2026-006").title("테크파트너 2026 ESG 진단 (승인)")
-                .campaign(esgCampaign2026).company(partnerCompany1).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + currentYear + "-006").title("테크파트너 " + currentYear + " ESG 진단 (승인)")
+                .campaign(esgCampaignCurrent).company(partnerCompany1).domain(esgDomain)
                 .drafterId(drafter1.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 3, 31)).build());
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 3, 31)).build());
         esgApproved1.submit();
         esgApproved1.approve();
         diagnosticRepository.save(esgApproved1);
 
         Diagnostic esgApproved2 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2026-007").title("안전건설 2026 ESG 진단 (승인)")
-                .campaign(esgCampaign2026).company(partnerCompany3).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + currentYear + "-007").title("안전건설 " + currentYear + " ESG 진단 (승인)")
+                .campaign(esgCampaignCurrent).company(partnerCompany3).domain(esgDomain)
                 .drafterId(drafter4.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 3, 31)).build());
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 3, 31)).build());
         esgApproved2.submit();
         esgApproved2.approve();
         diagnosticRepository.save(esgApproved2);
 
         // REVIEWING (심사중) - 2건
         Diagnostic esgReviewing1 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2025-001").title("테크파트너 2025 ESG 진단 (심사중)")
-                .campaign(esgCampaign2025).company(partnerCompany1).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + lastYear + "-001").title("테크파트너 " + lastYear + " ESG 진단 (심사중)")
+                .campaign(esgCampaignPast).company(partnerCompany1).domain(esgDomain)
                 .drafterId(drafter1.getUserId())
-                .periodStartDate(LocalDate.of(2025, 9, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2025, 3, 31)).build());
+                .periodStartDate(LocalDate.of(lastYear, 9, 1)).periodEndDate(LocalDate.of(lastYear, 12, 31))
+                .deadline(LocalDate.of(lastYear, 3, 31)).build());
         esgReviewing1.submit();
         esgReviewing1.approve();
         esgReviewing1.startReview();
         diagnosticRepository.save(esgReviewing1);
 
         Diagnostic esgReviewing2 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2025-002").title("그린매뉴 2025 ESG 진단 (심사중)")
-                .campaign(esgCampaign2025).company(partnerCompany2).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + lastYear + "-002").title("그린매뉴 " + lastYear + " ESG 진단 (심사중)")
+                .campaign(esgCampaignPast).company(partnerCompany2).domain(esgDomain)
                 .drafterId(drafter3.getUserId())
-                .periodStartDate(LocalDate.of(2025, 9, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2025, 3, 31)).build());
+                .periodStartDate(LocalDate.of(lastYear, 9, 1)).periodEndDate(LocalDate.of(lastYear, 12, 31))
+                .deadline(LocalDate.of(lastYear, 3, 31)).build());
         esgReviewing2.submit();
         esgReviewing2.approve();
         esgReviewing2.startReview();
@@ -346,52 +374,53 @@ public class DataInitializer implements CommandLineRunner {
 
         // COMPLETED (완료) - 2건
         Diagnostic esgCompleted1 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2025-003").title("안전건설 2025 ESG 진단 (완료)")
-                .campaign(esgCampaign2025).company(partnerCompany3).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + lastYear + "-003").title("안전건설 " + lastYear + " ESG 진단 (완료)")
+                .campaign(esgCampaignPast).company(partnerCompany3).domain(esgDomain)
                 .drafterId(drafter4.getUserId())
-                .periodStartDate(LocalDate.of(2025, 9, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2025, 3, 31)).build());
+                .periodStartDate(LocalDate.of(lastYear, 9, 1)).periodEndDate(LocalDate.of(lastYear, 12, 31))
+                .deadline(LocalDate.of(lastYear, 3, 31)).build());
         esgCompleted1.submit();
         esgCompleted1.approve();
         esgCompleted1.startReview();
         esgCompleted1.complete();
         diagnosticRepository.save(esgCompleted1);
 
+        // [MODIFIED] 정합성 수정: 리뷰가 보완요청(REVISION_REQUIRED)이므로 완료(COMPLETE) 처리하지 않음
         Diagnostic esgCompleted2 = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-ESG-2025-004").title("정밀부품 2025 ESG 진단 (완료)")
-                .campaign(esgCampaign2025).company(partnerCompany4).domain(esgDomain)
+                .diagnosticCode("DG-ESG-" + lastYear + "-004").title("정밀부품 " + lastYear + " ESG 진단 (보완요청)")
+                .campaign(esgCampaignPast).company(partnerCompany4).domain(esgDomain)
                 .drafterId(guest1.getUserId())
-                .periodStartDate(LocalDate.of(2025, 9, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2025, 3, 31)).build());
+                .periodStartDate(LocalDate.of(lastYear, 9, 1)).periodEndDate(LocalDate.of(lastYear, 12, 31))
+                .deadline(LocalDate.of(lastYear, 3, 31)).build());
         esgCompleted2.submit();
         esgCompleted2.approve();
         esgCompleted2.startReview();
-        esgCompleted2.complete();
+        // esgCompleted2.complete(); // 제거
         diagnosticRepository.save(esgCompleted2);
 
         // SAFETY 진단 (3건)
         Diagnostic safetyWriting = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-SAFETY-2026-001").title("그린매뉴 2026 안전보건 점검")
-                .campaign(safetyCampaign2026).company(partnerCompany2).domain(safetyDomain)
+                .diagnosticCode("DG-SAFETY-" + currentYear + "-001").title("그린매뉴 " + currentYear + " 안전보건 점검")
+                .campaign(safetyCampaignCurrent).company(partnerCompany2).domain(safetyDomain)
                 .drafterId(drafter3.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 2, 28)).build());
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 2, 28)).build());
 
         Diagnostic safetySubmitted = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-SAFETY-2026-002").title("안전건설 2026 안전보건 점검 (제출)")
-                .campaign(safetyCampaign2026).company(partnerCompany3).domain(safetyDomain)
+                .diagnosticCode("DG-SAFETY-" + currentYear + "-002").title("안전건설 " + currentYear + " 안전보건 점검 (제출)")
+                .campaign(safetyCampaignCurrent).company(partnerCompany3).domain(safetyDomain)
                 .drafterId(drafter4.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 2, 28)).build());
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 2, 28)).build());
         safetySubmitted.submit();
         diagnosticRepository.save(safetySubmitted);
 
         Diagnostic safetyCompleted = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-SAFETY-2025-001").title("안전건설 2025 안전보건 점검 (완료)")
-                .campaign(safetyCampaign2025).company(partnerCompany3).domain(safetyDomain)
+                .diagnosticCode("DG-SAFETY-" + lastYear + "-001").title("안전건설 " + lastYear + " 안전보건 점검 (완료)")
+                .campaign(safetyCampaignPast).company(partnerCompany3).domain(safetyDomain)
                 .drafterId(drafter4.getUserId())
-                .periodStartDate(LocalDate.of(2025, 9, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2025, 11, 30)).build());
+                .periodStartDate(LocalDate.of(lastYear, 9, 1)).periodEndDate(LocalDate.of(lastYear, 12, 31))
+                .deadline(LocalDate.of(lastYear, 11, 30)).build());
         safetyCompleted.submit();
         safetyCompleted.approve();
         safetyCompleted.startReview();
@@ -400,22 +429,23 @@ public class DataInitializer implements CommandLineRunner {
 
         // COMPLIANCE 진단 (2건)
         Diagnostic complianceWriting = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-COMPL-2026-001").title("테크파트너 2026 컴플라이언스 점검")
-                .campaign(complianceCampaign2026).company(partnerCompany1).domain(complianceDomain)
+                .diagnosticCode("DG-COMPL-" + currentYear + "-001").title("테크파트너 " + currentYear + " 컴플라이언스 점검")
+                .campaign(complianceCampaignCurrent).company(partnerCompany1).domain(complianceDomain)
                 .drafterId(drafter1.getUserId())
-                .periodStartDate(LocalDate.of(2026, 1, 1)).periodEndDate(LocalDate.of(2026, 4, 30))
-                .deadline(LocalDate.of(2026, 4, 15)).build());
+                .periodStartDate(LocalDate.of(currentYear, 1, 1)).periodEndDate(LocalDate.of(currentYear, 4, 30))
+                .deadline(LocalDate.of(currentYear, 4, 15)).build());
 
+        // [MODIFIED] 정합성 수정: 리뷰가 보완요청이므로 완료 처리하지 않음
         Diagnostic complianceCompleted = diagnosticRepository.save(Diagnostic.builder()
-                .diagnosticCode("DG-COMPL-2025-001").title("테크파트너 2025 컴플라이언스 점검 (완료)")
-                .campaign(complianceCampaign2025).company(partnerCompany1).domain(complianceDomain)
+                .diagnosticCode("DG-COMPL-" + lastYear + "-001").title("테크파트너 " + lastYear + " 컴플라이언스 점검 (보완요청)")
+                .campaign(complianceCampaignPast).company(partnerCompany1).domain(complianceDomain)
                 .drafterId(drafter1.getUserId())
-                .periodStartDate(LocalDate.of(2025, 1, 1)).periodEndDate(LocalDate.of(2025, 4, 30))
-                .deadline(LocalDate.of(2025, 5, 15)).build());
+                .periodStartDate(LocalDate.of(lastYear, 1, 1)).periodEndDate(LocalDate.of(lastYear, 4, 30))
+                .deadline(LocalDate.of(lastYear, 5, 15)).build());
         complianceCompleted.submit();
         complianceCompleted.approve();
         complianceCompleted.startReview();
-        complianceCompleted.complete();
+        // complianceCompleted.complete(); // 제거
         diagnosticRepository.save(complianceCompleted);
 
         log.info("Diagnostics created: 17 diagnostics (all statuses covered)");
@@ -427,25 +457,25 @@ public class DataInitializer implements CommandLineRunner {
         approvalRepository.save(Approval.builder()
                 .diagnostic(esgSubmitted1).requester(drafter2)
                 .requestComment("ESG 진단 결과 검토 요청드립니다.")
-                .deadline(LocalDate.of(2026, 3, 15)).build());
+                .deadline(LocalDate.of(currentYear, 3, 15)).build());
 
         approvalRepository.save(Approval.builder()
                 .diagnostic(safetySubmitted).requester(drafter4)
                 .requestComment("안전보건 점검 결과 결재 요청합니다.")
-                .deadline(LocalDate.of(2026, 2, 20)).build());
+                .deadline(LocalDate.of(currentYear, 2, 20)).build());
 
         // APPROVED (승인) - 2건
         Approval approvedApproval1 = Approval.builder()
                 .diagnostic(esgApproved1).requester(drafter1)
                 .requestComment("ESG 진단 완료하여 결재 요청드립니다.")
-                .deadline(LocalDate.of(2026, 3, 10)).build();
+                .deadline(LocalDate.of(currentYear, 3, 10)).build();
         approvedApproval1.approve(approver1, "검토 완료, 승인합니다.");
         approvalRepository.save(approvedApproval1);
 
         Approval approvedApproval2 = Approval.builder()
                 .diagnostic(esgReviewing1).requester(drafter1)
-                .requestComment("2025년 ESG 진단 결재 요청")
-                .deadline(LocalDate.of(2025, 3, 20)).build();
+                .requestComment(lastYear + "년 ESG 진단 결재 요청")
+                .deadline(LocalDate.of(lastYear, 3, 20)).build();
         approvedApproval2.approve(approver1, "승인합니다.");
         approvalRepository.save(approvedApproval2);
 
@@ -453,14 +483,14 @@ public class DataInitializer implements CommandLineRunner {
         Approval rejectedApproval1 = Approval.builder()
                 .diagnostic(esgReturned).requester(drafter3)
                 .requestComment("ESG 진단 결재 요청드립니다.")
-                .deadline(LocalDate.of(2026, 3, 1)).build();
+                .deadline(LocalDate.of(currentYear, 3, 1)).build();
         rejectedApproval1.reject(approver2, "온실가스 배출량 데이터가 누락되었습니다. 보완 후 재제출 바랍니다.");
         approvalRepository.save(rejectedApproval1);
 
         Approval rejectedApproval2 = Approval.builder()
                 .diagnostic(esgSubmitted2).requester(guest1)
                 .requestComment("ESG 진단 검토 부탁드립니다.")
-                .deadline(LocalDate.of(2026, 3, 25)).build();
+                .deadline(LocalDate.of(currentYear, 3, 25)).build();
         // 이건 WAITING 상태로 유지 (게스트가 요청한 건)
 
         log.info("Approvals created: 5 approvals (WAITING: 2, APPROVED: 2, REJECTED: 1)");
@@ -582,10 +612,10 @@ public class DataInitializer implements CommandLineRunner {
 
         AsyncJob jobBulk = AsyncJob.builder()
                 .jobType(JobType.BULK_REPORT).requesterId(reviewerEsg.getUserId())
-                .targetId(esgCampaign2025.getCampaignId())
-                .requestPayload("{\"campaignId\": " + esgCampaign2025.getCampaignId() + "}").estimatedSeconds(300).build();
+                .targetId(esgCampaignPast.getCampaignId())
+                .requestPayload("{\"campaignId\": " + esgCampaignPast.getCampaignId() + "}").estimatedSeconds(300).build();
         jobBulk.start();
-        jobBulk.succeed("/api/v1/reports/bulk/campaign-" + esgCampaign2025.getCampaignId() + ".zip");
+        jobBulk.succeed("/api/v1/reports/bulk/campaign-" + esgCampaignPast.getCampaignId() + ".zip");
         asyncJobRepository.save(jobBulk);
 
         log.info("AsyncJobs created: 5 jobs (PENDING: 1, RUNNING: 1, SUCCEEDED: 2, FAILED: 1)");
@@ -596,7 +626,7 @@ public class DataInitializer implements CommandLineRunner {
         // 결재 관련
         notificationRepository.save(Notification.builder()
                 .user(approver1).type(NotificationType.APPROVAL_COMPLETE)
-                .title("결재 요청").message("테크파트너 2026 ESG 진단 결재 요청이 도착했습니다.")
+                .title("결재 요청").message("테크파트너 " + currentYear + " ESG 진단 결재 요청이 도착했습니다.")
                 .linkUrl("/approvals").build());
 
         notificationRepository.save(Notification.builder()
@@ -658,15 +688,19 @@ public class DataInitializer implements CommandLineRunner {
         log.info("        TEST ACCOUNTS (password: Test1234!)");
         log.info("============================================");
         log.info("");
+        log.info("[MASTER ACCOUNTS - ALL DOMAINS]");
+        log.info("  REVIEWER:   master.reviewer@hdhhi.co.kr");
+        log.info("  DRAFTER:    master.drafter@techpartner.co.kr");
+        log.info("");
         log.info("[원청 심사자 - REVIEWER]");
         log.info("  ESG:        reviewer.esg@hdhhi.co.kr");
         log.info("  안전보건:   reviewer.safety@hdhhi.co.kr");
         log.info("  컴플라이언스: reviewer.compliance@hdhhi.co.kr");
         log.info("");
         log.info("[협력사 결재자 - APPROVER]");
-        log.info("  테크파트너: approver@techpartner.co.kr (ESG, COMPLIANCE)");
-        log.info("  그린매뉴:   approver@greenmanu.co.kr (ESG, SAFETY)");
-        log.info("  안전건설:   approver@safebuild.co.kr (SAFETY)");
+        log.info("  테크파트너: approver@techpartner.co.kr (ESG Only)");
+        log.info("  그린매뉴:   approver@greenmanu.co.kr (ESG Only)");
+        log.info("  안전건설:   approver@safebuild.co.kr (ESG Only)");
         log.info("");
         log.info("[협력사 기안자 - DRAFTER]");
         log.info("  테크파트너: drafter1@techpartner.co.kr (ESG, COMPLIANCE, SAFETY)");


### PR DESCRIPTION
변경 사항
1.
날짜 동적 처리: 기존 2025, 2026 하드코딩을 제거하고 LocalDate.now()를 기준으로 현재 연도와 작년 데이터가 생성되도록 변경했습니다.
2.
데이터 정합성 수정: 리뷰가 보완 요청 상태인 경우 진단이 완료 상태가 되지 않도록 로직을 수정했습니다.
3.
마스터 계정 추가: 모든 도메인 권한을 가진 테스트용 마스터 계정(master.reviewer, master.drafter)을 추가했습니다.
4.
권한 정리: 결재자(APPROVER)는 기획 의도에 맞춰 ESG 도메인 권한만 갖도록 수정했습니다.
테스트 방법
•
애플리케이션 실행 후 로그에 출력되는 계정 정보를 확인합니다.
•
마스터 계정으로 로그인하여 모든 도메인에 접근 가능한지 확인합니다.
•
결재자 계정으로 로그인하여 ESG 외 다른 도메인 접근이 제한되는지 확인합니다.