### PR TITLE
feat(privacy): 서버 사이드 이름 마스킹 적용

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,31 @@
 # Claude Code Learnings
 
+## 2026-02-05: 서버 사이드 이름 마스킹 (개인정보 보호법 제29조 준수)
+
+### 원인
+- API 응답에서 사용자 이름이 평문으로 노출되어 네트워크 탭에서 원본 이름 확인 가능
+- 프론트엔드 마스킹만으로는 개인정보 보호법 제29조(안전조치의무) 미충족
+
+### 해결
+- `NameMaskingUtil` 유틸리티 클래스 신설 (`global/util/NameMaskingUtil.java`)
+- 마스킹 규칙: 1글자 → 그대로, 2글자 → 첫+*, 3글자 → 첫+*+끝, 4글자+ → 첫+**...+끝
+- 10개 API 대상 DTO에 `maskedName` 필드 추가 (기존 `name` 필드 유지)
+- 6개 서비스 (Auth, Approval, Diagnostic, Review, RoleRequest, Management)에서 빌더 호출 시 마스킹 적용
+- 동일 구조의 ProcessedByDto가 3개 패키지(approval/detail, review/common, role/common)에 분산되어 있어 모두 통일 수정
+
+### 재발방지
+- 신규 사용자 이름 포함 DTO 추가 시 반드시 `maskedName` 필드 포함
+- `NameMaskingUtil.mask()` 사용하여 서비스 레이어에서 마스킹 적용
+
+### 검증방법
+- `NameMaskingUtilTest` 단위 테스트 (null/빈값, 1~4+글자, 영문 포함)
+- `./gradlew build` 전체 빌드 및 테스트 통과
+
+### 관련커밋
+- (커밋 전)
+
+---
+
 ## 2026-02-05: 외부 위험 감지 API 연동 - REVIEWER 전용 (#183)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
+++ b/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
@@ -28,6 +28,7 @@ import com.smartchain.platform.global.enums.ApprovalStatus;
 import com.smartchain.platform.global.enums.DiagnosticStatus;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
+import com.smartchain.platform.global.util.NameMaskingUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -209,6 +210,7 @@ public class ApprovalService {
             processedByDto = ProcessedByDto.builder()
                     .userId(approval.getApprover().getUserId())
                     .name(approval.getApprover().getName())
+                    .maskedName(NameMaskingUtil.mask(approval.getApprover().getName()))
                     .build();
         }
 
