### PR TITLE
fix(approval): 반려 후 재제출 시 Approval 중복 생성 버그 수정

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/approval/entity/Approval.java
+++ b/src/main/java/com/smartchain/platform/domain/approval/entity/Approval.java
@@ -81,4 +81,18 @@ public class Approval extends BaseTimeEntity {
     public boolean isApproved() {
         return this.status == ApprovalStatus.APPROVED;
     }
+
+    /**
+     * 반려 후 재제출 시 기존 Approval 재사용
+     * REJECTED 상태에서 WAITING으로 되돌리고 결재 정보 초기화
+     */
+    public void resubmit(User requester, String requestComment) {
+        this.status = ApprovalStatus.WAITING;
+        this.requester = requester;
+        this.requestComment = requestComment;
+        this.approver = null;
+        this.approverComment = null;
+        this.processedAt = null;
+        this.submittedToReviewerAt = null;
+    }
 }

--- a/src/main/java/com/smartchain/platform/domain/approval/repository/ApprovalRepository.java
+++ b/src/main/java/com/smartchain/platform/domain/approval/repository/ApprovalRepository.java
@@ -1,6 +1,7 @@
 package com.smartchain.platform.domain.approval.repository;
 
 import com.smartchain.platform.domain.approval.entity.Approval;
+import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.global.enums.ApprovalStatus;
@@ -12,9 +13,13 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ApprovalRepository extends JpaRepository<Approval, Long> {
+
+    // Diagnostic으로 Approval 조회 (재제출 시 기존 Approval 재사용)
+    Optional<Approval> findByDiagnostic(Diagnostic diagnostic);
 
     @Query("SELECT a FROM Approval a JOIN a.diagnostic d WHERE d.company = :company ORDER BY a.createdAt DESC")
     Page<Approval> findByCompanyOrderByCreatedAtDesc(@Param("company") Company company, Pageable pageable);

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -408,13 +408,23 @@ public class DiagnosticService {
 
         if ("ESG".equals(domainCode)) {
             // ESG: 결재자에게 결재 요청 (기안자 → 결재자 → 수신자)
-            Approval approval = Approval.builder()
-                    .diagnostic(diagnostic)
-                    .requester(currentUser)
-                    .requestComment(request.getSubmitComment())
-                    .deadline(diagnostic.getDeadline())
-                    .build();
-            Approval savedApproval = approvalRepository.save(approval);
+            // 기존 Approval이 있으면 재사용, 없으면 새로 생성 (반려 후 재제출 지원)
+            Approval savedApproval = approvalRepository.findByDiagnostic(diagnostic)
+                    .map(existingApproval -> {
+                        existingApproval.resubmit(currentUser, request.getSubmitComment());
+                        log.info("Reusing existing approval for resubmission: approvalId={}, diagnosticId={}",
+                                existingApproval.getApprovalId(), diagnostic.getDiagnosticId());
+                        return existingApproval;
+                    })
+                    .orElseGet(() -> {
+                        Approval newApproval = Approval.builder()
+                                .diagnostic(diagnostic)
+                                .requester(currentUser)
+                                .requestComment(request.getSubmitComment())
+                                .deadline(diagnostic.getDeadline())
+                                .build();
+                        return approvalRepository.save(newApproval);
+                    });
 
             log.info("Diagnostic submitted (ESG → Approval): diagnosticId={}, submittedBy={}, approvalId={}",
                     diagnosticId, userId, savedApproval.getApprovalId());


### PR DESCRIPTION
## Summary
- 결재자 반려 후 기안자 재제출 시 결재 목록에 Approval이 중복으로 나타나는 버그 수정
- 기존 REJECTED 상태의 Approval을 재사용하도록 로직 변경

## Changes
- `ApprovalRepository.findByDiagnostic()`: Diagnostic으로 Approval 조회
- `Approval.resubmit()`: 재제출 시 상태 초기화 메서드
- `DiagnosticService.submitDiagnostic()`: 기존 Approval 재사용

## Test plan
- [x] `./gradlew build` 전체 테스트 통과
- [ ] 결재 반려 → 재제출 → 결재 목록에서 단일 Approval 확인