### PR TITLE
fix(chat): Chat API 500/403 오류 수정 및 로컬 파일 다운로드 구현

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/smartchain/platform/domain/chat/controller/ChatController.java
@@ -1,21 +1,22 @@
 package com.smartchain.platform.domain.chat.controller;
 
 import com.smartchain.platform.domain.chat.service.ChatService;
-import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.dto.chat.AdminInspectResponse;
 import com.smartchain.platform.dto.chat.AdminSyncResponse;
 import com.smartchain.platform.dto.chat.ChatRequest;
 import com.smartchain.platform.dto.chat.ChatResponse;
 import com.smartchain.platform.global.response.BaseResponse;
+import com.smartchain.platform.global.security.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,9 +34,11 @@ public class ChatController {
     private static final Logger log = LoggerFactory.getLogger(ChatController.class);
 
     private final ChatService chatService;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public ChatController(ChatService chatService) {
+    public ChatController(ChatService chatService, JwtTokenProvider jwtTokenProvider) {
         this.chatService = chatService;
+        this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @Operation(summary = "AI 채팅", description = "RAG 기반 AI 챗봇과 대화합니다.")
@@ -49,11 +52,12 @@ public class ChatController {
     @PostMapping("/chat")
     public ResponseEntity<BaseResponse<ChatResponse>> chat(
         @Valid @RequestBody ChatRequest request,
-        @AuthenticationPrincipal User user
+        HttpServletRequest httpRequest
     ) {
-        log.info("채팅 API 호출 - userId: {}", user.getUserId());
+        Long userId = extractUserIdFromRequest(httpRequest);
+        log.info("채팅 API 호출 - userId: {}", userId);
 
-        ChatResponse response = chatService.chat(request, user);
+        ChatResponse response = chatService.chat(request, userId);
 
         return ResponseEntity.ok(BaseResponse.success("채팅 완료", response));
     }
@@ -66,11 +70,12 @@ public class ChatController {
     })
     @PostMapping("/admin/chat/sync")
     public ResponseEntity<BaseResponse<AdminSyncResponse>> syncData(
-        @AuthenticationPrincipal User user
+        HttpServletRequest httpRequest
     ) {
-        log.info("Admin 동기화 API 호출 - userId: {}", user.getUserId());
+        Long userId = extractUserIdFromRequest(httpRequest);
+        log.info("Admin 동기화 API 호출 - userId: {}", userId);
 
-        AdminSyncResponse response = chatService.syncData(user);
+        AdminSyncResponse response = chatService.syncData(userId);
 
         return ResponseEntity.ok(BaseResponse.success("동기화 요청이 접수되었습니다", response));
     }
@@ -83,12 +88,22 @@ public class ChatController {
     })
     @GetMapping("/admin/chat/inspect")
     public ResponseEntity<BaseResponse<AdminInspectResponse>> inspectDb(
-        @AuthenticationPrincipal User user
+        HttpServletRequest httpRequest
     ) {
-        log.info("Admin DB 현황 조회 API 호출 - userId: {}", user.getUserId());
+        Long userId = extractUserIdFromRequest(httpRequest);
+        log.info("Admin DB 현황 조회 API 호출 - userId: {}", userId);
 
-        AdminInspectResponse response = chatService.getDbStatus(user);
+        AdminInspectResponse response = chatService.getDbStatus(userId);
 
         return ResponseEntity.ok(BaseResponse.success("DB 현황 조회 완료", response));
+    }
+
+    private Long extractUserIdFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7);
+            return jwtTokenProvider.getUserIdFromToken(token);
+        }
+        throw new IllegalArgumentException("Authorization header is missing or invalid");
     }
 }

--- a/src/main/java/com/smartchain/platform/domain/chat/service/ChatService.java
+++ b/src/main/java/com/smartchain/platform/domain/chat/service/ChatService.java
@@ -4,7 +4,9 @@ import com.smartchain.platform.domain.chat.client.AiChatApiClient;
 import com.smartchain.platform.domain.evidence.entity.EvidenceFile;
 import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository;
 import com.smartchain.platform.domain.file.storage.FileStorageService;
