### PR TITLE
fix(seed): 캠페인 날짜 연장 및 마스터 결재자 계정 추가

### DIFF
--- a/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
+++ b/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
@@ -204,7 +204,11 @@ public class DataInitializer implements CommandLineRunner {
                 .name("마스터기안").email("master.drafter@posco.com").userPassword(encodedPassword)
                 .company(posco).role(drafterRole).emailVerified(true).build());
 
-        log.info("Users created: 14 users (including 2 masters)");
+        User masterApprover = userRepository.save(User.builder()
+                .name("마스터결재").email("master.approver@posco.com").userPassword(encodedPassword)
+                .company(posco).role(approverRole).emailVerified(true).build());
+
+        log.info("Users created: 15 users (including 3 masters)");
 
         // ========================================
         // 4. UserDomainRole (도메인별 권한)
@@ -236,6 +240,9 @@ public class DataInitializer implements CommandLineRunner {
             userDomainRoleRepository.save(UserDomainRole.builder().user(masterReviewer).domain(domain).role(reviewerRole).build());
             userDomainRoleRepository.save(UserDomainRole.builder().user(masterDrafter).domain(domain).role(drafterRole).build());
         }
+
+        // 마스터 결재자: ESG 도메인만
+        userDomainRoleRepository.save(UserDomainRole.builder().user(masterApprover).domain(esgDomain).role(approverRole).build());
         log.info("UserDomainRoles created");
 
         // ========================================
@@ -245,8 +252,8 @@ public class DataInitializer implements CommandLineRunner {
         Campaign esgCampaignCurrent = campaignRepository.save(Campaign.builder()
                 .campaignCode("CAMP-ESG-2025-H2").ownerCompanyId(ownerCompany.getCompanyId()).domain(esgDomain)
                 .title("2025년 하반기 ESG 공급망 진단").content("2025년 하반기 협력사 ESG 경영 현황 진단")
-                .periodStartDate(LocalDate.of(2025, 7, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2026, 2, 28)).isActive(true).build());
+                .periodStartDate(LocalDate.of(2025, 7, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 8, 31)).isActive(true).build());
 
         // 과거 완료: 2025 상반기
         Campaign esgCampaignPast = campaignRepository.save(Campaign.builder()
@@ -258,8 +265,8 @@ public class DataInitializer implements CommandLineRunner {
         Campaign safetyCampaignCurrent = campaignRepository.save(Campaign.builder()
                 .campaignCode("CAMP-SAFETY-2025-H2").ownerCompanyId(ownerCompany.getCompanyId()).domain(safetyDomain)
                 .title("2025년 하반기 안전보건 점검").content("2025년 하반기 협력사 안전보건 관리 현황 점검")
-                .periodStartDate(LocalDate.of(2025, 7, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2026, 2, 28)).isActive(true).build());
+                .periodStartDate(LocalDate.of(2025, 7, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 8, 31)).isActive(true).build());
 
         Campaign safetyCampaignPast = campaignRepository.save(Campaign.builder()
                 .campaignCode("CAMP-SAFETY-2025-H1").ownerCompanyId(ownerCompany.getCompanyId()).domain(safetyDomain)
@@ -270,8 +277,8 @@ public class DataInitializer implements CommandLineRunner {
         Campaign complianceCampaignCurrent = campaignRepository.save(Campaign.builder()
                 .campaignCode("CAMP-COMPL-2025-H2").ownerCompanyId(ownerCompany.getCompanyId()).domain(complianceDomain)
                 .title("2025년 하반기 하도급 컴플라이언스 점검").content("2025년 하반기 협력사 하도급 계약 법규 준수 점검")
-                .periodStartDate(LocalDate.of(2025, 7, 1)).periodEndDate(LocalDate.of(2025, 12, 31))
-                .deadline(LocalDate.of(2026, 2, 28)).isActive(true).build());
+                .periodStartDate(LocalDate.of(2025, 7, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .deadline(LocalDate.of(2026, 8, 31)).isActive(true).build());
 
         Campaign complianceCampaignPast = campaignRepository.save(Campaign.builder()
                 .campaignCode("CAMP-COMPL-2025-H1").ownerCompanyId(ownerCompany.getCompanyId()).domain(complianceDomain)
@@ -680,9 +687,10 @@ public class DataInitializer implements CommandLineRunner {
         log.info("        TEST ACCOUNTS (password: Test1234!)");
         log.info("============================================");
         log.info("");
-        log.info("[MASTER ACCOUNTS - ALL DOMAINS]");
-        log.info("  REVIEWER:   master.reviewer@hdhhi.co.kr");
-        log.info("  DRAFTER:    master.drafter@posco.com");
+        log.info("[MASTER ACCOUNTS]");
+        log.info("  REVIEWER:   master.reviewer@hdhhi.co.kr (ALL DOMAINS)");
+        log.info("  DRAFTER:    master.drafter@posco.com (ALL DOMAINS)");
+        log.info("  APPROVER:   master.approver@posco.com (ESG Only)");
         log.info("");
         log.info("[원청 심사자 - REVIEWER]");
         log.info("  ESG:        reviewer.esg@hdhhi.co.kr");


### PR DESCRIPTION
## 변경 요약
- H2 캠페인(ESG, SAFETY, COMPLIANCE) `periodEndDate`를 `2025-12-31` → `2026-06-30`으로 연장
- H2 캠페인 `deadline`을 `2026-02-28` → `2026-08-31`로 연장
- 마스터 결재자 계정 추가: `master.approver@posco.com` (포스코홀딩스, ESG 도메인, APPROVER)

## 관련 이슈
- 마스터 계정으로 로그인 시 캠페인 목록이 비어있는 문제
- 원인: `CampaignRepository.findAllNotClosed()` 쿼리가 `periodEndDate >= today`로 필터링하는데, H2 캠페인의 `periodEndDate`(2025-12-31)가 현재 날짜(2026-02-06)보다 과거라 전부 제외됨

## 테스트 방법
1. Docker DB 볼륨 초기화: `docker compose down -v && docker compose up -d`
2. 서버 재시작: `./gradlew bootRun`
3. `master.reviewer@hdhhi.co.kr` (비번: Test1234!) 로그인 → 캠페인 3개(ESG/SAFETY/COMPLIANCE H2) 표시 확인
4. `master.approver@posco.com` (비번: Test1234!) 로그인 → ESG 캠페인 1개 표시 확인
5. `master.drafter@posco.com` 로그인 → 캠페인 3개 표시 확인

## 명세 준수 체크
- [x] `DataInitializer` 시드 데이터만 변경 (비즈니스 로직 변경 없음)
- [x] 기존 계정/진단/결재/심사 데이터 영향 없음
- [x] 빌드 통과 (434/435 테스트 통과, 1건 기존 실패 - ChatServiceTest)

## 리뷰 포인트
- `periodEndDate`를 2026-06-30으로 설정한 것이 시나리오(2025 하반기)와 의미적으로 맞는지 확인 필요
- 마스터 결재자가 포스코홀딩스 소속인 것이 데모 시나리오에 적합한지

## TODO / 질문
- [ ] `CampaignRepository` 쿼리를 `periodEndDate` 대신 `deadline` 기준으로 필터링하는 것이 더 적절한지 검토 필요 (현재는 시드 데이터로 우회)
- [ ] 마스터 결재자에게 SAFETY/COMPLIANCE 도메인도 추가해야 하는지?