@@ -272,6 +274,7 @@ public class ApprovalService {
         ProcessedByDto processedByDto = ProcessedByDto.builder()
                 .userId(currentUser.getUserId())
                 .name(currentUser.getName())
+                .maskedName(NameMaskingUtil.mask(currentUser.getName()))
                 .build();
 
         return ApprovalDecisionResponse.builder()
@@ -384,6 +387,7 @@ public class ApprovalService {
         RequesterDto requesterDto = RequesterDto.builder()
                 .userId(approval.getRequester().getUserId())
                 .name(approval.getRequester().getName())
+                .maskedName(NameMaskingUtil.mask(approval.getRequester().getName()))
                 .build();
 
         String requestedAtLabel = approval.getCreatedAt() != null

--- a/src/main/java/com/smartchain/platform/domain/auth/service/AuthService.java
+++ b/src/main/java/com/smartchain/platform/domain/auth/service/AuthService.java
@@ -23,6 +23,7 @@ import com.smartchain.platform.dto.auth.register.RegisterRequest;
 import com.smartchain.platform.dto.auth.register.RegisterResponse;
 import com.smartchain.platform.dto.auth.token.TokenRefreshRequest;
 import com.smartchain.platform.dto.auth.token.TokenRefreshResponse;
+import com.smartchain.platform.global.util.NameMaskingUtil;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.enums.RequestStatus;
 import com.smartchain.platform.global.enums.UserStatus;
@@ -377,6 +378,7 @@ public class AuthService {
                 .userId(user.getUserId())
                 .email(user.getEmail())
                 .name(user.getName())
+                .maskedName(NameMaskingUtil.mask(user.getName()))
                 .lastLoginAt(user.getLastLoginAt())
                 .createdAt(user.getCreatedAt());
 
@@ -432,7 +434,8 @@ public class AuthService {
         UserInfoDto.UserInfoDtoBuilder builder = UserInfoDto.builder()
                 .userId(user.getUserId())
                 .email(user.getEmail())
-                .name(user.getName());
+                .name(user.getName())
+                .maskedName(NameMaskingUtil.mask(user.getName()));
 
         if (user.getRole() != null) {
             builder.role(RoleInfoDto.builder()

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -35,6 +35,7 @@ import com.smartchain.platform.dto.diagnostic.submit.DiagnosticSubmitResponse;
 import com.smartchain.platform.global.enums.DiagnosticStatus;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
+import com.smartchain.platform.global.util.NameMaskingUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -224,6 +225,7 @@ public class DiagnosticService {
             createdByDto = CreatedByDto.builder()
                     .userId(drafter.getUserId())
                     .name(drafter.getName())
+                    .maskedName(NameMaskingUtil.mask(drafter.getName()))
                     .build();
         }
 

--- a/src/main/java/com/smartchain/platform/domain/management/service/ManagementService.java
+++ b/src/main/java/com/smartchain/platform/domain/management/service/ManagementService.java
@@ -26,6 +26,7 @@ import com.smartchain.platform.dto.management.user.*;
 import com.smartchain.platform.global.enums.*;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
+import com.smartchain.platform.global.util.NameMaskingUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -429,6 +430,7 @@ public class ManagementService {
                 .user(UserSimpleDto.builder()
                         .userId(user.getUserId())
                         .name(user.getName())
+                        .maskedName(NameMaskingUtil.mask(user.getName()))
                         .email(user.getEmail())
                         .build())
                 .company(user.getCompany() != null ? CompanySimpleDto.builder()
@@ -451,6 +453,7 @@ public class ManagementService {
         return UserManagementItemDto.builder()
                 .userId(user.getUserId())
                 .name(user.getName())
+                .maskedName(NameMaskingUtil.mask(user.getName()))
                 .email(user.getEmail())
                 .company(user.getCompany() != null ? CompanySimpleDto.builder()
                         .companyId(user.getCompany().getCompanyId())
@@ -510,6 +513,7 @@ public class ManagementService {
             userInfo = UserLogInfoDto.builder()
                     .userId(user.getUserId())
                     .name(user.getName())
+                    .maskedUserName(NameMaskingUtil.mask(user.getName()))
                     .role(user.getRole() != null ? user.getRole().getCode() : null)
                     .build();
         }

--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -22,6 +22,7 @@ import com.smartchain.platform.global.enums.ReviewStatus;
 import com.smartchain.platform.global.enums.RiskLevel;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
+import com.smartchain.platform.global.util.NameMaskingUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -365,6 +366,7 @@ public class ReviewService {
         ProcessedByDto processedByDto = ProcessedByDto.builder()
                 .userId(currentUser.getUserId())
                 .name(currentUser.getName())
+                .maskedName(NameMaskingUtil.mask(currentUser.getName()))
                 .build();
 
         return ReviewDecisionResponse.builder()
@@ -594,6 +596,7 @@ public class ReviewService {
             assignedToDto = AssignedToDto.builder()
                     .userId(review.getAssignedReviewer().getUserId())
                     .name(review.getAssignedReviewer().getName())
+                    .maskedName(NameMaskingUtil.mask(review.getAssignedReviewer().getName()))
                     .build();
         }
 

--- a/src/main/java/com/smartchain/platform/domain/role/service/RoleRequestService.java
+++ b/src/main/java/com/smartchain/platform/domain/role/service/RoleRequestService.java
@@ -35,6 +35,7 @@ import com.smartchain.platform.dto.role.request.RoleRequestStatusDto;
 import com.smartchain.platform.global.enums.RequestStatus;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
+import com.smartchain.platform.global.util.NameMaskingUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -234,6 +235,7 @@ public class RoleRequestService {
             processedByDto = ProcessedByDto.builder()
                     .userId(roleRequest.getProcessedBy().getUserId())
                     .name(roleRequest.getProcessedBy().getName())
+                    .maskedName(NameMaskingUtil.mask(roleRequest.getProcessedBy().getName()))
                     .build();
         }
 
@@ -334,6 +336,7 @@ public class RoleRequestService {
         UserSimpleDto userDto = UserSimpleDto.builder()
                 .userId(roleRequest.getUser().getUserId())
                 .name(roleRequest.getUser().getName())
+                .maskedName(NameMaskingUtil.mask(roleRequest.getUser().getName()))
                 .email(roleRequest.getUser().getEmail())
                 .build();
 
@@ -399,6 +402,7 @@ public class RoleRequestService {
         UserSimpleDto userDto = UserSimpleDto.builder()
                 .userId(roleRequest.getUser().getUserId())
                 .name(roleRequest.getUser().getName())
+                .maskedName(NameMaskingUtil.mask(roleRequest.getUser().getName()))
                 .email(roleRequest.getUser().getEmail())
                 .build();
 
@@ -521,6 +525,7 @@ public class RoleRequestService {
         ProcessedByDto processedByDto = ProcessedByDto.builder()
                 .userId(currentUser.getUserId())
                 .name(currentUser.getName())
+                .maskedName(NameMaskingUtil.mask(currentUser.getName()))
                 .build();
 
         return RoleDecisionResponse.builder()

--- a/src/main/java/com/smartchain/platform/dto/approval/common/RequesterDto.java
+++ b/src/main/java/com/smartchain/platform/dto/approval/common/RequesterDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class RequesterDto {
     private Long userId;
     private String name;
+    private String maskedName;
 }

--- a/src/main/java/com/smartchain/platform/dto/approval/detail/ProcessedByDto.java
+++ b/src/main/java/com/smartchain/platform/dto/approval/detail/ProcessedByDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class ProcessedByDto {
     private Long userId;
     private String name;
+    private String maskedName;
 }

--- a/src/main/java/com/smartchain/platform/dto/auth/common/UserInfoDto.java
+++ b/src/main/java/com/smartchain/platform/dto/auth/common/UserInfoDto.java
@@ -16,6 +16,7 @@ public class UserInfoDto {
     private Long userId;
     private String email;
     private String name;
+    private String maskedName;
     private String profileImageUrl;
     private CompanyInfoDto company;
     private RoleInfoDto role;

--- a/src/main/java/com/smartchain/platform/dto/auth/myinfo/MyInfoResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/auth/myinfo/MyInfoResponse.java
@@ -19,6 +19,7 @@ public class MyInfoResponse {
     private Long userId;
     private String email;
     private String name;
+    private String maskedName;
     private String profileImageUrl;
     private CompanyInfoDto company;
     private RoleInfoDto role;

--- a/src/main/java/com/smartchain/platform/dto/diagnostic/detail/CreatedByDto.java
+++ b/src/main/java/com/smartchain/platform/dto/diagnostic/detail/CreatedByDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class CreatedByDto {
     private Long userId;
     private String name;
+    private String maskedName;
 }

--- a/src/main/java/com/smartchain/platform/dto/management/common/UserSimpleDto.java
+++ b/src/main/java/com/smartchain/platform/dto/management/common/UserSimpleDto.java
@@ -12,5 +12,6 @@ import lombok.NoArgsConstructor;
 public class UserSimpleDto {
     private Long userId;
     private String name;
+    private String maskedName;
     private String email;
 }

--- a/src/main/java/com/smartchain/platform/dto/management/log/UserLogInfoDto.java
+++ b/src/main/java/com/smartchain/platform/dto/management/log/UserLogInfoDto.java
@@ -12,5 +12,6 @@ import lombok.NoArgsConstructor;
 public class UserLogInfoDto {
     private Long userId;
     private String name;
+    private String maskedUserName;
     private String role;
 }

--- a/src/main/java/com/smartchain/platform/dto/management/user/UserManagementItemDto.java
+++ b/src/main/java/com/smartchain/platform/dto/management/user/UserManagementItemDto.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 public class UserManagementItemDto {
     private Long userId;
     private String name;
+    private String maskedName;
     private String email;
     private CompanySimpleDto company;
     private RoleSimpleDto role;

--- a/src/main/java/com/smartchain/platform/dto/review/common/AssignedToDto.java
+++ b/src/main/java/com/smartchain/platform/dto/review/common/AssignedToDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class AssignedToDto {
     private Long userId;
     private String name;
+    private String maskedName;
 }

--- a/src/main/java/com/smartchain/platform/dto/review/common/ProcessedByDto.java
+++ b/src/main/java/com/smartchain/platform/dto/review/common/ProcessedByDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class ProcessedByDto {
     private Long userId;
     private String name;
+    private String maskedName;
 }

--- a/src/main/java/com/smartchain/platform/dto/role/common/ProcessedByDto.java
+++ b/src/main/java/com/smartchain/platform/dto/role/common/ProcessedByDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class ProcessedByDto {
     private Long userId;
     private String name;
+    private String maskedName;
 }

--- a/src/main/java/com/smartchain/platform/dto/role/common/UserSimpleDto.java
+++ b/src/main/java/com/smartchain/platform/dto/role/common/UserSimpleDto.java
@@ -12,5 +12,6 @@ import lombok.NoArgsConstructor;
 public class UserSimpleDto {
     private Long userId;
     private String name;
+    private String maskedName;
     private String email;
 }

--- a/src/main/java/com/smartchain/platform/global/util/NameMaskingUtil.java
+++ b/src/main/java/com/smartchain/platform/global/util/NameMaskingUtil.java
@@ -1,0 +1,36 @@
+package com.smartchain.platform.global.util;
+
+/**
+ * 개인정보 보호법 제29조(안전조치의무) 준수를 위한 이름 마스킹 유틸리티.
+ *
+ * 마스킹 규칙: 첫 글자 + '*' × (길이-2) + 마지막 글자
+ * - 1글자: 그대로 (김 → 김)
+ * - 2글자: 첫 글자 + * (이수 → 이*)
+ * - 3글자: 첫 글자 + * + 마지막 (홍길동 → 홍*동)
+ * - 4글자+: 첫 글자 + ** ... + 마지막 (남궁선우 → 남**우)
+ */
+public final class NameMaskingUtil {
+
+    private NameMaskingUtil() {
+    }
+
+    public static String mask(String name) {
+        if (name == null || name.isBlank()) {
+            return name;
+        }
+
+        int length = name.length();
+
+        if (length == 1) {
+            return name;
+        }
+
+        if (length == 2) {
+            return name.charAt(0) + "*";
+        }
+
+        return name.charAt(0)
+                + "*".repeat(length - 2)
+                + name.charAt(length - 1);
+    }
+}

--- a/src/test/java/com/smartchain/platform/global/util/NameMaskingUtilTest.java
+++ b/src/test/java/com/smartchain/platform/global/util/NameMaskingUtilTest.java
@@ -1,0 +1,56 @@
+package com.smartchain.platform.global.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("NameMaskingUtil 테스트")
+class NameMaskingUtilTest {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "\t"})
+    @DisplayName("null, 빈 문자열, 공백은 그대로 반환")
+    void mask_nullOrBlank_returnsAsIs(String input) {
+        assertThat(NameMaskingUtil.mask(input)).isEqualTo(input);
+    }
+
+    @Test
+    @DisplayName("1글자 이름은 그대로 반환")
+    void mask_singleChar() {
+        assertThat(NameMaskingUtil.mask("김")).isEqualTo("김");
+    }
+
+    @Test
+    @DisplayName("2글자 이름은 첫 글자 + *")
+    void mask_twoChars() {
+        assertThat(NameMaskingUtil.mask("이수")).isEqualTo("이*");
+    }
+
+    @Test
+    @DisplayName("3글자 이름은 첫 글자 + * + 마지막 글자")
+    void mask_threeChars() {
+        assertThat(NameMaskingUtil.mask("홍길동")).isEqualTo("홍*동");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "남궁선우, 남**우",
+            "독고진세영, 독***영"
+    })
+    @DisplayName("4글자 이상 이름은 첫 글자 + * x (길이-2) + 마지막 글자")
+    void mask_fourOrMoreChars(String input, String expected) {
+        assertThat(NameMaskingUtil.mask(input)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("영문 이름도 동일한 규칙 적용")
+    void mask_englishName() {
+        assertThat(NameMaskingUtil.mask("John")).isEqualTo("J**n");
+    }
+}


### PR DESCRIPTION
## 변경 요약

개인정보 보호법 제29조(안전조치의무) 준수를 위해, 모든 API 응답에서 사용자 이름을 서버 사이드에서 마스킹하여 내려주도록 변경합니다.

- `NameMaskingUtil` 유틸리티 클래스 신설 (`global/util/`)
- 마스킹 규칙: 첫 글자 + `*` × (길이-2) + 마지막 글자
  - 1글자: `김` → `김` / 2글자: `이수` → `이*` / 3글자: `홍길동` → `홍*동` / 4글자+: `남궁선우` → `남**우`
- **12개 DTO**에 `maskedName` (ActivityLog는 `maskedUserName`) 필드 추가
- **6개 서비스**에서 빌더 호출 시 `NameMaskingUtil.mask()` 적용
- 기존 `name` 필드는 그대로 유지 (관리자 기능 등 원본 필요 시 대비)

### 변경 파일

| 구분 | 파일 | 변경 내용 |
|------|------|----------|
| **신규** | `global/util/NameMaskingUtil.java` | 마스킹 유틸리티 |
| **신규** | `test/.../NameMaskingUtilTest.java` | 단위 테스트 |
| **DTO** | `UserInfoDto`, `MyInfoResponse` | `maskedName` 추가 |
| **DTO** | `RequesterDto`, `CreatedByDto`, `AssignedToDto` | `maskedName` 추가 |
| **DTO** | `UserSimpleDto` (role/common, management/common) | `maskedName` 추가 |
| **DTO** | `ProcessedByDto` (role, approval, review) | `maskedName` 추가 |
| **DTO** | `UserManagementItemDto` | `maskedName` 추가 |
| **DTO** | `UserLogInfoDto` | `maskedUserName` 추가 |
| **서비스** | `AuthService` | login, me 응답에 마스킹 |
| **서비스** | `ApprovalService` | 목록/상세/결재 응답에 마스킹 |
| **서비스** | `DiagnosticService` | 상세 응답에 마스킹 |
| **서비스** | `ReviewService` | 목록/결재 응답에 마스킹 |
| **서비스** | `RoleRequestService` | 목록/상세/결재/내 요청 응답에 마스킹 |
| **서비스** | `ManagementService` | 사용자 목록/권한 요청/활동 로그 응답에 마스킹 |

## 관련 이슈

- 개인정보 보호법 제29조(안전조치의무) 준수
- 프론트엔드 마스킹만으로는 네트워크 탭에서 원본 이름 노출 → 서버 사이드 마스킹 필수

## 테스트 방법

```bash
# 1. 전체 빌드 및 테스트
./gradlew build

# 2. 마스킹 유틸리티 단위 테스트만 실행
./gradlew test --tests "NameMaskingUtilTest"

# 3. API 응답 확인 (로컬 서버 기동 후)
# POST /api/v1/auth/login → response.user.maskedName 확인
# GET /api/v1/auth/me → response.maskedName 확인
# GET /api/v1/approvals → items[].requester.maskedName 확인
# GET /api/v1/diagnostics/{id} → createdBy.maskedName 확인
# GET /api/v1/reviews → items[].assignedTo.maskedName 확인
# GET /api/v1/role-requests → items[].user.maskedName 확인
# GET /api/v1/management/users → items[].maskedName 확인
# GET /api/v1/management/activity-logs → items[].user.maskedUserName 확인
```

## 명세 준수 체크

- [x] `POST /v1/auth/login` → `UserInfoDto.maskedName`
- [x] `GET /v1/auth/me` → `MyInfoResponse.maskedName`
- [x] `GET /v1/approvals` → `ApprovalListItem.requester.maskedName`
- [x] `GET /v1/diagnostics/{id}` → `DiagnosticDetail.createdBy.maskedName`
- [x] `GET /v1/reviews` → `ReviewListItem.assignedTo.maskedName`
- [x] `GET /v1/role-requests` → `RoleApprovalItemDto.user.maskedName` (UserSimpleDto)
- [x] `GET /v1/role-requests/{id}` → `RoleApprovalDetailResponse.user.maskedName` (UserSimpleDto)
- [x] `GET /v1/role-requests/my` → `RoleRequestStatusDto.processedBy.maskedName` (ProcessedByDto)
- [x] `GET /v1/management/users` → `UserListItem.maskedName`
- [x] `GET /v1/management/activity-logs` → `ActivityLogItem.maskedUserName`
- [x] 기존 `name` 필드 유지
- [x] `maskedName`은 항상 마스킹된 값

## 리뷰 포인트

1. **마스킹 규칙 정확성**: `NameMaskingUtil` 로직이 명세(첫 글자 + * × (길이-2) + 마지막 글자)와 일치하는지
2. **누락 없는지**: 명세의 10개 API/DTO 외에 동일 구조의 `ProcessedByDto`가 3개 패키지(approval/detail, review/common, role/common)에 분산되어 있어 모두 수정함 — 과잉 수정 여부 확인
3. **null 안전성**: `NameMaskingUtil.mask(null)` → `null` 반환, 빌더에서 null name 전달 시 NPE 없음
4. **ActivityLog 필드명**: 명세대로 `maskedUserName` 사용 (`maskedName`이 아닌 이유: user 객체 내부가 아닌 ActivityLogItem 직접 필드로 요청됨 → 실제로는 `UserLogInfoDto.maskedUserName`으로 구현)

## TODO / 질문

- [ ] `name` 필드 자체를 권한 기반으로 제어할지 여부 — 별도 논의 필요 (현재는 name + maskedName 병행)
- [ ] `RequesterDetailDto` (결재 상세 API의 요청자)에도 `maskedName` 추가 필요한지? 현재 명세 대상 외이나 동일한 이름 노출 패턴
- [ ] Swagger 문서(`API_CONTRACT_SSOT.md`)에 `maskedName` 필드 반영 필요
- [ ] 프론트엔드에서 기존 `name` 필드 사용 코드가 남아있다면 `maskedName`으로 전환 확인 필요