+import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.domain.user.entity.User;
+import com.smartchain.platform.domain.user.repository.UserRepository;
 import com.smartchain.platform.dto.chat.AdminInspectResponse;
 import com.smartchain.platform.dto.chat.AdminSyncResponse;
 import com.smartchain.platform.dto.chat.ChatRequest;
@@ -15,9 +17,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.smartchain.platform.domain.user.entity.Domain;
-
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
@@ -27,6 +29,7 @@ import java.util.UUID;
  * AI Chatbot 서비스
  */
 @Service
+@Transactional(readOnly = true)
 public class ChatService {
 
     private static final Logger log = LoggerFactory.getLogger(ChatService.class);
@@ -36,29 +39,33 @@ public class ChatService {
     private final AiChatApiClient aiChatApiClient;
     private final EvidenceFileRepository evidenceFileRepository;
     private final FileStorageService fileStorageService;
+    private final UserRepository userRepository;
 
-    @Value("${server.port:8080}")
-    private int serverPort;
+    @Value("${file.storage.local.base-path:./uploads}")
+    private String fileBasePath;
 
     public ChatService(
         AiChatApiClient aiChatApiClient,
         EvidenceFileRepository evidenceFileRepository,
-        FileStorageService fileStorageService
+        FileStorageService fileStorageService,
+        UserRepository userRepository
     ) {
         this.aiChatApiClient = aiChatApiClient;
         this.evidenceFileRepository = evidenceFileRepository;
         this.fileStorageService = fileStorageService;
+        this.userRepository = userRepository;
     }
 
     /**
      * 채팅 처리
      * @param request 채팅 요청
-     * @param user 현재 사용자
+     * @param userId 현재 사용자 ID
      * @return 채팅 응답
      */
-    public ChatResponse chat(ChatRequest request, User user) {
+    public ChatResponse chat(ChatRequest request, Long userId) {
+        User user = validateUser(userId);
         log.info("채팅 요청 - userId: {}, domain: {}, fileId: {}",
-            user.getUserId(), request.domain(), request.fileId());
+            userId, request.domain(), request.fileId());
 
         // 도메인 유효성 검증
         validateDomain(request.domain());
@@ -90,11 +97,12 @@ public class ChatService {
 
     /**
      * Admin 데이터 동기화
-     * @param user 현재 사용자 (REVIEWER 권한 필요)
+     * @param userId 현재 사용자 ID (REVIEWER 권한 필요)
      * @return 동기화 응답
      */
-    public AdminSyncResponse syncData(User user) {
-        log.info("Admin 동기화 요청 - userId: {}", user.getUserId());
+    public AdminSyncResponse syncData(Long userId) {
+        User user = validateUser(userId);
+        log.info("Admin 동기화 요청 - userId: {}", userId);
 
         validateReviewerRole(user);
 
@@ -103,11 +111,12 @@ public class ChatService {
 
     /**
      * Admin DB 현황 조회
-     * @param user 현재 사용자 (REVIEWER 권한 필요)
+     * @param userId 현재 사용자 ID (REVIEWER 권한 필요)
      * @return DB 현황 응답
      */
-    public AdminInspectResponse getDbStatus(User user) {
-        log.info("Admin DB 현황 조회 - userId: {}", user.getUserId());
+    public AdminInspectResponse getDbStatus(Long userId) {
+        User user = validateUser(userId);
+        log.info("Admin DB 현황 조회 - userId: {}", userId);
 
         validateReviewerRole(user);
 
@@ -115,8 +124,17 @@ public class ChatService {
     }
 
     /**
-     * fileId로 EvidenceFile 조회 후 presigned URL 생성
-     * @return presigned URL 또는 null (fileId가 없는 경우)
+     * 사용자 검증
+     */
+    private User validateUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * fileId로 EvidenceFile 조회 후 파일 경로/URL 생성
+     * AiAnalysisService.submit()과 동일한 방식: 로컬=절대경로, Azure=SAS URL
+     * @return 파일 절대경로 또는 presigned URL, null (fileId가 없는 경우)
      */
     private String resolveFileUrl(Long fileId, User user) {
         if (fileId == null) {
@@ -126,8 +144,13 @@ public class ChatService {
         EvidenceFile evidenceFile = evidenceFileRepository.findById(fileId)
             .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
 
-        // 파일 소속 회사와 사용자 회사 일치 확인
-        if (evidenceFile.getDiagnostic() != null
+        // 파일 소속 회사와 사용자 회사 일치 확인 (REVIEWER는 원청 담당자로 모든 협력사 파일 접근 가능)
+        List<Domain> reviewerDomains = user.getDomainsWithRole("REVIEWER");
+        boolean isReviewer = (reviewerDomains != null && !reviewerDomains.isEmpty())
+                || (user.getRole() != null && "REVIEWER".equals(user.getRole().getCode()));
+
+        if (!isReviewer
+                && evidenceFile.getDiagnostic() != null
                 && evidenceFile.getDiagnostic().getCompany() != null
                 && user.getCompany() != null) {
             Long fileCompanyId = evidenceFile.getDiagnostic().getCompany().getCompanyId();
@@ -139,15 +162,19 @@ public class ChatService {
             }
         }
 
-        String presignedUrl = fileStorageService.getPresignedUrl(evidenceFile.getFilePath(), FILE_URL_EXPIRY);
+        String filePath = evidenceFile.getFilePath();
 
-        // 로컬 환경: 상대 경로를 절대 URL로 변환 (Python이 다운로드 가능하도록)
-        if (presignedUrl.startsWith("/")) {
-            presignedUrl = "http://localhost:" + serverPort + presignedUrl;
+        // Azure: filePath가 URL이면 presigned URL 생성
+        if (filePath.startsWith("http")) {
+            String fileUrl = fileStorageService.getPresignedUrl(filePath, FILE_URL_EXPIRY);
+            log.debug("파일 URL 생성 (Azure) - fileId: {}, fileName: {}", fileId, evidenceFile.getOriginalFileName());
+            return fileUrl;
         }
 
-        log.debug("파일 URL 생성 - fileId: {}, fileName: {}", fileId, evidenceFile.getOriginalFileName());
-        return presignedUrl;
+        // 로컬: 절대 경로로 변환 (AiAnalysisService.submit()과 동일 방식)
+        String absolutePath = Paths.get(fileBasePath, filePath).toAbsolutePath().toString();
+        log.debug("파일 절대경로 생성 (로컬) - fileId: {}, path: {}", fileId, absolutePath);
+        return absolutePath;
     }
 
     /**

--- a/src/main/java/com/smartchain/platform/domain/file/controller/FileController.java
+++ b/src/main/java/com/smartchain/platform/domain/file/controller/FileController.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -73,6 +75,27 @@ public class FileController {
         Long userId = extractUserIdFromRequest(request);
         FileDownloadUrlResponse response = fileService.getDownloadUrl(userId, fileId);
         return ResponseEntity.ok(BaseResponse.success(response));
+    }
+
+    @Operation(summary = "파일 직접 다운로드", description = "파일을 직접 다운로드합니다. local 환경에서 사용됩니다.")
+    @GetMapping("/api/v1/files/{fileId}/download")
+    public ResponseEntity<InputStreamResource> downloadFile(
+            HttpServletRequest request,
+            @Parameter(description = "파일 ID")
+            @PathVariable Long fileId) {
+        Long userId = extractUserIdFromRequest(request);
+        FileService.FileDownloadData data = fileService.downloadFile(userId, fileId);
+
+        String contentDisposition = "attachment; filename=\"" + data.fileName() + "\"";
+        MediaType mediaType = data.mimeType() != null
+                ? MediaType.parseMediaType(data.mimeType())
+                : MediaType.APPLICATION_OCTET_STREAM;
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
+                .contentType(mediaType)
+                .contentLength(data.fileSize())
+                .body(new InputStreamResource(data.inputStream()));
     }
 
     @Operation(summary = "파일 삭제", description = "파일을 삭제합니다. 제출된 진단의 파일은 삭제할 수 없습니다.")

--- a/src/main/java/com/smartchain/platform/domain/file/service/FileService.java
+++ b/src/main/java/com/smartchain/platform/domain/file/service/FileService.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.InputStream;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -204,6 +205,11 @@ public class FileService {
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(30);
         String signedUrl = fileStorageService.getPresignedUrl(evidenceFile.getFilePath(), Duration.ofMinutes(30));
 
+        // local 환경: 상대 경로 반환 시 직접 다운로드 엔드포인트로 교체
+        if (signedUrl.startsWith("/")) {
+            signedUrl = "/api/v1/files/" + fileId + "/download";
+        }
+
         log.info("Download URL generated: fileId={}, requestedBy={}, expiresAt={}",
                 fileId, userId, expiresAt);
 
@@ -214,6 +220,34 @@ public class FileService {
                 .expiresAt(expiresAt)
                 .build();
     }
+
+    /**
+     * 파일 직접 다운로드 (local 환경용)
+     */
+    public FileDownloadData downloadFile(Long userId, Long fileId) {
+        validateUser(userId);
+
+        EvidenceFile evidenceFile = evidenceFileRepository.findById(fileId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
+
+        InputStream inputStream = fileStorageService.download(evidenceFile.getFilePath());
+
+        log.info("File download: fileId={}, requestedBy={}", fileId, userId);
+
+        return new FileDownloadData(
+                inputStream,
+                evidenceFile.getOriginalFileName(),
+                evidenceFile.getMimeType(),
+                evidenceFile.getFileSize()
+        );
+    }
+
+    public record FileDownloadData(
+            InputStream inputStream,
+            String fileName,
+            String mimeType,
+            Long fileSize
+    ) {}
 
     /**
      * 파일 삭제

--- a/src/test/java/com/smartchain/platform/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/chat/service/ChatServiceTest.java
@@ -8,6 +8,7 @@ import com.smartchain.platform.domain.file.storage.FileStorageService;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Role;
 import com.smartchain.platform.domain.user.entity.User;
+import com.smartchain.platform.domain.user.repository.UserRepository;
 import com.smartchain.platform.dto.chat.AdminInspectResponse;
 import com.smartchain.platform.dto.chat.AdminSyncResponse;
 import com.smartchain.platform.dto.chat.ChatRequest;
@@ -47,12 +48,15 @@ class ChatServiceTest {
     @Mock
     private FileStorageService fileStorageService;
 
+    @Mock
+    private UserRepository userRepository;
+
     private ChatService chatService;
 
     @BeforeEach
     void setUp() {
-        chatService = new ChatService(aiChatApiClient, evidenceFileRepository, fileStorageService);
-        ReflectionTestUtils.setField(chatService, "serverPort", 8080);
+        chatService = new ChatService(aiChatApiClient, evidenceFileRepository, fileStorageService, userRepository);
+        ReflectionTestUtils.setField(chatService, "fileBasePath", "./uploads");
     }
 
     @Nested
@@ -63,7 +67,9 @@ class ChatServiceTest {
         @DisplayName("정상 채팅 요청 시 AI 응답을 반환한다")
         void chat_success_returnsResponse() {
             // given
-            User user = createTestUser("DRAFTER");
+            User user = createTestUser(1L, "DRAFTER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
             ChatRequest request = new ChatRequest(
                 "하도급법 위반 시 벌점은?",
                 null, null,
@@ -82,7 +88,7 @@ class ChatServiceTest {
             when(aiChatApiClient.chatSync(any(ChatRequest.class))).thenReturn(expectedResponse);
 
             // when
-            ChatResponse response = chatService.chat(request, user);
+            ChatResponse response = chatService.chat(request, 1L);
 
             // then
             assertThat(response).isNotNull();
@@ -99,7 +105,9 @@ class ChatServiceTest {
         @DisplayName("sessionId가 있으면 그대로 사용한다")
         void chat_withSessionId_usesExistingSessionId() {
             // given
-            User user = createTestUser("DRAFTER");
+            User user = createTestUser(1L, "DRAFTER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
             String existingSessionId = "existing-session-123";
             ChatRequest request = new ChatRequest(
                 "추가 질문입니다",
@@ -113,7 +121,7 @@ class ChatServiceTest {
             when(aiChatApiClient.chatSync(any(ChatRequest.class))).thenReturn(expectedResponse);
 
             // when
-            chatService.chat(request, user);
+            chatService.chat(request, 1L);
 
             // then
             ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
@@ -125,7 +133,9 @@ class ChatServiceTest {
         @DisplayName("유효하지 않은 도메인이면 AI_CHAT_INVALID_DOMAIN 에러를 발생시킨다")
         void chat_invalidDomain_throwsException() {
             // given
-            User user = createTestUser("DRAFTER");
+            User user = createTestUser(1L, "DRAFTER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
             ChatRequest request = new ChatRequest(
                 "질문입니다",
                 null, null,
@@ -135,7 +145,7 @@ class ChatServiceTest {
             );
 
             // when & then
-            assertThatThrownBy(() -> chatService.chat(request, user))
+            assertThatThrownBy(() -> chatService.chat(request, 1L))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -149,7 +159,9 @@ class ChatServiceTest {
         @DisplayName("AI 서비스 에러 시 예외가 전파된다")
         void chat_aiServiceError_propagatesException() {
             // given
-            User user = createTestUser("DRAFTER");
+            User user = createTestUser(1L, "DRAFTER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
             ChatRequest request = new ChatRequest(
                 "질문입니다",
                 null, null,
@@ -162,12 +174,37 @@ class ChatServiceTest {
                 .thenThrow(new CustomException(ErrorCode.AI_CHAT_SERVICE_ERROR));
 
             // when & then
-            assertThatThrownBy(() -> chatService.chat(request, user))
+            assertThatThrownBy(() -> chatService.chat(request, 1L))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
                     assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.AI_CHAT_SERVICE_ERROR);
                 });
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자면 USER_NOT_FOUND 에러를 발생시킨다")
+        void chat_userNotFound_throwsException() {
+            // given
+            when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+            ChatRequest request = new ChatRequest(
+                "질문입니다",
+                null, null,
+                List.of(),
+                "all",
+                null, 8, null
+            );
+
+            // when & then
+            assertThatThrownBy(() -> chatService.chat(request, 999L))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+                });
+
+            verify(aiChatApiClient, never()).chatSync(any());
         }
     }
 
@@ -176,23 +213,21 @@ class ChatServiceTest {
     class ChatFileTest {
 
         @Test
-        @DisplayName("fileId가 있으면 presigned URL로 변환하여 Python에 전달한다")
-        void chat_withFileId_resolvesFileUrl() {
+        @DisplayName("로컬 환경: fileId가 있으면 절대 경로로 변환하여 Python에 전달한다")
+        void chat_withFileId_localEnv_resolvesAbsolutePath() {
             // given
             Company company = createTestCompany(1L);
-            User user = createTestUserWithCompany("DRAFTER", company);
+            User user = createTestUserWithCompany(1L, "DRAFTER", company);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
             Diagnostic diagnostic = mock(Diagnostic.class);
             when(diagnostic.getCompany()).thenReturn(company);
 
             EvidenceFile evidenceFile = mock(EvidenceFile.class);
             when(evidenceFile.getFilePath()).thenReturn("diagnostics/1/abc_report.pdf");
-            when(evidenceFile.getOriginalFileName()).thenReturn("report.pdf");
             when(evidenceFile.getDiagnostic()).thenReturn(diagnostic);
 
             when(evidenceFileRepository.findById(42L)).thenReturn(Optional.of(evidenceFile));
-            when(fileStorageService.getPresignedUrl(eq("diagnostics/1/abc_report.pdf"), any(Duration.class)))
-                .thenReturn("https://account.blob.core.windows.net/container/diagnostics/1/abc_report.pdf?sv=...");
 
             ChatRequest request = new ChatRequest(
                 "이 문서를 요약해줘",
@@ -204,7 +239,7 @@ class ChatServiceTest {
             when(aiChatApiClient.chatSync(any(ChatRequest.class))).thenReturn(expectedResponse);
 
             // when
-            ChatResponse response = chatService.chat(request, user);
+            ChatResponse response = chatService.chat(request, 1L);
 
             // then
             assertThat(response).isNotNull();
@@ -212,28 +247,32 @@ class ChatServiceTest {
             ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
             verify(aiChatApiClient).chatSync(requestCaptor.capture());
             ChatRequest sentRequest = requestCaptor.getValue();
-            assertThat(sentRequest.fileUrl()).startsWith("https://");
+            // 로컬: Paths.get("./uploads", "diagnostics/1/abc_report.pdf").toAbsolutePath()
+            assertThat(sentRequest.fileUrl()).endsWith("uploads/diagnostics/1/abc_report.pdf");
+            assertThat(sentRequest.fileUrl()).startsWith("/"); // 절대 경로
             assertThat(sentRequest.fileId()).isNull(); // Python에 보내는 요청에는 fileId 제거
+            verify(fileStorageService, never()).getPresignedUrl(any(), any()); // presignedUrl 미사용
         }
 
         @Test
-        @DisplayName("로컬 환경에서는 상대 경로를 절대 URL로 변환한다")
-        void chat_withFileId_localEnv_convertsToAbsoluteUrl() {
+        @DisplayName("Azure 환경: filePath가 URL이면 presigned URL을 생성한다")
+        void chat_withFileId_azureEnv_resolvesPresignedUrl() {
             // given
             Company company = createTestCompany(1L);
-            User user = createTestUserWithCompany("DRAFTER", company);
+            User user = createTestUserWithCompany(1L, "DRAFTER", company);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
             Diagnostic diagnostic = mock(Diagnostic.class);
             when(diagnostic.getCompany()).thenReturn(company);
 
             EvidenceFile evidenceFile = mock(EvidenceFile.class);
-            when(evidenceFile.getFilePath()).thenReturn("diagnostics/1/abc_report.pdf");
+            when(evidenceFile.getFilePath()).thenReturn("https://account.blob.core.windows.net/container/diagnostics/1/abc_report.pdf");
             when(evidenceFile.getOriginalFileName()).thenReturn("report.pdf");
             when(evidenceFile.getDiagnostic()).thenReturn(diagnostic);
 
             when(evidenceFileRepository.findById(10L)).thenReturn(Optional.of(evidenceFile));
-            when(fileStorageService.getPresignedUrl(eq("diagnostics/1/abc_report.pdf"), any(Duration.class)))
-                .thenReturn("/api/v1/files/local/diagnostics/1/abc_report.pdf");
+            when(fileStorageService.getPresignedUrl(eq("https://account.blob.core.windows.net/container/diagnostics/1/abc_report.pdf"), any(Duration.class)))
+                .thenReturn("https://account.blob.core.windows.net/container/diagnostics/1/abc_report.pdf?sv=2021&sig=xxx");
 
             ChatRequest request = new ChatRequest(
                 "이 문서를 분석해줘",
@@ -245,20 +284,22 @@ class ChatServiceTest {
             when(aiChatApiClient.chatSync(any(ChatRequest.class))).thenReturn(expectedResponse);
 
             // when
-            chatService.chat(request, user);
+            chatService.chat(request, 1L);
 
             // then
             ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
             verify(aiChatApiClient).chatSync(requestCaptor.capture());
-            assertThat(requestCaptor.getValue().fileUrl())
-                .isEqualTo("http://localhost:8080/api/v1/files/local/diagnostics/1/abc_report.pdf");
+            assertThat(requestCaptor.getValue().fileUrl()).startsWith("https://");
+            assertThat(requestCaptor.getValue().fileUrl()).contains("?sv=");
         }
 
         @Test
         @DisplayName("fileId가 null이면 fileUrl 없이 정상 동작한다")
         void chat_withoutFileId_worksNormally() {
             // given
-            User user = createTestUser("DRAFTER");
+            User user = createTestUser(1L, "DRAFTER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
             ChatRequest request = new ChatRequest(
                 "일반 질문입니다",
                 null, null,
@@ -269,7 +310,7 @@ class ChatServiceTest {
             when(aiChatApiClient.chatSync(any(ChatRequest.class))).thenReturn(expectedResponse);
 
             // when
-            ChatResponse response = chatService.chat(request, user);
+            ChatResponse response = chatService.chat(request, 1L);
 
             // then
             assertThat(response).isNotNull();
@@ -284,7 +325,9 @@ class ChatServiceTest {
         @DisplayName("존재하지 않는 fileId면 FILE_NOT_FOUND 에러를 발생시킨다")
         void chat_fileNotFound_throwsException() {
             // given
-            User user = createTestUser("DRAFTER");
+            User user = createTestUser(1L, "DRAFTER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
             ChatRequest request = new ChatRequest(
                 "이 문서를 분석해줘",
                 999L, null,
@@ -294,7 +337,7 @@ class ChatServiceTest {
             when(evidenceFileRepository.findById(999L)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> chatService.chat(request, user))
+            assertThatThrownBy(() -> chatService.chat(request, 1L))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -310,7 +353,8 @@ class ChatServiceTest {
             // given
             Company userCompany = createTestCompany(1L);
             Company fileCompany = createTestCompany(2L);
-            User user = createTestUserWithCompany("DRAFTER", userCompany);
+            User user = createTestUserWithCompany(1L, "DRAFTER", userCompany);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
             Diagnostic diagnostic = mock(Diagnostic.class);
             when(diagnostic.getCompany()).thenReturn(fileCompany);
@@ -327,7 +371,7 @@ class ChatServiceTest {
             );
 
             // when & then
-            assertThatThrownBy(() -> chatService.chat(request, user))
+            assertThatThrownBy(() -> chatService.chat(request, 1L))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -346,13 +390,15 @@ class ChatServiceTest {
         @DisplayName("REVIEWER 역할이면 동기화 요청이 성공한다")
         void syncData_reviewer_success() {
             // given
-            User user = createTestUser("REVIEWER");
+            User user = createTestUser(1L, "REVIEWER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
             AdminSyncResponse expectedResponse = new AdminSyncResponse("accepted", "동기화가 시작되었습니다.");
 
             when(aiChatApiClient.syncDataSync()).thenReturn(expectedResponse);
 
             // when
-            AdminSyncResponse response = chatService.syncData(user);
+            AdminSyncResponse response = chatService.syncData(1L);
 
             // then
             assertThat(response).isNotNull();
@@ -364,10 +410,11 @@ class ChatServiceTest {
         @DisplayName("REVIEWER가 아니면 PERMISSION_DENIED_ACTION 에러를 발생시킨다")
         void syncData_notReviewer_throwsException() {
             // given
-            User user = createTestUser("DRAFTER");
+            User user = createTestUser(1L, "DRAFTER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
             // when & then
-            assertThatThrownBy(() -> chatService.syncData(user))
+            assertThatThrownBy(() -> chatService.syncData(1L))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -381,10 +428,11 @@ class ChatServiceTest {
         @DisplayName("APPROVER도 동기화 권한이 없다")
         void syncData_approver_throwsException() {
             // given
-            User user = createTestUser("APPROVER");
+            User user = createTestUser(1L, "APPROVER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
             // when & then
-            assertThatThrownBy(() -> chatService.syncData(user))
+            assertThatThrownBy(() -> chatService.syncData(1L))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -403,7 +451,9 @@ class ChatServiceTest {
         @DisplayName("REVIEWER 역할이면 DB 현황 조회가 성공한다")
         void getDbStatus_reviewer_success() {
             // given
-            User user = createTestUser("REVIEWER");
+            User user = createTestUser(1L, "REVIEWER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
             AdminInspectResponse expectedResponse = new AdminInspectResponse(
                 1542,
                 List.of("[manual] 안전작업표준.pdf", "[code] validators.py")
@@ -412,7 +462,7 @@ class ChatServiceTest {
             when(aiChatApiClient.inspectDbSync()).thenReturn(expectedResponse);
 
             // when
-            AdminInspectResponse response = chatService.getDbStatus(user);
+            AdminInspectResponse response = chatService.getDbStatus(1L);
 
             // then
             assertThat(response).isNotNull();
@@ -425,10 +475,11 @@ class ChatServiceTest {
         @DisplayName("REVIEWER가 아니면 PERMISSION_DENIED_ACTION 에러를 발생시킨다")
         void getDbStatus_notReviewer_throwsException() {
             // given
-            User user = createTestUser("DRAFTER");
+            User user = createTestUser(1L, "DRAFTER");
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
             // when & then
-            assertThatThrownBy(() -> chatService.getDbStatus(user))
+            assertThatThrownBy(() -> chatService.getDbStatus(1L))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -440,7 +491,7 @@ class ChatServiceTest {
     }
 
     // Helper methods
-    private User createTestUser(String roleCode) {
+    private User createTestUser(Long userId, String roleCode) {
         Role role = new Role(roleCode + " 역할", roleCode);
 
         User user = User.builder()
@@ -449,12 +500,12 @@ class ChatServiceTest {
             .name("테스트 사용자")
             .role(role)
             .build();
-        ReflectionTestUtils.setField(user, "userId", 1L);
+        ReflectionTestUtils.setField(user, "userId", userId);
 
         return user;
     }
 
-    private User createTestUserWithCompany(String roleCode, Company company) {
+    private User createTestUserWithCompany(Long userId, String roleCode, Company company) {
         Role role = new Role(roleCode + " 역할", roleCode);
 
         User user = User.builder()
@@ -464,7 +515,7 @@ class ChatServiceTest {
             .role(role)
             .company(company)
             .build();
-        ReflectionTestUtils.setField(user, "userId", 1L);
+        ReflectionTestUtils.setField(user, "userId", userId);
 
         return user;
     }


### PR DESCRIPTION
## 변경 요약
- **Chat API 500 (S001) 수정**: `@AuthenticationPrincipal User user` → `HttpServletRequest + JwtTokenProvider` 패턴 변경. JWT principal이 `Long`인데 `User`로 받아 NPE 발생하던 문제 해결
- **Chat API LazyInitializationException 수정**: `ChatService`에 `@Transactional(readOnly=true)` 추가
- **Chat API REVIEWER 403 수정**: `resolveFileUrl()`에서 REVIEWER(원청 담당자)는 회사 일치 검증 우회
- **로컬 파일 다운로드**: `GET /api/v1/files/{fileId}/download` 엔드포인트 추가, `getDownloadUrl()`에서 local 환경 시 download URL 반환

## 관련 이슈
- Closes #190 (Chat API 500/403 오류)
- Closes #191 (로컬 파일 다운로드)

## 테스트 방법
1. `./gradlew test` — 전체 테스트 통과 확인
2. Chat API 수동 테스트:
   - `POST /api/v1/chat` (JWT 포함) → 200 응답 확인
   - `file_id` 포함 요청 → REVIEWER는 다른 회사 파일 접근 가능, DRAFTER는 본인 회사만
3. 파일 다운로드 테스트 (로컬):
   - `GET /api/v1/files/{fileId}/download-url` → `downloadUrl`이 `/api/v1/files/{id}/download` 형태
   - `GET /api/v1/files/{fileId}/download` → 파일 바이트 스트리밍 확인

## 명세 준수 체크
- [x] Chat API: `AI_CHAT_BOT_API_v1.1.md` 요청/응답 스키마 변경 없음
- [x] File API: `API_CONTRACT_SSOT.md` 기존 엔드포인트 동작 변경 없음
- [x] SecurityConfig: `/api/v1/files/**`, `/api/v1/chat/**` 기존 패턴 유지
- [x] Azure 환경: SAS URL 로직 영향 없음 (local 분기만 추가)

## 리뷰 포인트
1. `ChatService.resolveFileUrl()` REVIEWER 우회 로직 — 도메인 기반 + 레거시 역할 모두 체크
2. `FileController.downloadFile()` — `InputStreamResource`로 스트리밍, `Content-Disposition` 헤더 설정
3. `FileService.getDownloadUrl()` — `signedUrl.startsWith("/")` 조건으로 local/Azure 분기

## TODO / 질문
- [ ] `Content-Disposition` 한글 파일명 인코딩 (RFC 5987) — 현재 미적용, 추후 개선
- [ ] REVIEWER 회사 우회 테스트 케이스 추가 필요
- [ ] `FileService.downloadFile()`에 파일 접근 권한 검증 추가 여부 (현재 `getDownloadUrl()`과 동일 수준)