### PR TITLE
fix(review): 반려 후 재제출 시 Review 중복 생성 버그 수정

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,31 @@
 # Claude Code Learnings
 
+## 2026-02-06: 반려 후 재제출 시 Review 중복 생성 버그 수정
+
+### 원인
+- 심사자가 반려(REVISION_REQUIRED) 후 기안자가 재제출하면 심사 목록에 2개의 Review가 나타남
+- `ApprovalService.submitToReviewer()`, `DiagnosticService.submitDiagnostic()`에서 항상 새 Review를 생성하는 로직
+- 기존 REVISION_REQUIRED 상태의 Review를 무시하고 새로 생성
+
+### 해결
+- `ReviewRepository.findByDiagnostic()` 메서드 추가
+- `Review.resubmit()` 메서드 추가 (상태를 REVIEWING으로 되돌리고 제출 시간 업데이트)
+- `ApprovalService.submitToReviewer()`: 기존 Review가 있으면 `resubmit()` 호출하여 재사용
+- `DiagnosticService.submitDiagnostic()` (SAFETY/COMPLIANCE): 동일하게 기존 Review 재사용
+
+### 재발방지
+- 워크플로우에서 상태 전이 시 새 엔티티 생성 전에 기존 엔티티 존재 여부 확인
+- 반려 → 재제출 시나리오는 기존 레코드 재사용이 일반적
+
+### 검증방법
+- `./gradlew build` 전체 빌드 및 테스트 통과
+- 프론트엔드에서 반려 → 재제출 → 심사 목록 확인
+
+### 관련커밋
+- (커밋 전)
+
+---
+
 ## 2026-02-06: 기안 삭제 API 500 에러 수정 (FK constraint 위반)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
+++ b/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
@@ -312,15 +312,26 @@ public class ApprovalService {
         approval.submitToReviewer();
         diagnostic.markAsReviewing();
 
-        // Review 엔티티 생성 (#158)
-        Review review = Review.builder()
-                .diagnostic(diagnostic)
-                .company(diagnostic.getCompany())
-                .domain(diagnostic.getDomain())
-                .score(diagnostic.getOverallScore())
-                .submittedAt(approval.getSubmittedToReviewerAt())
-                .build();
-        Review savedReview = reviewRepository.save(review);
+        // 기존 Review가 있으면 재사용, 없으면 새로 생성 (#158, 반려 후 재제출 지원)
+        Review savedReview = reviewRepository.findByDiagnostic(diagnostic)
+                .map(existingReview -> {
+                    // 반려(REVISION_REQUIRED) 상태의 기존 Review를 재사용
+                    existingReview.resubmit(approval.getSubmittedToReviewerAt());
+                    log.info("Reusing existing review for resubmission: reviewId={}, diagnosticId={}",
+                            existingReview.getReviewId(), diagnostic.getDiagnosticId());
+                    return existingReview;
+                })
+                .orElseGet(() -> {
+                    // 신규 Review 생성
+                    Review newReview = Review.builder()
+                            .diagnostic(diagnostic)
+                            .company(diagnostic.getCompany())
+                            .domain(diagnostic.getDomain())
+                            .score(diagnostic.getOverallScore())
+                            .submittedAt(approval.getSubmittedToReviewerAt())
+                            .build();
+                    return reviewRepository.save(newReview);
+                });
 
         log.info("Submitted to reviewer: approvalId={}, diagnosticId={}, reviewId={}, submittedBy={}",
                 approvalId, diagnostic.getDiagnosticId(), savedReview.getReviewId(), userId);

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -441,13 +441,23 @@ public class DiagnosticService {
                     .build();
             diagnosticHistoryRepository.save(approveHistory);
 
-            Review review = Review.builder()
-                    .diagnostic(diagnostic)
-                    .company(diagnostic.getCompany())
-                    .domain(domain)
-                    .submittedAt(diagnostic.getSubmittedAt())
-                    .build();
-            Review savedReview = reviewRepository.save(review);
+            // 기존 Review가 있으면 재사용, 없으면 새로 생성 (반려 후 재제출 지원)
+            Review savedReview = reviewRepository.findByDiagnostic(diagnostic)
+                    .map(existingReview -> {
+                        existingReview.resubmit(diagnostic.getSubmittedAt());
+                        log.info("Reusing existing review for resubmission: reviewId={}, diagnosticId={}",
+                                existingReview.getReviewId(), diagnostic.getDiagnosticId());
+                        return existingReview;
+                    })
+                    .orElseGet(() -> {
+                        Review newReview = Review.builder()
+                                .diagnostic(diagnostic)
+                                .company(diagnostic.getCompany())
+                                .domain(domain)
+                                .submittedAt(diagnostic.getSubmittedAt())
+                                .build();
+                        return reviewRepository.save(newReview);
+                    });
 
             log.info("Diagnostic submitted ({} → Review, approval skipped): diagnosticId={}, submittedBy={}, reviewId={}",
                     domainCode, diagnosticId, userId, savedReview.getReviewId());

--- a/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
+++ b/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
@@ -119,6 +119,21 @@ public class Review extends BaseTimeEntity {
         this.comment = null;
     }
 
+    /**
+     * 반려 후 재제출 시 기존 Review 재사용
+     * REVISION_REQUIRED 상태에서 REVIEWING으로 되돌리고 제출 시간 업데이트
+     */
+    public void resubmit(LocalDateTime newSubmittedAt) {
+        this.status = ReviewStatus.REVIEWING;
+        this.submittedAt = newSubmittedAt;
+        this.processedBy = null;
+        this.processedAt = null;
+        this.comment = null;
+        this.categoryCommentE = null;
+        this.categoryCommentS = null;
+        this.categoryCommentG = null;
+    }
+
     public void updateScore(Integer score) {
         this.score = score;
         this.riskLevel = RiskLevel.fromScore(score);

--- a/src/main/java/com/smartchain/platform/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.smartchain.platform.domain.review.repository;
 
+import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Domain;
@@ -13,8 +14,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    // Diagnostic으로 Review 조회 (재제출 시 기존 Review 재사용)
+    Optional<Review> findByDiagnostic(Diagnostic diagnostic);
 
     // 전체 심사 목록 조회 (REVIEWER용)
     Page<Review> findAllByOrderByCreatedAtDesc(Pageable pageable);


### PR DESCRIPTION
## Summary
- 심사자 반려 후 기안자 재제출 시 심사 목록에 Review가 중복으로 나타나는 버그 수정
- 기존 REVISION_REQUIRED 상태의 Review를 재사용하도록 로직 변경

## Changes
- `ReviewRepository.findByDiagnostic()`: Diagnostic으로 Review 조회
- `Review.resubmit()`: 재제출 시 상태 초기화 메서드
- `ApprovalService.submitToReviewer()`: 기존 Review 재사용
- `DiagnosticService.submitDiagnostic()`: SAFETY/COMPLIANCE 도메인도 동일 적용

## Test plan
- [x] `./gradlew build` 전체 테스트 통과
- [ ] 반려 → 재제출 → 심사 목록에서 단일 Review 확인