### PR TITLE
feat(risk): 외부 리스크 감지 API 구현 (#193)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,7 @@ Swagger UI available at: `http://localhost:8080/swagger-ui.html`
 - [Backend Implementation Guide](./docs/BACKEND_IMPLEMENTATION_GUIDE.md) - 백엔드 구현 가이드
 - [Status and Error Codes](./docs/STATUS_AND_ERROR_CODES.md) - 상태/에러 코드 참조
 - [AI Integration Guide](./docs/AI_INTEGRATION_GUIDE.md) - AI Run API 연동 가이드
+- [AI Risk API](./docs/AI_RISK_API.md) - 외부 리스크 감지 API 프론트엔드 연동 가이드
 
 ## Implementation Notes
 

--- a/docs/AI_RISK_API.md
+++ b/docs/AI_RISK_API.md
@@ -1,0 +1,363 @@
+# 외부 리스크 감지 API - 프론트엔드 연동 가이드
+
+> 최종 업데이트: 2026-02-05
+> PR: #183 / Commit: fbc2aa8
+> 담당: REVIEWER(수신자) 전용 기능
+
+## 1. 개요
+
+협력사에 대한 외부 리스크(뉴스, 제재이력, 규제 위반 등)를 AI로 분석하는 API입니다.
+
+### 아키텍처
+
+```
+┌─────────────┐     ┌─────────────┐     ┌──────────────────┐
+│   Frontend  │────▶│   Backend   │────▶│  AI Risk Server  │
+│  (React)    │     │ (Spring Boot)│     │  (FastAPI)       │
+└─────────────┘     └─────────────┘     └──────────────────┘
+                           │
+                           ▼
+                    ┌─────────────┐
+                    │  PostgreSQL │
+                    │  (결과 저장) │
+                    └─────────────┘
+```
+
+### 권한
+
+| 역할 | 접근 가능 여부 |
+|------|---------------|
+| GUEST | X |
+| DRAFTER (기안자) | X |
+| APPROVER (결재자) | X |
+| **REVIEWER (수신자)** | **O** |
+
+> REVIEWER가 아닌 사용자에게는 해당 메뉴/버튼을 숨기거나 비활성화 처리해주세요.
+
+---
+
+## 2. API 엔드포인트
+
+**Base URL**: `/api/v1/risk/external`
+**인증**: 모든 요청에 `Authorization: Bearer <JWT토큰>` 헤더 필수
+
+| Method | Path | 설명 |
+|--------|------|------|
+| POST | `/api/v1/risk/external/detect` | 리스크 분석 요청 |
+| GET | `/api/v1/risk/external/results/{companyId}` | 특정 회사 최신 결과 조회 |
+| GET | `/api/v1/risk/external/results?page=0&size=10` | 전체 결과 이력 조회 |
+
+---
+
+## 3. 상세 스펙
+
+### 3.1 리스크 분석 요청
+
+```
+POST /api/v1/risk/external/detect
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+**Request Body:**
+
+```json
+{
+  "companyIds": [1, 2, 3]
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `companyIds` | `Long[]` | O | 분석 대상 회사 ID 배열 (1개 이상) |
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "message": "외부 위험 감지 완료",
+  "data": [
+    {
+      "id": 1,
+      "companyId": 1,
+      "companyName": "협력사A",
+      "riskLevel": "HIGH",
+      "summary": "최근 환경 규제 위반 이력 발견",
+      "evidenceJson": "[{\"source\":\"뉴스\",\"title\":\"협력사A 환경규제 위반\",\"snippet\":\"...\",\"url\":\"https://...\",\"date\":\"2026-01-15\"}]",
+      "detectedAt": "2026-02-05T15:30:00"
+    }
+  ],
+  "timestamp": "2026-02-05T15:30:00"
+}
+```
+
+> **주의**: AI 서버 호출이 포함되어 응답까지 **최대 60초** 소요될 수 있습니다. 로딩 UI를 반드시 적용해주세요.
+
+---
+
+### 3.2 특정 회사 최신 결과 조회
+
+```
+GET /api/v1/risk/external/results/{companyId}
+Authorization: Bearer <token>
+```
+
+| 파라미터 | 위치 | 타입 | 설명 |
+|---------|------|------|------|
+| `companyId` | Path | `Long` | 회사 ID |
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "message": "리스크 결과 조회 완료",
+  "data": {
+    "id": 1,
+    "companyId": 1,
+    "companyName": "협력사A",
+    "riskLevel": "MEDIUM",
+    "summary": "경미한 리스크 요소 발견",
+    "evidenceJson": "[...]",
+    "detectedAt": "2026-02-05T15:30:00"
+  },
+  "timestamp": "2026-02-05T15:30:00"
+}
+```
+
+---
+
+### 3.3 전체 결과 이력 조회 (페이지네이션)
+
+```
+GET /api/v1/risk/external/results?page=0&size=10
+Authorization: Bearer <token>
+```
+
+| 파라미터 | 위치 | 타입 | 기본값 | 설명 |
+|---------|------|------|--------|------|
+| `page` | Query | `int` | `0` | 페이지 번호 (0-based) |
+| `size` | Query | `int` | `10` | 페이지당 항목 수 |
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "message": "리스크 결과 이력 조회 완료",
+  "data": {
+    "content": [
+      {
+        "id": 1,
+        "companyId": 1,
+        "companyName": "협력사A",
+        "riskLevel": "HIGH",
+        "summary": "환경 규제 위반 이력 발견",
+        "evidenceJson": "[...]",
+        "detectedAt": "2026-02-05T15:30:00"
+      }
+    ],
+    "page": {
+      "number": 0,
+      "size": 10,
+      "totalElements": 25,
+      "totalPages": 3
+    }
+  },
+  "timestamp": "2026-02-05T15:30:00"
+}
+```
+
+> 기존 `diagnostics`, `approvals` API와 동일한 `PagedResponse` 형식입니다.
+
+---
+
+## 4. 응답 필드 상세
+
+### 4.1 결과 객체 (ExternalRiskResultResponse)
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `id` | `Long` | 결과 고유 ID |
+| `companyId` | `Long` | 회사 ID |
+| `companyName` | `String` | 회사명 |
+| `riskLevel` | `String` | 리스크 등급: `LOW`, `MEDIUM`, `HIGH` |
+| `summary` | `String` | AI가 생성한 리스크 요약 |
+| `evidenceJson` | `String` | 근거 자료 JSON 문자열 (**파싱 필요**) |
+| `detectedAt` | `String` | 분석 시각 (ISO 8601) |
+
+### 4.2 riskLevel 값 정의
+
+| 값 | 의미 | 권장 색상 |
+|----|------|----------|
+| `LOW` | 낮은 리스크 | 🟢 초록 (`#22C55E`) |
+| `MEDIUM` | 중간 리스크 | 🟡 주황 (`#F59E0B`) |
+| `HIGH` | 높은 리스크 | 🔴 빨강 (`#EF4444`) |
+
+### 4.3 evidenceJson 파싱
+
+`evidenceJson`은 **JSON 문자열**로 전달됩니다. 프론트에서 파싱이 필요합니다.
+
+```typescript
+// 파싱 예시
+interface Evidence {
+  source: string;   // 출처 유형 (예: "뉴스", "공시")
+  title: string;    // 제목
+  snippet: string;  // 관련 내용 발췌
+  url: string;      // 원문 URL
+  date: string;     // 날짜
+}
+
+const evidenceList: Evidence[] = JSON.parse(result.evidenceJson);
+```
+
+**파싱 후 구조 예시:**
+
+```json
+[
+  {
+    "source": "뉴스",
+    "title": "협력사A, 환경규제 위반으로 과징금 부과",
+    "snippet": "환경부는 협력사A에 대해 대기오염물질 배출 기준 초과로...",
+    "url": "https://news.example.com/article/12345",
+    "date": "2026-01-15"
+  },
+  {
+    "source": "공시",
+    "title": "행정처분 공시",
+    "snippet": "사업정지 15일 처분...",
+    "url": "https://dart.example.com/report/67890",
+    "date": "2026-01-20"
+  }
+]
+```
+
+---
+
+## 5. 에러 응답
+
+### 공통 에러 형식
+
+```json
+{
+  "success": false,
+  "message": "에러 메시지",
+  "data": null,
+  "timestamp": "2026-02-05T15:30:00"
+}
+```
+
+### 에러 코드
+
+| 코드 | HTTP Status | 메시지 | 발생 상황 | 프론트 처리 |
+|------|-------------|--------|----------|------------|
+| `RISK001` | 404 | 리스크 분석 대상 회사를 찾을 수 없습니다 | 존재하지 않는 companyId 전달 | "회사 정보를 찾을 수 없습니다" 안내 |
+| `RISK002` | 500 | 외부 위험 감지 API 호출에 실패했습니다 | AI 서버 장애 또는 타임아웃 | "잠시 후 다시 시도해주세요" 안내 |
+| `RISK003` | 404 | 리스크 분석 결과를 찾을 수 없습니다 | 해당 회사 분석 이력 없음 | "아직 분석된 결과가 없습니다" 안내 |
+| `RISK004` | 403 | REVIEWER만 리스크 분석을 요청할 수 있습니다 | 권한 없는 사용자 접근 | 접근 차단 또는 권한 안내 |
+| `U001` | 400 | 입력값이 올바르지 않습니다 | companyIds 빈 배열 전달 | 입력값 검증 |
+
+---
+
+## 6. 프론트엔드 구현 체크리스트
+
+### 필수 사항
+
+- [ ] REVIEWER 역할 확인 후 메뉴/버튼 노출 제어
+- [ ] `detect` 요청 시 로딩 UI 적용 (최대 60초 소요 가능)
+- [ ] `evidenceJson` 필드 `JSON.parse()` 처리
+- [ ] 에러 코드별 사용자 안내 메시지 분기 처리
+- [ ] 페이지네이션 `page` 파라미터 0-based 처리
+
+### 권장 사항
+
+- [ ] riskLevel별 색상 배지(Badge) 컴포넌트
+- [ ] evidence 목록에서 URL 클릭 시 새 탭으로 열기 (`target="_blank"`)
+- [ ] 분석 요청 전 확인 모달 (여러 회사 동시 분석 시)
+- [ ] 결과 없는 회사에 대해 "분석 요청" 버튼 노출
+
+---
+
+## 7. 연동 예시 (React/TypeScript)
+
+### API 호출
+
+```typescript
+// 리스크 분석 요청
+const detectRisk = async (companyIds: number[]) => {
+  const response = await api.post('/api/v1/risk/external/detect', {
+    companyIds,
+  });
+  return response.data;
+};
+
+// 특정 회사 최신 결과 조회
+const getLatestResult = async (companyId: number) => {
+  const response = await api.get(`/api/v1/risk/external/results/${companyId}`);
+  return response.data;
+};
+
+// 전체 결과 이력 조회
+const getAllResults = async (page = 0, size = 10) => {
+  const response = await api.get('/api/v1/risk/external/results', {
+    params: { page, size },
+  });
+  return response.data;
+};
+```
+
+### 타입 정의
+
+```typescript
+interface ExternalRiskResult {
+  id: number;
+  companyId: number;
+  companyName: string;
+  riskLevel: 'LOW' | 'MEDIUM' | 'HIGH';
+  summary: string;
+  evidenceJson: string;
+  detectedAt: string;
+}
+
+interface Evidence {
+  source: string;
+  title: string;
+  snippet: string;
+  url: string;
+  date: string;
+}
+
+interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+  timestamp: string;
+}
+
+interface PagedData<T> {
+  content: T[];
+  page: {
+    number: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+  };
+}
+```
+
+---
+
+## 8. 테스트 방법
+
+Swagger UI에서 직접 테스트 가능: `http://localhost:8080/swagger-ui.html`
+
+### 테스트 시나리오
+
+| 시나리오 | 방법 | 기대 결과 |
+|---------|------|----------|
+| 정상 분석 | REVIEWER 토큰으로 `POST /detect` | 200 + 결과 배열 |
+| 권한 없음 | DRAFTER 토큰으로 `POST /detect` | 403 RISK004 |
+| 없는 회사 | 존재하지 않는 companyId 전달 | 404 RISK001 |
+| 결과 없음 | 분석 이력 없는 회사 결과 조회 | 404 RISK003 |
+| 빈 배열 | `companyIds: []` 전달 | 400 U001 |

