### PR TITLE
feat(chat): 챗봇 파일 분석 기능 구현 (file_url) + 도메인 권한 검증

### DIFF
--- a/docs/AI_CHAT_BOT_API_v1.1.md
+++ b/docs/AI_CHAT_BOT_API_v1.1.md
@@ -1,0 +1,144 @@
+# 챗봇(v1.1) - 0205
+
+# **📘 HD HHI AI Advisor - API 명세서 (v1.1)**
+
+## 1. 기본 정보
+
+- **Base URL**: `http://127.0.0.1:8001` (로컬 기준)
+- **Content-Type**: `application/json`
+- **Auth**: Admin API는 `X-API-KEY` 헤더 필요
+
+---
+
+## 2. 데이터 스키마 (Data Schemas)
+
+### 🟢 요청 객체: `ChatRequest`
+
+채팅 API 호출 시 전송하는 JSON 데이터 구조입니다.
+
+| 필드명 | 타입 | 필수 | 기본값 | 설명 |
+| --- | --- | --- | --- | --- |
+| `message` | `string` | **Yes** | - | 사용자의 질문 내용 |
+| `file_url` | `string` | No | `null` | **[New]** 분석할 파일의 S3 URL (Presigned URL).입력 시 해당 문서를 다운로드하여 답변 생성에 참고합니다. |
+| `history` | `list[dict]` | No | `[]` | 이전 대화 기록 (멀티턴 문맥 파악용)예: `[{"role": "user", "content": "..."}]` |
+| `domain` | `string` | No | `"all"` | 검색 영역 필터 (`safety`, `compliance`, `esg`, `all`) |
+| `doc_name` | `string` | No | `null` | Vector DB에 저장된 특정 문서 내 검색 시 파일명(예: `"하도급법_가이드.pdf"`) |
+| `top_k` | `integer` | No | `8` | 검색할 문서 개수 (1~30) |
+| `session_id` | `string` | No | `null` | 세션 식별자 (로그 분석용) |
+
+### 🔵 응답 객체: `ChatResponse`
+
+채팅 API의 응답 JSON 데이터 구조입니다.
+
+| 필드명 | 타입 | 설명 |
+| --- | --- | --- |
+| `answer` | `string` | AI가 생성한 최종 답변 |
+| `confidence` | `string` | 답변 신뢰도 (`high`, `medium`, `low`) |
+| `notes` | `string` | 비고 (예: "근거 자료 없음") |
+| `sources` | `list[SourceItem]` | 답변에 사용된 근거 자료 목록 |
+
+### 🟠 근거 자료 객체: `SourceItem`
+
+`ChatResponse.sources` 리스트 안에 들어가는 객체입니다.
+
+| 필드명 | 타입 | 설명 |
+| --- | --- | --- |
+| `title` | `string` | 문서 제목 또는 파일명 |
+| `type` | `string` | 자료 유형 (`manual`, `code`, `law`) |
+| `snippet` | `string` | 실제 참고한 본문 내용 (일부) |
+| `score` | `float` | 검색 유사도 점수 (0.0 ~ 1.0) |
+| `loc` | `object` | 위치 정보 (`page`: 페이지 번호, `line_start`: 시작 줄 등) |
+
+---
+
+## 3. API 엔드포인트 (Endpoints)
+
+### 💬 1. 채팅 (RAG + File Analysis)
+
+사용자의 질문을 받아 답변을 생성합니다. `file_url`이 제공되면 해당 문서를 우선적으로 분석합니다.
+
+- **URL**: `/api/chat`
+- **Method**: `POST`
+- **Auth**: 없음
+
+**Request Example (기본 채팅):**
+
+```json
+{
+  "message": "하도급법 위반 시 벌점은?",
+  "domain": "compliance",
+  "history": [
+    {"role": "user", "content": "하도급법이 뭐야?"},
+    {"role": "assistant", "content": "하도급 거래 공정화에 관한 법률입니다..."}
+  ]
+}
+```
+
+**Request Example (파일 분석 채팅):**
+
+```json
+{
+  "message": "이 문서의 핵심 내용을 요약해줘",
+  "file_url": "https://s3.ap-northeast-2.amazonaws.com/my-bucket/sample_contract.pdf?X-Amz-Algorithm=...",
+  "domain": "all"
+}
+```
+
+**Response Example:**
+
+```json
+{
+  "answer": "문서 내용에 따르면, 하도급법 위반 시 벌점은 최대 5점까지 부과될 수 있습니다. [manual:하도급가이드.pdf p.15]",
+  "confidence": "high",
+  "sources": [
+    {
+      "title": "하도급가이드.pdf",
+      "type": "manual",
+      "score": 0.89,
+      "loc": {"page": 15},
+      "snippet": "벌점 부과 기준은 다음과 같다..."
+    }
+  ]
+}
+```
+
+---
+
+### ⚙️ 2. 데이터 동기화 (Admin)
+
+PDF 파일과 소스 코드를 파싱하여 Vector DB에 적재합니다. (비동기 실행)
+
+- **URL**: `/api/admin/sync`
+- **Method**: `POST`
+- **Headers**: `X-API-KEY: {ADMIN_KEY}`
+
+**Response Example:**
+
+```json
+{
+  "status": "accepted",
+  "message": "동기화 작업이 백그라운드에서 시작되었습니다. 완료될 때까지 터미널 로그를 확인해주세요."
+}
+```
+
+---
+
+### 🔍 3. DB 현황 조회 (Admin)
+
+현재 Vector DB에 저장된 문서 개수와 샘플 데이터를 확인합니다.
+
+- **URL**: `/api/admin/inspect`
+- **Method**: `GET`
+- **Headers**: `X-API-KEY: {ADMIN_KEY}`
+
+**Response Example:**
+
+```json
+{
+  "total_documents": 1542,
+  "samples": [
+    "[manual] 안전작업표준.pdf (ID: manual:안전작업표준.pdf:p1:c0...)",
+    "[code] validators.py (ID: code:validators.py:L10-L50...)"
+  ]
+}
+```

