### PR TITLE
feat(risk): 외부 위험 감지 API 연동 - REVIEWER 전용 (#183)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,33 @@
 # Claude Code Learnings
 
+## 2026-02-05: 외부 위험 감지 API 연동 - REVIEWER 전용 (#183)
+
+### 원인
+- REVIEWER 전용 외부 리스크 감지 기능 필요 (협력사 리스크 분석)
+- 기존 AI Run API 패턴 재사용하여 새로운 `/risk/external/detect` API 연동
+
+### 해결
+- **ErrorCode**: RISK001~004 에러코드 추가
+- **ExternalRiskApiConfig**: `ai.risk-api` 설정 기반 WebClient 빈 생성 (AiRunApiConfig 패턴 복사)
+- **DTO 4개**: Backend↔AI 통신용 + Frontend↔Backend 통신용 분리
+- **ExternalRiskApiClient**: WebClient 기반 AI 서버 통신 (retry/에러핸들링)
+- **ExternalRiskResult**: JPA 엔티티 (리스크 결과 저장, BaseTimeEntity 상속)
+- **ExternalRiskService**: userId 기반 User 조회 + REVIEWER 권한 검증 + AI 호출 + 결과 저장
+- **ExternalRiskController**: REST 엔드포인트 3개 (detect, results/{companyId}, results)
+- **SecurityConfig**: `/api/v1/risk/**` REVIEWER 전용 제한 추가
+
+### 재발방지
+- 새 도메인 API 추가 시 SecurityConfig에 경로 권한 설정 필수
+- 서비스 메서드는 Controller에서 userId(Long)를 받아 내부에서 User 조회하는 패턴 준수
+- WebClient 빈 이름 충돌 주의 (@Qualifier로 구분)
+
+### 검증방법
+- `./gradlew test --tests "ExternalRiskServiceTest"` (단위 테스트 8개)
+- `./gradlew test && ./gradlew build` (전체 빌드 통과)
+
+### 관련커밋
+- feature/refactor-data-initializer 브랜치에서 작업
+
 ## 2026-02-04: 기안 상태 불일치 - 심사중/완료 동시 존재 (#156)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/risk/client/ExternalRiskApiClient.java
+++ b/src/main/java/com/smartchain/platform/domain/risk/client/ExternalRiskApiClient.java
@@ -1,0 +1,80 @@
+package com.smartchain.platform.domain.risk.client;
+
+import com.smartchain.platform.domain.risk.config.ExternalRiskApiConfig;
+import com.smartchain.platform.dto.risk.ExternalRiskDetectRequest;
+import com.smartchain.platform.dto.risk.ExternalRiskDetectResponse;
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+
+@Component
+public class ExternalRiskApiClient {
+
+    private static final Logger log = LoggerFactory.getLogger(ExternalRiskApiClient.class);
+
+    private final WebClient webClient;
+    private final int maxRetry;
+
+    public ExternalRiskApiClient(
+        @Qualifier("externalRiskApiWebClient") WebClient webClient,
+        ExternalRiskApiConfig config
+    ) {
+        this.webClient = webClient;
+        this.maxRetry = config.getMaxRetry();
+    }
+
+    public ExternalRiskDetectResponse detect(ExternalRiskDetectRequest request) {
+        log.info("외부 위험 감지 API 호출 - vendors: {}", request.vendors());
+
+        return webClient.post()
+            .uri("/risk/external/detect")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(ExternalRiskDetectResponse.class)
+            .retryWhen(Retry.backoff(maxRetry, Duration.ofSeconds(1))
+                .filter(this::isRetryableError)
+                .onRetryExhaustedThrow((spec, signal) ->
+                    new CustomException(ErrorCode.RISK_DETECT_FAILED)))
+            .onErrorMap(this::mapToCustomException)
+            .doOnSuccess(response ->
+                log.info("외부 위험 감지 API 성공 - results: {}",
+                    response.results() != null ? response.results().size() : 0))
+            .doOnError(error -> {
+                if (!(error instanceof CustomException)) {
+                    log.error("외부 위험 감지 API 실패", error);
+                }
+            })
+            .block();
+    }
+
+    private boolean isRetryableError(Throwable throwable) {
+        if (throwable instanceof WebClientResponseException ex) {
+            return ex.getStatusCode().is5xxServerError();
+        }
+        return throwable instanceof WebClientRequestException;
+    }
+
+    private Throwable mapToCustomException(Throwable throwable) {
+        if (throwable instanceof CustomException) {
+            return throwable;
+        }
+
+        if (throwable instanceof WebClientResponseException ex) {
+            log.error("외부 위험 감지 API 에러 응답 - status: {}, body: {}",
+                ex.getStatusCode(), ex.getResponseBodyAsString());
+        }
+
+        return new CustomException(ErrorCode.RISK_DETECT_FAILED);
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/risk/config/ExternalRiskApiConfig.java
+++ b/src/main/java/com/smartchain/platform/domain/risk/config/ExternalRiskApiConfig.java
@@ -1,0 +1,54 @@
+package com.smartchain.platform.domain.risk.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Configuration
+@ConfigurationProperties(prefix = "ai.risk-api")
+public class ExternalRiskApiConfig {
+
+    private String url = "http://localhost:8000";
+    private int timeoutSeconds = 60;
+    private int maxRetry = 3;
+
+    @Bean
+    public WebClient externalRiskApiWebClient() {
+        HttpClient httpClient = HttpClient.create()
+            .responseTimeout(Duration.ofSeconds(timeoutSeconds));
+
+        return WebClient.builder()
+            .baseUrl(url)
+            .clientConnector(new ReactorClientHttpConnector(httpClient))
+            .build();
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public int getTimeoutSeconds() {
+        return timeoutSeconds;
+    }
+
+    public void setTimeoutSeconds(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    public int getMaxRetry() {
+        return maxRetry;
+    }
+
+    public void setMaxRetry(int maxRetry) {
+        this.maxRetry = maxRetry;
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/risk/controller/ExternalRiskController.java
+++ b/src/main/java/com/smartchain/platform/domain/risk/controller/ExternalRiskController.java
@@ -1,0 +1,85 @@
+package com.smartchain.platform.domain.risk.controller;
+
+import com.smartchain.platform.domain.risk.service.ExternalRiskService;
+import com.smartchain.platform.dto.common.page.PageDto;
+import com.smartchain.platform.dto.common.page.PagedResponse;
+import com.smartchain.platform.dto.risk.ExternalRiskDetectApiRequest;
+import com.smartchain.platform.dto.risk.ExternalRiskResultResponse;
+import com.smartchain.platform.global.response.BaseResponse;
+import com.smartchain.platform.global.security.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "External Risk Detection", description = "외부 위험 감지 API (REVIEWER 전용)")
+@RestController
+@RequestMapping("/api/v1/risk/external")
+@RequiredArgsConstructor
+public class ExternalRiskController {
+
+    private final ExternalRiskService externalRiskService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "협력사 리스크 분석 요청", description = "외부 AI API를 통해 협력사 리스크를 분석합니다. REVIEWER 권한이 필요합니다.")
+    @PostMapping("/detect")
+    public ResponseEntity<BaseResponse<List<ExternalRiskResultResponse>>> detect(
+            HttpServletRequest request,
+            @Valid @RequestBody ExternalRiskDetectApiRequest apiRequest) {
+        Long userId = extractUserIdFromRequest(request);
+        List<ExternalRiskResultResponse> results = externalRiskService.detect(userId, apiRequest.companyIds());
+        return ResponseEntity.ok(BaseResponse.success("외부 위험 감지 완료", results));
+    }
+
+    @Operation(summary = "특정 협력사 최신 리스크 결과 조회", description = "특정 협력사의 최신 외부 리스크 분석 결과를 조회합니다.")
+    @GetMapping("/results/{companyId}")
+    public ResponseEntity<BaseResponse<ExternalRiskResultResponse>> getLatestResult(
+            HttpServletRequest request,
+            @Parameter(description = "회사 ID") @PathVariable Long companyId) {
+        Long userId = extractUserIdFromRequest(request);
+        ExternalRiskResultResponse result = externalRiskService.getLatestResult(userId, companyId);
+        return ResponseEntity.ok(BaseResponse.success("리스크 결과 조회 완료", result));
+    }
+
+    @Operation(summary = "전체 리스크 결과 이력 조회", description = "전체 외부 리스크 분석 결과를 페이지네이션으로 조회합니다.")
+    @GetMapping("/results")
+    public ResponseEntity<BaseResponse<PagedResponse<ExternalRiskResultResponse>>> getAllResults(
+            HttpServletRequest request,
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "10") int size) {
+        Long userId = extractUserIdFromRequest(request);
+        Pageable pageable = PageRequest.of(page, size);
+        Page<ExternalRiskResultResponse> resultPage = externalRiskService.getAllResults(userId, pageable);
+
+        PagedResponse<ExternalRiskResultResponse> response = PagedResponse.<ExternalRiskResultResponse>builder()
+            .content(resultPage.getContent())
+            .page(PageDto.builder()
+                .number(resultPage.getNumber())
+                .size(resultPage.getSize())
+                .totalElements(resultPage.getTotalElements())
+                .totalPages(resultPage.getTotalPages())
+                .build())
+            .build();
+
+        return ResponseEntity.ok(BaseResponse.success("리스크 결과 이력 조회 완료", response));
+    }
+
+    private Long extractUserIdFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7);
+            return jwtTokenProvider.getUserIdFromToken(token);
+        }
+        throw new IllegalArgumentException("Authorization header is missing or invalid");
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/risk/entity/ExternalRiskResult.java
+++ b/src/main/java/com/smartchain/platform/domain/risk/entity/ExternalRiskResult.java
@@ -1,0 +1,56 @@
+package com.smartchain.platform.domain.risk.entity;
+
+import com.smartchain.platform.global.entity.BaseTimeEntity;
+import com.smartchain.platform.global.enums.RiskLevel;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "external_risk_result")
+public class ExternalRiskResult extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long companyId;
+
+    @Column(nullable = false)
+    private String companyName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RiskLevel riskLevel;
+
+    @Column(columnDefinition = "TEXT")
+    private String summary;
+
+    @Column(columnDefinition = "TEXT")
+    private String evidenceJson;
+
+    @Column(nullable = false)
+    private Long requestedBy;
+
+    @Column(nullable = false)
+    private LocalDateTime detectedAt;
+
+    @Builder
+    public ExternalRiskResult(Long companyId, String companyName, RiskLevel riskLevel,
+                              String summary, String evidenceJson, Long requestedBy) {
+        this.companyId = companyId;
+        this.companyName = companyName;
+        this.riskLevel = riskLevel;
+        this.summary = summary;
+        this.evidenceJson = evidenceJson;
+        this.requestedBy = requestedBy;
+        this.detectedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/smartchain/platform/domain/risk/repository/ExternalRiskResultRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/risk/repository/ExternalRiskResultRepository.java
@@ -1,0 +1,19 @@
+package com.smartchain.platform.domain.risk.repository;
+
+import com.smartchain.platform.domain.risk.entity.ExternalRiskResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ExternalRiskResultRepository extends JpaRepository<ExternalRiskResult, Long> {
+
+    Optional<ExternalRiskResult> findTopByCompanyIdOrderByDetectedAtDesc(Long companyId);
+
+    Page<ExternalRiskResult> findAllByOrderByDetectedAtDesc(Pageable pageable);
+
+    Page<ExternalRiskResult> findByRequestedByOrderByDetectedAtDesc(Long requestedBy, Pageable pageable);
+}

--- a/src/main/java/com/smartchain/platform/domain/risk/service/ExternalRiskService.java
+++ b/src/main/java/com/smartchain/platform/domain/risk/service/ExternalRiskService.java
@@ -1,0 +1,138 @@
+package com.smartchain.platform.domain.risk.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartchain.platform.domain.risk.client.ExternalRiskApiClient;
+import com.smartchain.platform.domain.risk.entity.ExternalRiskResult;
+import com.smartchain.platform.domain.risk.repository.ExternalRiskResultRepository;
+import com.smartchain.platform.domain.user.entity.Company;
+import com.smartchain.platform.domain.user.entity.User;
+import com.smartchain.platform.domain.user.repository.CompanyRepository;
+import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.dto.risk.ExternalRiskDetectRequest;
+import com.smartchain.platform.dto.risk.ExternalRiskDetectResponse;
+import com.smartchain.platform.dto.risk.ExternalRiskResultResponse;
+import com.smartchain.platform.global.enums.RiskLevel;
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ExternalRiskService {
+
+    private static final Logger log = LoggerFactory.getLogger(ExternalRiskService.class);
+
+    private final ExternalRiskApiClient externalRiskApiClient;
+    private final ExternalRiskResultRepository riskResultRepository;
+    private final CompanyRepository companyRepository;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public List<ExternalRiskResultResponse> detect(Long userId, List<Long> companyIds) {
+        User user = getUser(userId);
+        validateReviewerRole(user);
+
+        List<Company> companies = companyIds.stream()
+            .map(id -> companyRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.RISK_COMPANY_NOT_FOUND)))
+            .toList();
+
+        List<String> vendorNames = companies.stream()
+            .map(Company::getName)
+            .toList();
+
+        ExternalRiskDetectRequest request = ExternalRiskDetectRequest.of(vendorNames);
+        ExternalRiskDetectResponse response = externalRiskApiClient.detect(request);
+
+        List<ExternalRiskResultResponse> results = new ArrayList<>();
+
+        for (ExternalRiskDetectResponse.VendorRiskResult vendorResult : response.results()) {
+            Company company = companies.stream()
+                .filter(c -> c.getName().equals(vendorResult.vendor()))
+                .findFirst()
+                .orElse(null);
+
+            if (company == null) {
+                log.warn("AI 응답의 vendor '{}'에 매칭되는 회사를 찾을 수 없습니다", vendorResult.vendor());
+                continue;
+            }
+
+            RiskLevel riskLevel = RiskLevel.fromString(vendorResult.riskLevel());
+            if (riskLevel == null) {
+                log.warn("유효하지 않은 riskLevel: {}, 기본값 MEDIUM 적용", vendorResult.riskLevel());
+                riskLevel = RiskLevel.MEDIUM;
+            }
+
+            String evidenceJson = serializeEvidence(vendorResult.evidence());
+
+            ExternalRiskResult entity = ExternalRiskResult.builder()
+                .companyId(company.getCompanyId())
+                .companyName(company.getName())
+                .riskLevel(riskLevel)
+                .summary(vendorResult.summary())
+                .evidenceJson(evidenceJson)
+                .requestedBy(user.getUserId())
+                .build();
+
+            ExternalRiskResult saved = riskResultRepository.save(entity);
+            results.add(ExternalRiskResultResponse.from(saved));
+        }
+
+        log.info("외부 위험 감지 완료 - 요청: {}개 회사, 결과: {}개", companyIds.size(), results.size());
+        return results;
+    }
+
+    @Transactional(readOnly = true)
+    public ExternalRiskResultResponse getLatestResult(Long userId, Long companyId) {
+        User user = getUser(userId);
+        validateReviewerRole(user);
+
+        ExternalRiskResult result = riskResultRepository.findTopByCompanyIdOrderByDetectedAtDesc(companyId)
+            .orElseThrow(() -> new CustomException(ErrorCode.RISK_RESULT_NOT_FOUND));
+
+        return ExternalRiskResultResponse.from(result);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ExternalRiskResultResponse> getAllResults(Long userId, Pageable pageable) {
+        User user = getUser(userId);
+        validateReviewerRole(user);
+
+        return riskResultRepository.findAllByOrderByDetectedAtDesc(pageable)
+            .map(ExternalRiskResultResponse::from);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private void validateReviewerRole(User user) {
+        if (!"REVIEWER".equals(user.getRole().getCode())) {
+            throw new CustomException(ErrorCode.RISK_PERMISSION_DENIED);
+        }
+    }
+
+    private String serializeEvidence(List<ExternalRiskDetectResponse.Evidence> evidence) {
+        if (evidence == null || evidence.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(evidence);
+        } catch (JsonProcessingException e) {
+            log.warn("evidence 직렬화 실패", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskDetectApiRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskDetectApiRequest.java
@@ -1,0 +1,14 @@
+package com.smartchain.platform.dto.risk;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/**
+ * Frontend -> Backend 요청 DTO
+ * POST /api/v1/risk/external/detect
+ */
+public record ExternalRiskDetectApiRequest(
+    @NotEmpty(message = "분석 대상 회사 ID 목록은 필수입니다")
+    List<Long> companyIds
+) {}

--- a/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskDetectRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskDetectRequest.java
@@ -1,0 +1,16 @@
+package com.smartchain.platform.dto.risk;
+
+import java.util.List;
+
+/**
+ * Backend -> AI 서버 요청 DTO
+ * POST /risk/external/detect
+ */
+public record ExternalRiskDetectRequest(
+    List<String> vendors,
+    boolean rag
+) {
+    public static ExternalRiskDetectRequest of(List<String> vendorNames) {
+        return new ExternalRiskDetectRequest(vendorNames, true);
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskDetectResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskDetectResponse.java
@@ -1,0 +1,25 @@
+package com.smartchain.platform.dto.risk;
+
+import java.util.List;
+
+/**
+ * AI 서버 -> Backend 응답 DTO
+ */
+public record ExternalRiskDetectResponse(
+    List<VendorRiskResult> results
+) {
+    public record VendorRiskResult(
+        String vendor,
+        String riskLevel,
+        String summary,
+        List<Evidence> evidence
+    ) {}
+
+    public record Evidence(
+        String source,
+        String title,
+        String snippet,
+        String url,
+        String date
+    ) {}
+}

--- a/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskResultResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskResultResponse.java
@@ -1,0 +1,30 @@
+package com.smartchain.platform.dto.risk;
+
+import com.smartchain.platform.domain.risk.entity.ExternalRiskResult;
+
+import java.time.LocalDateTime;
+
+/**
+ * Backend -> Frontend 응답 DTO
+ */
+public record ExternalRiskResultResponse(
+    Long id,
+    Long companyId,
+    String companyName,
+    String riskLevel,
+    String summary,
+    String evidenceJson,
+    LocalDateTime detectedAt
+) {
+    public static ExternalRiskResultResponse from(ExternalRiskResult entity) {
+        return new ExternalRiskResultResponse(
+            entity.getId(),
+            entity.getCompanyId(),
+            entity.getCompanyName(),
+            entity.getRiskLevel().name(),
+            entity.getSummary(),
+            entity.getEvidenceJson(),
+            entity.getDetectedAt()
+        );
+    }
+}

--- a/src/main/java/com/smartchain/platform/global/config/SecurityConfig.java
+++ b/src/main/java/com/smartchain/platform/global/config/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
                                 "/api/v1/jobs/**",
                                 "/api/v1/chat/**"
                         ).hasAnyRole("DRAFTER", "APPROVER", "REVIEWER")
-                        // Admin Chat API는 REVIEWER만 접근 가능
+                        // REVIEWER 전용 API
+                        .requestMatchers("/api/v1/risk/**").hasRole("REVIEWER")
                         .requestMatchers("/api/v1/admin/chat/**").hasRole("REVIEWER")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -105,7 +105,13 @@ public enum ErrorCode {
     // AI Chat Service
     AI_CHAT_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT001", "AI 채팅 서비스 오류가 발생했습니다"),
     AI_CHAT_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "CHAT002", "AI 채팅 서비스 응답 시간이 초과되었습니다"),
-    AI_CHAT_INVALID_DOMAIN(HttpStatus.BAD_REQUEST, "CHAT003", "유효하지 않은 도메인입니다");
+    AI_CHAT_INVALID_DOMAIN(HttpStatus.BAD_REQUEST, "CHAT003", "유효하지 않은 도메인입니다"),
+
+    // External Risk Detection
+    RISK_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "RISK001", "리스크 분석 대상 회사를 찾을 수 없습니다"),
+    RISK_DETECT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "RISK002", "외부 위험 감지 API 호출에 실패했습니다"),
+    RISK_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "RISK003", "리스크 분석 결과를 찾을 수 없습니다"),
+    RISK_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "RISK004", "REVIEWER만 리스크 분석을 요청할 수 있습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,6 +82,10 @@ ai:
     base-url: http://127.0.0.1:8001
     admin-api-key: ${AI_CHAT_ADMIN_KEY:test-key}
     timeout-seconds: 30
+  risk-api:
+    url: ${AI_RISK_API_URL:http://127.0.0.1:8000}
+    timeout-seconds: 60
+    max-retry: 3
   slots:
     # 슬롯 정의: docs/API_CONTRACT_SSOT.md §8.6 기준
     domains:

--- a/src/test/java/com/smartchain/platform/domain/risk/service/ExternalRiskServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/risk/service/ExternalRiskServiceTest.java
@@ -1,0 +1,325 @@
+package com.smartchain.platform.domain.risk.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartchain.platform.domain.risk.client.ExternalRiskApiClient;
+import com.smartchain.platform.domain.risk.entity.ExternalRiskResult;
+import com.smartchain.platform.domain.risk.repository.ExternalRiskResultRepository;
+import com.smartchain.platform.domain.user.entity.Company;
+import com.smartchain.platform.domain.user.entity.Role;
+import com.smartchain.platform.domain.user.entity.User;
+import com.smartchain.platform.domain.user.repository.CompanyRepository;
+import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.dto.risk.ExternalRiskDetectRequest;
+import com.smartchain.platform.dto.risk.ExternalRiskDetectResponse;
+import com.smartchain.platform.dto.risk.ExternalRiskResultResponse;
+import com.smartchain.platform.global.enums.RiskLevel;
+import com.smartchain.platform.global.error.CustomException;
+import com.smartchain.platform.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ExternalRiskServiceTest {
+
+    @Mock
+    private ExternalRiskApiClient externalRiskApiClient;
+    @Mock
+    private ExternalRiskResultRepository riskResultRepository;
+    @Mock
+    private CompanyRepository companyRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private ObjectMapper objectMapper;
+    private ExternalRiskService externalRiskService;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        externalRiskService = new ExternalRiskService(
+            externalRiskApiClient,
+            riskResultRepository,
+            companyRepository,
+            userRepository,
+            objectMapper
+        );
+    }
+
+    @Nested
+    @DisplayName("detect")
+    class DetectTest {
+
+        @Test
+        @DisplayName("REVIEWER가 아닌 사용자는 RISK_PERMISSION_DENIED 에러를 발생시킨다")
+        void detect_nonReviewer_throwsException() {
+            // given
+            Long userId = 1L;
+            User user = createTestUser(userId, "DRAFTER");
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            // when & then
+            assertThatThrownBy(() -> externalRiskService.detect(userId, List.of(1L)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.RISK_PERMISSION_DENIED);
+                });
+
+            verify(externalRiskApiClient, never()).detect(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회사 ID를 전달하면 RISK_COMPANY_NOT_FOUND 에러를 발생시킨다")
+        void detect_companyNotFound_throwsException() {
+            // given
+            Long userId = 1L;
+            User user = createTestUser(userId, "REVIEWER");
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(companyRepository.findById(999L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> externalRiskService.detect(userId, List.of(999L)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.RISK_COMPANY_NOT_FOUND);
+                });
+
+            verify(externalRiskApiClient, never()).detect(any());
+        }
+
+        @Test
+        @DisplayName("정상 흐름: 회사 조회 → AI 호출 → 결과 저장")
+        void detect_success_savesResults() {
+            // given
+            Long userId = 1L;
+            User user = createTestUser(userId, "REVIEWER");
+            Company company = createTestCompany(10L, "테스트협력사");
+
+            ExternalRiskDetectResponse aiResponse = new ExternalRiskDetectResponse(
+                List.of(new ExternalRiskDetectResponse.VendorRiskResult(
+                    "테스트협력사", "HIGH", "뉴스 기사에서 위험 감지",
+                    List.of(new ExternalRiskDetectResponse.Evidence(
+                        "뉴스", "위험 기사", "내용 발췌", "https://example.com", "2025-01-01"
+                    ))
+                ))
+            );
+
+            ExternalRiskResult savedEntity = ExternalRiskResult.builder()
+                .companyId(10L)
+                .companyName("테스트협력사")
+                .riskLevel(RiskLevel.HIGH)
+                .summary("뉴스 기사에서 위험 감지")
+                .requestedBy(userId)
+                .build();
+            ReflectionTestUtils.setField(savedEntity, "id", 100L);
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(companyRepository.findById(10L)).thenReturn(Optional.of(company));
+            when(externalRiskApiClient.detect(any(ExternalRiskDetectRequest.class))).thenReturn(aiResponse);
+            when(riskResultRepository.save(any(ExternalRiskResult.class))).thenReturn(savedEntity);
+
+            // when
+            List<ExternalRiskResultResponse> results = externalRiskService.detect(userId, List.of(10L));
+
+            // then
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).companyName()).isEqualTo("테스트협력사");
+            assertThat(results.get(0).riskLevel()).isEqualTo("HIGH");
+
+            verify(externalRiskApiClient).detect(any(ExternalRiskDetectRequest.class));
+            verify(riskResultRepository).save(any(ExternalRiskResult.class));
+        }
+
+        @Test
+        @DisplayName("AI 서비스 에러 시 예외가 전파된다")
+        void detect_aiServiceError_propagatesException() {
+            // given
+            Long userId = 1L;
+            User user = createTestUser(userId, "REVIEWER");
+            Company company = createTestCompany(10L, "테스트협력사");
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(companyRepository.findById(10L)).thenReturn(Optional.of(company));
+            when(externalRiskApiClient.detect(any(ExternalRiskDetectRequest.class)))
+                .thenThrow(new CustomException(ErrorCode.RISK_DETECT_FAILED));
+
+            // when & then
+            assertThatThrownBy(() -> externalRiskService.detect(userId, List.of(10L)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.RISK_DETECT_FAILED);
+                });
+
+            verify(riskResultRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 USER_NOT_FOUND 에러를 발생시킨다")
+        void detect_userNotFound_throwsException() {
+            // given
+            Long userId = 999L;
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> externalRiskService.detect(userId, List.of(1L)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+                });
+        }
+    }
+
+    @Nested
+    @DisplayName("getLatestResult")
+    class GetLatestResultTest {
+
+        @Test
+        @DisplayName("리스크 결과가 없으면 RISK_RESULT_NOT_FOUND 에러를 발생시킨다")
+        void getLatestResult_notFound_throwsException() {
+            // given
+            Long userId = 1L;
+            Long companyId = 10L;
+            User user = createTestUser(userId, "REVIEWER");
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(riskResultRepository.findTopByCompanyIdOrderByDetectedAtDesc(companyId))
+                .thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> externalRiskService.getLatestResult(userId, companyId))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.RISK_RESULT_NOT_FOUND);
+                });
+        }
+
+        @Test
+        @DisplayName("리스크 결과가 있으면 최신 결과를 반환한다")
+        void getLatestResult_found_returnsResult() {
+            // given
+            Long userId = 1L;
+            Long companyId = 10L;
+            User user = createTestUser(userId, "REVIEWER");
+
+            ExternalRiskResult result = ExternalRiskResult.builder()
+                .companyId(companyId)
+                .companyName("테스트협력사")
+                .riskLevel(RiskLevel.MEDIUM)
+                .summary("중간 위험")
+                .requestedBy(userId)
+                .build();
+            ReflectionTestUtils.setField(result, "id", 1L);
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(riskResultRepository.findTopByCompanyIdOrderByDetectedAtDesc(companyId))
+                .thenReturn(Optional.of(result));
+
+            // when
+            ExternalRiskResultResponse response = externalRiskService.getLatestResult(userId, companyId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.companyName()).isEqualTo("테스트협력사");
+            assertThat(response.riskLevel()).isEqualTo("MEDIUM");
+        }
+
+        @Test
+        @DisplayName("REVIEWER가 아니면 RISK_PERMISSION_DENIED 에러를 발생시킨다")
+        void getLatestResult_nonReviewer_throwsException() {
+            // given
+            Long userId = 1L;
+            User user = createTestUser(userId, "APPROVER");
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            // when & then
+            assertThatThrownBy(() -> externalRiskService.getLatestResult(userId, 10L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.RISK_PERMISSION_DENIED);
+                });
+        }
+    }
+
+    @Nested
+    @DisplayName("getAllResults")
+    class GetAllResultsTest {
+
+        @Test
+        @DisplayName("전체 결과를 페이지네이션으로 반환한다")
+        void getAllResults_success_returnsPagedResults() {
+            // given
+            Long userId = 1L;
+            User user = createTestUser(userId, "REVIEWER");
+            Pageable pageable = PageRequest.of(0, 10);
+
+            ExternalRiskResult result = ExternalRiskResult.builder()
+                .companyId(10L)
+                .companyName("테스트협력사")
+                .riskLevel(RiskLevel.LOW)
+                .summary("저위험")
+                .requestedBy(userId)
+                .build();
+            ReflectionTestUtils.setField(result, "id", 1L);
+
+            Page<ExternalRiskResult> page = new PageImpl<>(List.of(result), pageable, 1);
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(riskResultRepository.findAllByOrderByDetectedAtDesc(pageable)).thenReturn(page);
+
+            // when
+            Page<ExternalRiskResultResponse> responsePage = externalRiskService.getAllResults(userId, pageable);
+
+            // then
+            assertThat(responsePage.getContent()).hasSize(1);
+            assertThat(responsePage.getContent().get(0).riskLevel()).isEqualTo("LOW");
+            assertThat(responsePage.getTotalElements()).isEqualTo(1);
+        }
+    }
+
+    // Helper methods
+    private User createTestUser(Long userId, String roleCode) {
+        Role role = new Role("테스트역할", roleCode);
+        ReflectionTestUtils.setField(role, "roleId", 1L);
+
+        User user = User.builder()
+            .name("테스트유저")
+            .email("test@test.com")
+            .userPassword("password123!")
+            .role(role)
+            .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+        return user;
+    }
+
+    private Company createTestCompany(Long companyId, String name) {
+        Company company = Company.builder()
+            .name(name)
+            .build();
+        ReflectionTestUtils.setField(company, "companyId", companyId);
+        return company;
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -37,6 +37,10 @@ ai:
     url: http://localhost:8000
     timeout-seconds: 30
     max-retry: 1
+  risk-api:
+    url: http://localhost:8000
+    timeout-seconds: 10
+    max-retry: 1
   slots:
     # 슬롯 정의: docs/API_CONTRACT_SSOT.md §8.6 기준
     domains:


### PR DESCRIPTION
## 변경 요약

외부 위험 감지 AI API(`POST /risk/external/detect`)를 연동하여 **REVIEWER만** 협력사 리스크 분석 결과를 조회할 수 있도록 구현합니다.

### 신규 파일 (11개)
| 파일 | 설명 |
|------|------|
| `domain/risk/config/ExternalRiskApiConfig.java` | WebClient 빈 + timeout/retry 설정 |
| `dto/risk/ExternalRiskDetectRequest.java` | Backend→AI 요청 DTO (vendors, rag) |
| `dto/risk/ExternalRiskDetectResponse.java` | AI→Backend 응답 DTO (results, evidence) |
| `dto/risk/ExternalRiskDetectApiRequest.java` | Frontend→Backend 요청 DTO (companyIds) |
| `dto/risk/ExternalRiskResultResponse.java` | Backend→Frontend 응답 DTO |
| `domain/risk/client/ExternalRiskApiClient.java` | WebClient 기반 AI 서버 통신 (retry+에러핸들링) |
| `domain/risk/entity/ExternalRiskResult.java` | JPA 엔티티 (BaseTimeEntity 상속) |
| `domain/risk/repository/ExternalRiskResultRepository.java` | JPA 리포지토리 |
| `domain/risk/service/ExternalRiskService.java` | 비즈니스 로직 + REVIEWER 권한 검증 |
| `domain/risk/controller/ExternalRiskController.java` | REST 엔드포인트 3개 |
| `test/.../risk/service/ExternalRiskServiceTest.java` | 단위 테스트 8개 |

### 수정 파일 (4개)
| 파일 | 변경 |
|------|------|
| `ErrorCode.java` | RISK001~004 에러코드 추가 |
| `SecurityConfig.java` | `/api/v1/risk/**` REVIEWER 전용 제한 |
| `application.yaml` | `ai.risk-api` url/timeout/retry 설정 추가 |
| `application-test.yaml` | 테스트용 risk-api 설정 추가 |

### API 엔드포인트
| Method | Path | 설명 |
|--------|------|------|
| POST | `/api/v1/risk/external/detect` | 협력사 리스크 분석 요청 (companyIds) |
| GET | `/api/v1/risk/external/results/{companyId}` | 특정 협력사 최신 결과 |
| GET | `/api/v1/risk/external/results` | 전체 결과 이력 (페이지네이션) |

---

## 관련 이슈

- Closes #183

---

## 테스트 방법

```bash
# 단위 테스트 실행
./gradlew test --tests "ExternalRiskServiceTest"

# 전체 테스트 + 빌드
./gradlew test && ./gradlew build
```

### 테스트 케이스 (8개)
- [x] REVIEWER가 아닌 사용자 → `RISK_PERMISSION_DENIED`
- [x] 존재하지 않는 회사 ID → `RISK_COMPANY_NOT_FOUND`
- [x] 정상 흐름: 회사 조회 → AI 호출 → 결과 저장
- [x] AI 서비스 에러 시 예외 전파
- [x] 사용자 미존재 → `USER_NOT_FOUND`
- [x] 리스크 결과 미존재 → `RISK_RESULT_NOT_FOUND`
- [x] 최신 결과 정상 반환
- [x] 전체 결과 페이지네이션 반환

---

## 명세 준수 체크

- [x] `RiskLevel` enum 재사용 (LOW/MEDIUM/HIGH)
- [x] `BaseTimeEntity` 상속 (createdAt/updatedAt 감사)
- [x] `BaseResponse<T>` 응답 래핑
- [x] `CustomException` + `ErrorCode` 에러 처리 패턴
- [x] `PagedResponse<T>` + `PageDto` 페이지네이션 패턴
- [x] Controller에서 JWT → userId 추출, Service에서 User 조회 패턴
- [x] AiRunApiConfig 패턴 복사 (WebClient + @ConfigurationProperties)
- [x] SecurityConfig REVIEWER 제한 (`hasRole("REVIEWER")`)
- [x] DTO record 사용 (불변 객체)
- [x] `@Transactional` / `@Transactional(readOnly = true)` 적용

---

## 리뷰 포인트

1. **REVIEWER 권한 이중 검증**: SecurityConfig(`hasRole`)에서 URL 레벨 차단 + Service(`validateReviewerRole`)에서 비즈니스 레벨 차단. 이중으로 검증하는 게 의도입니다.
2. **AI 응답 vendor 매칭**: `company.getName().equals(vendorResult.vendor())` — AI가 vendor 이름을 변형 반환할 경우 매칭 실패 가능. 현재는 로그 경고 후 skip 처리.
3. **riskLevel 기본값**: AI가 유효하지 않은 riskLevel을 반환하면 `MEDIUM`으로 fallback 처리.
4. **evidence JSON 저장**: evidence 목록을 JSON 문자열로 직렬화하여 TEXT 컬럼에 저장. 별도 테이블 대신 단순 구조 채택.

---

## TODO / 질문

- [ ] AI 서버의 `/risk/external/detect` 엔드포인트 스펙이 확정되면 DTO 필드 검증 필요
- [ ] vendor 이름 매칭 로직 개선 (유사도 매칭 등) 필요 여부 논의
- [ ] evidence를 별도 테이블로 분리할지 현재 JSON 저장 방식 유지할지 결정
- [ ] 비동기 처리 필요 여부 (현재 동기 호출 → 다수 회사 분석 시 timeout 우려)

🤖 Generated with [Claude Code](https://claude.com/claude-code)