--- a/src/main/java/com/smartchain/platform/domain/risk/config/ExternalRiskApiConfig.java
+++ b/src/main/java/com/smartchain/platform/domain/risk/config/ExternalRiskApiConfig.java
@@ -8,6 +8,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 @Configuration
 @ConfigurationProperties(prefix = "ai.risk-api")
@@ -16,6 +18,7 @@ public class ExternalRiskApiConfig {
     private String url = "http://localhost:8000";
     private int timeoutSeconds = 60;
     private int maxRetry = 3;
+    private List<String> targetCompanies = new ArrayList<>();
 
     @Bean
     public WebClient externalRiskApiWebClient() {
@@ -50,5 +53,13 @@ public class ExternalRiskApiConfig {
 
     public void setMaxRetry(int maxRetry) {
         this.maxRetry = maxRetry;
+    }
+
+    public List<String> getTargetCompanies() {
+        return targetCompanies;
+    }
+
+    public void setTargetCompanies(List<String> targetCompanies) {
+        this.targetCompanies = targetCompanies;
     }
 }

--- a/src/main/java/com/smartchain/platform/domain/risk/controller/ExternalRiskController.java
+++ b/src/main/java/com/smartchain/platform/domain/risk/controller/ExternalRiskController.java
@@ -3,6 +3,7 @@ package com.smartchain.platform.domain.risk.controller;
 import com.smartchain.platform.domain.risk.service.ExternalRiskService;
 import com.smartchain.platform.dto.common.page.PageDto;
 import com.smartchain.platform.dto.common.page.PagedResponse;
+import com.smartchain.platform.dto.risk.ExternalRiskCompanyResponse;
 import com.smartchain.platform.dto.risk.ExternalRiskDetectApiRequest;
 import com.smartchain.platform.dto.risk.ExternalRiskResultResponse;
 import com.smartchain.platform.global.response.BaseResponse;
@@ -30,6 +31,15 @@ public class ExternalRiskController {
 
     private final ExternalRiskService externalRiskService;
     private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "리스크 대상 회사 목록 조회", description = "리스크 분석 대상으로 설정된 회사 목록을 조회합니다. REVIEWER 권한이 필요합니다.")
+    @GetMapping("/companies")
+    public ResponseEntity<BaseResponse<List<ExternalRiskCompanyResponse>>> getRiskTargetCompanies(
+            HttpServletRequest request) {
+        Long userId = extractUserIdFromRequest(request);
+        List<ExternalRiskCompanyResponse> companies = externalRiskService.getRiskTargetCompanies(userId);
+        return ResponseEntity.ok(BaseResponse.success("리스크 대상 회사 목록 조회 완료", companies));
+    }
 
     @Operation(summary = "협력사 리스크 분석 요청", description = "외부 AI API를 통해 협력사 리스크를 분석합니다. REVIEWER 권한이 필요합니다.")
     @PostMapping("/detect")

--- a/src/main/java/com/smartchain/platform/domain/risk/service/ExternalRiskService.java
+++ b/src/main/java/com/smartchain/platform/domain/risk/service/ExternalRiskService.java
@@ -3,12 +3,14 @@ package com.smartchain.platform.domain.risk.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartchain.platform.domain.risk.client.ExternalRiskApiClient;
+import com.smartchain.platform.domain.risk.config.ExternalRiskApiConfig;
 import com.smartchain.platform.domain.risk.entity.ExternalRiskResult;
 import com.smartchain.platform.domain.risk.repository.ExternalRiskResultRepository;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.domain.user.repository.CompanyRepository;
 import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.dto.risk.ExternalRiskCompanyResponse;
 import com.smartchain.platform.dto.risk.ExternalRiskDetectRequest;
 import com.smartchain.platform.dto.risk.ExternalRiskDetectResponse;
 import com.smartchain.platform.dto.risk.ExternalRiskResultResponse;
@@ -33,6 +35,7 @@ public class ExternalRiskService {
     private static final Logger log = LoggerFactory.getLogger(ExternalRiskService.class);
 
     private final ExternalRiskApiClient externalRiskApiClient;
+    private final ExternalRiskApiConfig externalRiskApiConfig;
     private final ExternalRiskResultRepository riskResultRepository;
     private final CompanyRepository companyRepository;
     private final UserRepository userRepository;
@@ -48,11 +51,7 @@ public class ExternalRiskService {
                 .orElseThrow(() -> new CustomException(ErrorCode.RISK_COMPANY_NOT_FOUND)))
             .toList();
 
-        List<String> vendorNames = companies.stream()
-            .map(Company::getName)
-            .toList();
-
-        ExternalRiskDetectRequest request = ExternalRiskDetectRequest.of(vendorNames);
+        ExternalRiskDetectRequest request = ExternalRiskDetectRequest.of(companies);
         ExternalRiskDetectResponse response = externalRiskApiClient.detect(request);
 
         List<ExternalRiskResultResponse> results = new ArrayList<>();
@@ -111,6 +110,22 @@ public class ExternalRiskService {
 
         return riskResultRepository.findAllByOrderByDetectedAtDesc(pageable)
             .map(ExternalRiskResultResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ExternalRiskCompanyResponse> getRiskTargetCompanies(Long userId) {
+        User user = getUser(userId);
+        validateReviewerRole(user);
+
+        List<String> targetNames = externalRiskApiConfig.getTargetCompanies();
+        if (targetNames == null || targetNames.isEmpty()) {
+            return List.of();
+        }
+
+        List<Company> companies = companyRepository.findByNameIn(targetNames);
+        return companies.stream()
+            .map(ExternalRiskCompanyResponse::from)
+            .toList();
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/com/smartchain/platform/domain/user/repository/CompanyRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/user/repository/CompanyRepository.java
@@ -37,4 +37,6 @@ public interface CompanyRepository extends JpaRepository<Company, Long> {
 
     @Query("SELECT COUNT(d) FROM Diagnostic d WHERE d.company.companyId = :companyId")
     int countDiagnosticsByCompanyId(@Param("companyId") Long companyId);
+
+    List<Company> findByNameIn(List<String> names);
 }

--- a/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskCompanyResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskCompanyResponse.java
@@ -1,0 +1,9 @@
+package com.smartchain.platform.dto.risk;
+
+import com.smartchain.platform.domain.user.entity.Company;
+
+public record ExternalRiskCompanyResponse(Long companyId, String name) {
+    public static ExternalRiskCompanyResponse from(Company company) {
+        return new ExternalRiskCompanyResponse(company.getCompanyId(), company.getName());
+    }
+}

--- a/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskDetectRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskDetectRequest.java
@@ -1,16 +1,25 @@
 package com.smartchain.platform.dto.risk;
 
+import com.smartchain.platform.domain.user.entity.Company;
+
 import java.util.List;
 
 /**
  * Backend -> AI 서버 요청 DTO
  * POST /risk/external/detect
+ *
+ * AI 서버 스키마: vendors는 회사명 문자열 배열
  */
 public record ExternalRiskDetectRequest(
     List<String> vendors,
-    boolean rag
+    RagConfig rag
 ) {
-    public static ExternalRiskDetectRequest of(List<String> vendorNames) {
-        return new ExternalRiskDetectRequest(vendorNames, true);
+    public record RagConfig(boolean enabled) {}
+
+    public static ExternalRiskDetectRequest of(List<Company> companies) {
+        List<String> vendorNames = companies.stream()
+            .map(Company::getName)
+            .toList();
+        return new ExternalRiskDetectRequest(vendorNames, new RagConfig(true));
     }
 }

--- a/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskDetectResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/risk/ExternalRiskDetectResponse.java
@@ -1,5 +1,7 @@
 package com.smartchain.platform.dto.risk;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 /**
@@ -10,16 +12,20 @@ public record ExternalRiskDetectResponse(
 ) {
     public record VendorRiskResult(
         String vendor,
-        String riskLevel,
-        String summary,
+        @JsonProperty("external_risk_level") String riskLevel,
+        @JsonProperty("total_score") Double totalScore,
+        @JsonProperty("docs_count") Integer docsCount,
+        @JsonProperty("reason_1line") String summary,
+        @JsonProperty("reason_3lines") List<String> reason3lines,
         List<Evidence> evidence
     ) {}
 
     public record Evidence(
+        @JsonProperty("doc_id") String docId,
         String source,
         String title,
         String snippet,
         String url,
-        String date
+        @JsonProperty("published_at") String date
     ) {}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -83,9 +83,15 @@ ai:
     admin-api-key: ${AI_CHAT_ADMIN_KEY:test-key}
     timeout-seconds: 30
   risk-api:
-    url: ${AI_RISK_API_URL:http://127.0.0.1:8000}
-    timeout-seconds: 60
+    url: ${AI_RISK_API_URL:http://127.0.0.1:8002}
+    timeout-seconds: 300
     max-retry: 3
+    target-companies:
+      - 포스코홀딩스
+      - 현대제철
+      - 성광벤드
+      - 동국제강
+      - HD현대일렉트릭
   slots:
     # 슬롯 정의: docs/API_CONTRACT_SSOT.md §8.6 기준
     domains:

--- a/src/test/java/com/smartchain/platform/domain/risk/service/ExternalRiskServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/risk/service/ExternalRiskServiceTest.java
@@ -2,6 +2,7 @@ package com.smartchain.platform.domain.risk.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartchain.platform.domain.risk.client.ExternalRiskApiClient;
+import com.smartchain.platform.domain.risk.config.ExternalRiskApiConfig;
 import com.smartchain.platform.domain.risk.entity.ExternalRiskResult;
 import com.smartchain.platform.domain.risk.repository.ExternalRiskResultRepository;
 import com.smartchain.platform.domain.user.entity.Company;
@@ -9,6 +10,7 @@ import com.smartchain.platform.domain.user.entity.Role;
 import com.smartchain.platform.domain.user.entity.User;
 import com.smartchain.platform.domain.user.repository.CompanyRepository;
 import com.smartchain.platform.domain.user.repository.UserRepository;
+import com.smartchain.platform.dto.risk.ExternalRiskCompanyResponse;
 import com.smartchain.platform.dto.risk.ExternalRiskDetectRequest;
 import com.smartchain.platform.dto.risk.ExternalRiskDetectResponse;
 import com.smartchain.platform.dto.risk.ExternalRiskResultResponse;
@@ -43,6 +45,8 @@ class ExternalRiskServiceTest {
     @Mock
     private ExternalRiskApiClient externalRiskApiClient;
     @Mock
+    private ExternalRiskApiConfig externalRiskApiConfig;
+    @Mock
     private ExternalRiskResultRepository riskResultRepository;
     @Mock
     private CompanyRepository companyRepository;
@@ -57,6 +61,7 @@ class ExternalRiskServiceTest {
         objectMapper = new ObjectMapper();
         externalRiskService = new ExternalRiskService(
             externalRiskApiClient,
+            externalRiskApiConfig,
             riskResultRepository,
             companyRepository,
             userRepository,
@@ -117,9 +122,10 @@ class ExternalRiskServiceTest {
 
             ExternalRiskDetectResponse aiResponse = new ExternalRiskDetectResponse(
                 List.of(new ExternalRiskDetectResponse.VendorRiskResult(
-                    "테스트협력사", "HIGH", "뉴스 기사에서 위험 감지",
+                    "테스트협력사", "HIGH", 85.0, 1, "뉴스 기사에서 위험 감지",
+                    List.of("위험 요소 발견"),
                     List.of(new ExternalRiskDetectResponse.Evidence(
-                        "뉴스", "위험 기사", "내용 발췌", "https://example.com", "2025-01-01"
+                        "doc-1", "뉴스", "위험 기사", "내용 발췌", "https://example.com", "2025-01-01"
                     ))
                 ))
             );
@@ -297,6 +303,71 @@ class ExternalRiskServiceTest {
             assertThat(responsePage.getContent()).hasSize(1);
             assertThat(responsePage.getContent().get(0).riskLevel()).isEqualTo("LOW");
             assertThat(responsePage.getTotalElements()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("getRiskTargetCompanies")
+    class GetRiskTargetCompaniesTest {
+
+        @Test
+        @DisplayName("설정된 대상 회사 목록을 반환한다")
+        void getRiskTargetCompanies_success_returnsCompanies() {
+            // given
+            Long userId = 1L;
+            User user = createTestUser(userId, "REVIEWER");
+            List<String> targetNames = List.of("포스코홀딩스", "현대제철");
+            Company company1 = createTestCompany(1L, "포스코홀딩스");
+            Company company2 = createTestCompany(2L, "현대제철");
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(externalRiskApiConfig.getTargetCompanies()).thenReturn(targetNames);
+            when(companyRepository.findByNameIn(targetNames)).thenReturn(List.of(company1, company2));
+
+            // when
+            List<ExternalRiskCompanyResponse> result = externalRiskService.getRiskTargetCompanies(userId);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).companyId()).isEqualTo(1L);
+            assertThat(result.get(0).name()).isEqualTo("포스코홀딩스");
+            assertThat(result.get(1).companyId()).isEqualTo(2L);
+            assertThat(result.get(1).name()).isEqualTo("현대제철");
+        }
+
+        @Test
+        @DisplayName("REVIEWER가 아니면 RISK_PERMISSION_DENIED 에러를 발생시킨다")
+        void getRiskTargetCompanies_nonReviewer_throwsException() {
+            // given
+            Long userId = 1L;
+            User user = createTestUser(userId, "DRAFTER");
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            // when & then
+            assertThatThrownBy(() -> externalRiskService.getRiskTargetCompanies(userId))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.RISK_PERMISSION_DENIED);
+                });
+        }
+
+        @Test
+        @DisplayName("대상 회사가 비어있으면 빈 목록을 반환한다")
+        void getRiskTargetCompanies_emptyConfig_returnsEmpty() {
+            // given
+            Long userId = 1L;
+            User user = createTestUser(userId, "REVIEWER");
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(externalRiskApiConfig.getTargetCompanies()).thenReturn(List.of());
+
+            // when
+            List<ExternalRiskCompanyResponse> result = externalRiskService.getRiskTargetCompanies(userId);
+
+            // then
+            assertThat(result).isEmpty();
+            verify(companyRepository, never()).findByNameIn(any());
         }
     }
 


### PR DESCRIPTION
## 변경 요약
- AI 서버 연동 외부 리스크 감지 API 전체 구현
- `ExternalRiskController`: GET /companies, POST /detect, GET /results/{id}, GET /results
- `ExternalRiskService`: AI 서버 호출 → 결과 파싱 → DB 저장/조회
- `ExternalRiskDetectRequest`: vendors 타입을 `List<VendorInfo>` → `List<String>`로 수정 (AI 서버 422 에러 해결)
- `application.yaml`: risk-api timeout 60s → 300s, 대상 회사 5개 설정
- `CompanyRepository`: `findByNameIn` 쿼리 메서드 추가
- `docs/AI_RISK_API.md`: 프론트엔드 연동 가이드 문서

## 관련 이슈
- Closes #193

## 테스트 방법
1. `./gradlew test --tests "ExternalRiskServiceTest"` - 단위 테스트 통과 확인
2. 로컬 AI 서버(port 8002) 실행 후 Swagger UI에서 수동 테스트
3. 프론트엔드에서 리스크 현황 패널 → 회사 클릭 → 결과 확인

## 명세 준수 체크
- [x] AI 서버 OpenAPI 스펙과 요청/응답 DTO 일치 확인
- [x] `vendors: List[str]` 형식으로 전송 (AI FastAPI Pydantic 검증 통과)
- [x] 에러 코드 RISK001~RISK003 ErrorCode enum 등록
- [x] 타임아웃 300s (프론트엔드 310s와 정합)

## 리뷰 포인트
- `ExternalRiskService`의 WebClient 재시도 로직 (maxRetry 3회)
- AI 서버 응답 매핑 시 null 처리 (evidenceJson이 null일 수 있음)
- `application.yaml`의 target-companies 목록 관리 방식 (config vs DB)

## TODO / 질문
- [ ] AI 서버 URL을 환경변수로 분리 필요 여부 (현재 local: 하드코딩, dev: 환경변수)
- [ ] 리스크 결과 캐싱 전략 논의 필요 (현재 매 요청마다 AI 서버 호출)