--- a/src/main/java/com/smartchain/platform/domain/chat/service/ChatService.java
+++ b/src/main/java/com/smartchain/platform/domain/chat/service/ChatService.java
@@ -1,18 +1,24 @@
 package com.smartchain.platform.domain.chat.service;
 
 import com.smartchain.platform.domain.chat.client.AiChatApiClient;
+import com.smartchain.platform.domain.evidence.entity.EvidenceFile;
+import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository;
+import com.smartchain.platform.domain.file.storage.FileStorageService;
 import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.dto.chat.AdminInspectResponse;
 import com.smartchain.platform.dto.chat.AdminSyncResponse;
-import com.smartchain.platform.dto.chat.ChatMessage;
 import com.smartchain.platform.dto.chat.ChatRequest;
 import com.smartchain.platform.dto.chat.ChatResponse;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import com.smartchain.platform.domain.user.entity.Domain;
+
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -25,11 +31,23 @@ public class ChatService {
 
     private static final Logger log = LoggerFactory.getLogger(ChatService.class);
     private static final Set<String> VALID_DOMAINS = Set.of("safety", "compliance", "esg", "all");
+    private static final Duration FILE_URL_EXPIRY = Duration.ofMinutes(30);
 
     private final AiChatApiClient aiChatApiClient;
+    private final EvidenceFileRepository evidenceFileRepository;
+    private final FileStorageService fileStorageService;
 
-    public ChatService(AiChatApiClient aiChatApiClient) {
+    @Value("${server.port:8080}")
+    private int serverPort;
+
+    public ChatService(
+        AiChatApiClient aiChatApiClient,
+        EvidenceFileRepository evidenceFileRepository,
+        FileStorageService fileStorageService
+    ) {
         this.aiChatApiClient = aiChatApiClient;
+        this.evidenceFileRepository = evidenceFileRepository;
+        this.fileStorageService = fileStorageService;
     }
 
     /**
@@ -39,10 +57,14 @@ public class ChatService {
      * @return 채팅 응답
      */
     public ChatResponse chat(ChatRequest request, User user) {
-        log.info("채팅 요청 - userId: {}, domain: {}", user.getUserId(), request.domain());
+        log.info("채팅 요청 - userId: {}, domain: {}, fileId: {}",
+            user.getUserId(), request.domain(), request.fileId());
 
         // 도메인 유효성 검증
         validateDomain(request.domain());
+
+        // fileId → presigned URL 변환
+        String fileUrl = resolveFileUrl(request.fileId(), user);
 
         // sessionId가 없으면 생성
         String sessionId = request.sessionId();
@@ -51,9 +73,11 @@ public class ChatService {
             log.debug("새 세션 ID 생성: {}", sessionId);
         }
 
-        // 요청 재구성 (sessionId 포함)
+        // 요청 재구성 (fileUrl, sessionId 포함)
         ChatRequest enrichedRequest = new ChatRequest(
             request.message(),
+            null,
+            fileUrl,
             request.history() != null ? request.history() : List.of(),
             request.domain(),
             request.docName(),
@@ -91,6 +115,42 @@ public class ChatService {
     }
 
     /**
+     * fileId로 EvidenceFile 조회 후 presigned URL 생성
+     * @return presigned URL 또는 null (fileId가 없는 경우)
+     */
+    private String resolveFileUrl(Long fileId, User user) {
+        if (fileId == null) {
+            return null;
+        }
+
+        EvidenceFile evidenceFile = evidenceFileRepository.findById(fileId)
+            .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
+
+        // 파일 소속 회사와 사용자 회사 일치 확인
+        if (evidenceFile.getDiagnostic() != null
+                && evidenceFile.getDiagnostic().getCompany() != null
+                && user.getCompany() != null) {
+            Long fileCompanyId = evidenceFile.getDiagnostic().getCompany().getCompanyId();
+            Long userCompanyId = user.getCompany().getCompanyId();
+            if (!fileCompanyId.equals(userCompanyId)) {
+                log.warn("파일 접근 권한 없음 - userId: {}, fileId: {}, fileCompanyId: {}, userCompanyId: {}",
+                    user.getUserId(), fileId, fileCompanyId, userCompanyId);
+                throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);
+            }
+        }
+
+        String presignedUrl = fileStorageService.getPresignedUrl(evidenceFile.getFilePath(), FILE_URL_EXPIRY);
+
+        // 로컬 환경: 상대 경로를 절대 URL로 변환 (Python이 다운로드 가능하도록)
+        if (presignedUrl.startsWith("/")) {
+            presignedUrl = "http://localhost:" + serverPort + presignedUrl;
+        }
+
+        log.debug("파일 URL 생성 - fileId: {}, fileName: {}", fileId, evidenceFile.getOriginalFileName());
+        return presignedUrl;
+    }
+
+    /**
      * 도메인 유효성 검증
      */
     private void validateDomain(String domain) {
@@ -105,8 +165,14 @@ public class ChatService {
      * 어느 도메인이든 REVIEWER 역할이 있으면 Admin API 접근 가능
      */
     private void validateReviewerRole(User user) {
-        String userRoleCode = user.getRole() != null ? user.getRole().getCode() : "GUEST";
+        // 도메인 기반: 어떤 도메인이든 REVIEWER 역할이 있으면 허용
+        List<Domain> reviewerDomains = user.getDomainsWithRole("REVIEWER");
+        if (reviewerDomains != null && !reviewerDomains.isEmpty()) {
+            return;
+        }
 
+        // 전역 역할 fallback (레거시)
+        String userRoleCode = user.getRole() != null ? user.getRole().getCode() : "GUEST";
         if (!"REVIEWER".equals(userRoleCode)) {
             log.warn("Admin API 접근 권한 없음 - userId: {}, role: {}", user.getUserId(), userRoleCode);
             throw new CustomException(ErrorCode.PERMISSION_DENIED_ACTION);

--- a/src/main/java/com/smartchain/platform/dto/chat/ChatRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/chat/ChatRequest.java
@@ -9,10 +9,17 @@ import java.util.List;
 
 /**
  * AI Chat API 요청 DTO
+ * FE → BE: fileId로 파일 지정, BE → Python: fileUrl(presigned URL)로 변환하여 전달
  */
 public record ChatRequest(
     @NotBlank(message = "메시지는 필수입니다")
     String message,
+
+    @JsonProperty("file_id")
+    Long fileId,
+
+    @JsonProperty("file_url")
+    String fileUrl,
 
     List<ChatMessage> history,
 

--- a/src/test/java/com/smartchain/platform/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/chat/service/ChatServiceTest.java
@@ -1,6 +1,11 @@
 package com.smartchain.platform.domain.chat.service;
 
 import com.smartchain.platform.domain.chat.client.AiChatApiClient;
+import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.domain.evidence.entity.EvidenceFile;
+import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository;
+import com.smartchain.platform.domain.file.storage.FileStorageService;
+import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Role;
 import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.dto.chat.AdminInspectResponse;
@@ -20,11 +25,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,11 +41,18 @@ class ChatServiceTest {
     @Mock
     private AiChatApiClient aiChatApiClient;
 
+    @Mock
+    private EvidenceFileRepository evidenceFileRepository;
+
+    @Mock
+    private FileStorageService fileStorageService;
+
     private ChatService chatService;
 
     @BeforeEach
     void setUp() {
-        chatService = new ChatService(aiChatApiClient);
+        chatService = new ChatService(aiChatApiClient, evidenceFileRepository, fileStorageService);
+        ReflectionTestUtils.setField(chatService, "serverPort", 8080);
     }
 
     @Nested
@@ -51,11 +66,10 @@ class ChatServiceTest {
             User user = createTestUser("DRAFTER");
             ChatRequest request = new ChatRequest(
                 "하도급법 위반 시 벌점은?",
+                null, null,
                 List.of(),
                 "compliance",
-                null,
-                8,
-                null
+                null, 8, null
             );
 
             ChatResponse expectedResponse = new ChatResponse(
@@ -89,11 +103,10 @@ class ChatServiceTest {
             String existingSessionId = "existing-session-123";
             ChatRequest request = new ChatRequest(
                 "추가 질문입니다",
+                null, null,
                 List.of(),
                 "esg",
-                null,
-                8,
-                existingSessionId
+                null, 8, existingSessionId
             );
 
             ChatResponse expectedResponse = new ChatResponse("답변입니다.", "medium", null, List.of());
@@ -115,11 +128,10 @@ class ChatServiceTest {
             User user = createTestUser("DRAFTER");
             ChatRequest request = new ChatRequest(
                 "질문입니다",
+                null, null,
                 List.of(),
                 "invalid_domain",
-                null,
-                8,
-                null
+                null, 8, null
             );
 
             // when & then
@@ -140,11 +152,10 @@ class ChatServiceTest {
             User user = createTestUser("DRAFTER");
             ChatRequest request = new ChatRequest(
                 "질문입니다",
+                null, null,
                 List.of(),
                 "all",
-                null,
-                8,
-                null
+                null, 8, null
             );
 
             when(aiChatApiClient.chatSync(any(ChatRequest.class)))
@@ -157,6 +168,173 @@ class ChatServiceTest {
                     CustomException customEx = (CustomException) ex;
                     assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.AI_CHAT_SERVICE_ERROR);
                 });
+        }
+    }
+
+    @Nested
+    @DisplayName("chat - fileId")
+    class ChatFileTest {
+
+        @Test
+        @DisplayName("fileId가 있으면 presigned URL로 변환하여 Python에 전달한다")
+        void chat_withFileId_resolvesFileUrl() {
+            // given
+            Company company = createTestCompany(1L);
+            User user = createTestUserWithCompany("DRAFTER", company);
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getCompany()).thenReturn(company);
+
+            EvidenceFile evidenceFile = mock(EvidenceFile.class);
+            when(evidenceFile.getFilePath()).thenReturn("diagnostics/1/abc_report.pdf");
+            when(evidenceFile.getOriginalFileName()).thenReturn("report.pdf");
+            when(evidenceFile.getDiagnostic()).thenReturn(diagnostic);
+
+            when(evidenceFileRepository.findById(42L)).thenReturn(Optional.of(evidenceFile));
+            when(fileStorageService.getPresignedUrl(eq("diagnostics/1/abc_report.pdf"), any(Duration.class)))
+                .thenReturn("https://account.blob.core.windows.net/container/diagnostics/1/abc_report.pdf?sv=...");
+
+            ChatRequest request = new ChatRequest(
+                "이 문서를 요약해줘",
+                42L, null,
+                List.of(), "esg", null, 8, null
+            );
+
+            ChatResponse expectedResponse = new ChatResponse("문서 요약입니다.", "high", null, List.of());
+            when(aiChatApiClient.chatSync(any(ChatRequest.class))).thenReturn(expectedResponse);
+
+            // when
+            ChatResponse response = chatService.chat(request, user);
+
+            // then
+            assertThat(response).isNotNull();
+
+            ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+            verify(aiChatApiClient).chatSync(requestCaptor.capture());
+            ChatRequest sentRequest = requestCaptor.getValue();
+            assertThat(sentRequest.fileUrl()).startsWith("https://");
+            assertThat(sentRequest.fileId()).isNull(); // Python에 보내는 요청에는 fileId 제거
+        }
+
+        @Test
+        @DisplayName("로컬 환경에서는 상대 경로를 절대 URL로 변환한다")
+        void chat_withFileId_localEnv_convertsToAbsoluteUrl() {
+            // given
+            Company company = createTestCompany(1L);
+            User user = createTestUserWithCompany("DRAFTER", company);
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getCompany()).thenReturn(company);
+
+            EvidenceFile evidenceFile = mock(EvidenceFile.class);
+            when(evidenceFile.getFilePath()).thenReturn("diagnostics/1/abc_report.pdf");
+            when(evidenceFile.getOriginalFileName()).thenReturn("report.pdf");
+            when(evidenceFile.getDiagnostic()).thenReturn(diagnostic);
+
+            when(evidenceFileRepository.findById(10L)).thenReturn(Optional.of(evidenceFile));
+            when(fileStorageService.getPresignedUrl(eq("diagnostics/1/abc_report.pdf"), any(Duration.class)))
+                .thenReturn("/api/v1/files/local/diagnostics/1/abc_report.pdf");
+
+            ChatRequest request = new ChatRequest(
+                "이 문서를 분석해줘",
+                10L, null,
+                List.of(), "esg", null, 8, null
+            );
+
+            ChatResponse expectedResponse = new ChatResponse("분석 결과입니다.", "medium", null, List.of());
+            when(aiChatApiClient.chatSync(any(ChatRequest.class))).thenReturn(expectedResponse);
+
+            // when
+            chatService.chat(request, user);
+
+            // then
+            ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+            verify(aiChatApiClient).chatSync(requestCaptor.capture());
+            assertThat(requestCaptor.getValue().fileUrl())
+                .isEqualTo("http://localhost:8080/api/v1/files/local/diagnostics/1/abc_report.pdf");
+        }
+
+        @Test
+        @DisplayName("fileId가 null이면 fileUrl 없이 정상 동작한다")
+        void chat_withoutFileId_worksNormally() {
+            // given
+            User user = createTestUser("DRAFTER");
+            ChatRequest request = new ChatRequest(
+                "일반 질문입니다",
+                null, null,
+                List.of(), "all", null, 8, null
+            );
+
+            ChatResponse expectedResponse = new ChatResponse("답변입니다.", "high", null, List.of());
+            when(aiChatApiClient.chatSync(any(ChatRequest.class))).thenReturn(expectedResponse);
+
+            // when
+            ChatResponse response = chatService.chat(request, user);
+
+            // then
+            assertThat(response).isNotNull();
+            verify(evidenceFileRepository, never()).findById(any());
+
+            ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
+            verify(aiChatApiClient).chatSync(requestCaptor.capture());
+            assertThat(requestCaptor.getValue().fileUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 fileId면 FILE_NOT_FOUND 에러를 발생시킨다")
+        void chat_fileNotFound_throwsException() {
+            // given
+            User user = createTestUser("DRAFTER");
+            ChatRequest request = new ChatRequest(
+                "이 문서를 분석해줘",
+                999L, null,
+                List.of(), "esg", null, 8, null
+            );
+
+            when(evidenceFileRepository.findById(999L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> chatService.chat(request, user))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.FILE_NOT_FOUND);
+                });
+
+            verify(aiChatApiClient, never()).chatSync(any());
+        }
+
+        @Test
+        @DisplayName("다른 회사의 파일에 접근하면 PERMISSION_DENIED_ACTION 에러를 발생시킨다")
+        void chat_differentCompany_throwsException() {
+            // given
+            Company userCompany = createTestCompany(1L);
+            Company fileCompany = createTestCompany(2L);
+            User user = createTestUserWithCompany("DRAFTER", userCompany);
+
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getCompany()).thenReturn(fileCompany);
+
+            EvidenceFile evidenceFile = mock(EvidenceFile.class);
+            when(evidenceFile.getDiagnostic()).thenReturn(diagnostic);
+
+            when(evidenceFileRepository.findById(42L)).thenReturn(Optional.of(evidenceFile));
+
+            ChatRequest request = new ChatRequest(
+                "이 문서를 분석해줘",
+                42L, null,
+                List.of(), "esg", null, 8, null
+            );
+
+            // when & then
+            assertThatThrownBy(() -> chatService.chat(request, user))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.PERMISSION_DENIED_ACTION);
+                });
+
+            verify(aiChatApiClient, never()).chatSync(any());
         }
     }
 
@@ -274,5 +452,29 @@ class ChatServiceTest {
         ReflectionTestUtils.setField(user, "userId", 1L);
 
         return user;
+    }
+
+    private User createTestUserWithCompany(String roleCode, Company company) {
+        Role role = new Role(roleCode + " 역할", roleCode);
+
+        User user = User.builder()
+            .email("test@example.com")
+            .userPassword("password")
+            .name("테스트 사용자")
+            .role(role)
+            .company(company)
+            .build();
+        ReflectionTestUtils.setField(user, "userId", 1L);
+
+        return user;
+    }
+
+    private Company createTestCompany(Long companyId) {
+        Company company = Company.builder()
+            .name("테스트 회사 " + companyId)
+            .businessNumber("123-45-6789" + companyId)
+            .build();
+        ReflectionTestUtils.setField(company, "companyId", companyId);
+        return company;
     }
 }


### PR DESCRIPTION
## 변경 요약
- `ChatRequest` DTO에 `fileId`(FE→BE), `fileUrl`(BE→Python) 필드 추가
- `ChatService`에서 `fileId` → presigned URL 변환 로직 구현
  - 로컬: `http://localhost:8080/api/v1/files/local/...` 절대 URL 변환
  - Azure: SAS URL 그대로 전달
- 파일 접근 권한 검증: 사용자 회사와 파일 소속 회사 일치 확인
- Admin API(`sync`, `inspect`) 도메인 기반 권한 검증 적용 (전역 역할 fallback 유지)
- AI 챗봇 API v1.1 명세서 추가 (`docs/AI_CHAT_BOT_API_v1.1.md`)

## 관련 이슈
- Closes #186 - ChatRequest에 fileId 필드 추가 및 file_url 변환 로직 구현
- Closes #187 - Admin API 도메인 기반 권한 검증 적용
- Closes #188 - file_url 관련 테스트 케이스 추가

## 테스트 방법
```bash
./gradlew test --tests "ChatServiceTest"
```
- 기존 9개 + 신규 5개 = **총 14개 테스트 통과**
- 전체 테스트(`./gradlew test`)도 통과 확인

## 명세 준수 체크 (v1.1 기준)
- [x] `file_url` 파라미터 지원 (Python에 presigned URL 전달)
- [x] `file_url` 미전달 시 기존 RAG 채팅 정상 동작
- [x] 기존 필드(`message`, `history`, `domain`, `doc_name`, `top_k`, `session_id`) 호환 유지
- [x] Admin API 인증(`X-API-KEY`) 기존 동작 유지

## 리뷰 포인트
1. **FE 인터페이스**: FE는 `file_id`(Long)만 보내면 됨 — presigned URL 생성은 BE 담당
2. **권한 검증**: 파일 소속 회사 ≠ 사용자 회사 → `PERMISSION_DENIED_ACTION`
3. **로컬 URL 변환**: `getPresignedUrl()`이 상대경로 반환 시 `http://localhost:{port}` prefix 추가

## TODO / 질문
- [ ] Python 챗봇 서비스에서 Azure SAS URL 다운로드 지원 여부 확인 필요 (현재 S3 기준 명세)
- [ ] 로컬 환경에서 Python이 `http://localhost:8080/api/v1/files/local/...` 엔드포인트로 파일 다운로드 가능한지 확인 필요
- [ ] REVIEWER가 아닌 사용자도 자기 회사 파일만 챗봇 분석 가능 — 이 정책이 맞는지 확인