### PR TITLE
fix(history): 결재/심사 시 DiagnosticHistory에 comment 저장

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
+++ b/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
@@ -3,6 +3,8 @@ package com.smartchain.platform.domain.approval.service;
 import com.smartchain.platform.domain.approval.entity.Approval;
 import com.smartchain.platform.domain.approval.repository.ApprovalRepository;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.domain.diagnostic.entity.DiagnosticHistory;
+import com.smartchain.platform.domain.diagnostic.repository.DiagnosticHistoryRepository;
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
@@ -52,6 +54,7 @@ public class ApprovalService {
     private final UserRepository userRepository;
     private final DomainRepository domainRepository;
     private final ReviewRepository reviewRepository;
+    private final DiagnosticHistoryRepository diagnosticHistoryRepository;
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
 
@@ -253,16 +256,18 @@ public class ApprovalService {
         String decision = request.getDecision().toUpperCase();
         String message;
         String diagnosticNewStatus;
+        Diagnostic diagnostic = approval.getDiagnostic();
+        String previousStatus = diagnostic.getStatus().name();
 
         if ("APPROVED".equals(decision)) {
             approval.approve(currentUser, request.getComment());
-            approval.getDiagnostic().markAsApproved();
+            diagnostic.markAsApproved();
             message = "결재가 완료되었습니다";
             diagnosticNewStatus = DiagnosticStatus.APPROVED.name();
             log.info("Approval approved: approvalId={}, approvedBy={}", approvalId, userId);
         } else if ("REJECTED".equals(decision)) {
             approval.reject(currentUser, request.getComment());
-            approval.getDiagnostic().markAsReturned();
+            diagnostic.markAsReturned();
             message = "결재가 반려되었습니다";
             diagnosticNewStatus = DiagnosticStatus.RETURNED.name();
             log.info("Approval rejected: approvalId={}, rejectedBy={}, comment={}",
@@ -270,6 +275,17 @@ public class ApprovalService {
         } else {
             throw new CustomException(ErrorCode.INVALID_DECISION);
         }
+
+        // DiagnosticHistory 저장
+        DiagnosticHistory history = DiagnosticHistory.builder()
+                .diagnostic(diagnostic)
+                .actor(currentUser)
+                .action("APPROVED".equals(decision) ? "APPROVAL_APPROVED" : "APPROVAL_REJECTED")
+                .previousStatus(previousStatus)
+                .newStatus(diagnosticNewStatus)
+                .comment(request.getComment())
+                .build();
+        diagnosticHistoryRepository.save(history);
 
         ProcessedByDto processedByDto = ProcessedByDto.builder()
                 .userId(currentUser.getUserId())

--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -2,6 +2,9 @@ package com.smartchain.platform.domain.review.service;
 
 import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
 import com.smartchain.platform.domain.ai.repository.AiAnalysisResultRepository;
+import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.domain.diagnostic.entity.DiagnosticHistory;
+import com.smartchain.platform.domain.diagnostic.repository.DiagnosticHistoryRepository;
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
@@ -47,6 +50,7 @@ public class ReviewService {
     private final CompanyRepository companyRepository;
     private final DomainRepository domainRepository;
     private final AiAnalysisResultRepository aiAnalysisResultRepository;
+    private final DiagnosticHistoryRepository diagnosticHistoryRepository;
 
     private static final Map<String, String> RISK_LEVEL_LABEL_MAP = Map.of(
             "HIGH", "고위험군",
@@ -325,6 +329,9 @@ public class ReviewService {
         String decision = request.getDecision().toUpperCase();
         String message;
         String nextStep;
+        Diagnostic diagnostic = review.getDiagnostic();
+        String previousStatus = diagnostic.getStatus().name();
+        String newStatus;
 
         if ("APPROVED".equals(decision)) {
             String commentE = null;
@@ -339,12 +346,13 @@ public class ReviewService {
             // REVISION_REQUIRED 상태에서 재승인하는 경우
             if (review.isRevisionRequired()) {
                 // 기안 상태를 REVIEWING으로 되돌린 후 완료 처리
-                review.getDiagnostic().markAsReviewing();
+                diagnostic.markAsReviewing();
                 log.info("Review re-approved from REVISION_REQUIRED: reviewId={}, reapprovedBy={}", reviewId, userId);
             }
 
             review.approve(currentUser, request.getComment(), commentE, commentS, commentG);
-            review.getDiagnostic().complete();
+            diagnostic.complete();
+            newStatus = "COMPLETED";
             message = "심사가 승인되었습니다";
             nextStep = "보고서 발행이 가능합니다";
             log.info("Review approved: reviewId={}, approvedBy={}", reviewId, userId);
@@ -354,7 +362,8 @@ public class ReviewService {
                 throw new CustomException(ErrorCode.ALREADY_PROCESSED_REVIEW);
             }
             review.requestRevision(currentUser, request.getComment());
-            review.getDiagnostic().returnForRevision();
+            diagnostic.returnForRevision();
+            newStatus = "RETURNED";
             message = "보완 요청이 완료되었습니다";
             nextStep = "협력사에게 보완 요청이 전달됩니다";
             log.info("Review revision required: reviewId={}, requestedBy={}, comment={}",
@@ -362,6 +371,17 @@ public class ReviewService {
         } else {
             throw new CustomException(ErrorCode.INVALID_DECISION);
         }
+
+        // DiagnosticHistory 저장
+        DiagnosticHistory history = DiagnosticHistory.builder()
+                .diagnostic(diagnostic)
+                .actor(currentUser)
+                .action("APPROVED".equals(decision) ? "REVIEW_APPROVED" : "REVIEW_REVISION_REQUIRED")
+                .previousStatus(previousStatus)
+                .newStatus(newStatus)
+                .comment(request.getComment())
+                .build();
+        diagnosticHistoryRepository.save(history);
 
         ProcessedByDto processedByDto = ProcessedByDto.builder()
                 .userId(currentUser.getUserId())

--- a/src/test/java/com/smartchain/platform/domain/approval/service/ApprovalServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/approval/service/ApprovalServiceTest.java
@@ -3,6 +3,7 @@ package com.smartchain.platform.domain.approval.service;
 import com.smartchain.platform.domain.approval.entity.Approval;
 import com.smartchain.platform.domain.approval.repository.ApprovalRepository;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.domain.diagnostic.repository.DiagnosticHistoryRepository;
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
@@ -66,6 +67,9 @@ class ApprovalServiceTest {
     private ReviewRepository reviewRepository;
 
     @Mock
+    private DiagnosticHistoryRepository diagnosticHistoryRepository;
+
+    @Mock
     private User approverUser;
 
     @Mock
@@ -113,6 +117,7 @@ class ApprovalServiceTest {
         lenient().when(testDiagnostic.getQualitativeProgress()).thenReturn(100);
         lenient().when(testDiagnostic.getQuantitativeProgress()).thenReturn(100);
         lenient().when(testDiagnostic.getOverallScore()).thenReturn(72);
+        lenient().when(testDiagnostic.getStatus()).thenReturn(DiagnosticStatus.SUBMITTED);
 
         lenient().when(testApproval.getApprovalId()).thenReturn(1L);
         lenient().when(testApproval.getDiagnostic()).thenReturn(testDiagnostic);
@@ -597,6 +602,7 @@ class ApprovalServiceTest {
             Diagnostic diagnosticWithDomain = mock(Diagnostic.class);
             when(diagnosticWithDomain.getDomain()).thenReturn(esgDomain);
             when(diagnosticWithDomain.getCompany()).thenReturn(testCompany);
+            when(diagnosticWithDomain.getStatus()).thenReturn(DiagnosticStatus.SUBMITTED);
 
             Approval approvalWithDomain = mock(Approval.class);
             lenient().when(approvalWithDomain.getApprovalId()).thenReturn(5L);

--- a/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticServiceTest.java
@@ -887,6 +887,52 @@ class DiagnosticServiceTest {
             assertThat(response.getHistory().get(0).getAction()).isEqualTo("CREATED");
             assertThat(response.getHistory().get(0).getNewStatus()).isEqualTo("WRITING");
         }
+
+        @Test
+        @DisplayName("기안 이력 조회 시 comment가 응답에 포함된다")
+        void getDiagnosticHistory_includesComment() {
+            // given
+            Diagnostic diagnostic = mock(Diagnostic.class);
+            when(diagnostic.getDrafterId()).thenReturn(1L);
+
+            DiagnosticHistory history1 = mock(DiagnosticHistory.class);
+            when(history1.getHistoryId()).thenReturn(1L);
+            when(history1.getAction()).thenReturn("CREATED");
+            when(history1.getPreviousStatus()).thenReturn(null);
+            when(history1.getNewStatus()).thenReturn("WRITING");
+            when(history1.getComment()).thenReturn(null);
+            when(history1.getActor()).thenReturn(drafterUser);
+            when(history1.getCreatedAt()).thenReturn(LocalDateTime.now().minusHours(2));
+
+            DiagnosticHistory history2 = mock(DiagnosticHistory.class);
+            when(history2.getHistoryId()).thenReturn(2L);
+            when(history2.getAction()).thenReturn("SUBMITTED");
+            when(history2.getPreviousStatus()).thenReturn("WRITING");
+            when(history2.getNewStatus()).thenReturn("SUBMITTED");
+            when(history2.getComment()).thenReturn("검토 부탁드립니다");
+            when(history2.getActor()).thenReturn(drafterUser);
+            when(history2.getCreatedAt()).thenReturn(LocalDateTime.now().minusHours(1));
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(drafterUser));
+            given(diagnosticRepository.findById(1L)).willReturn(Optional.of(diagnostic));
+            given(diagnosticHistoryRepository.findByDiagnosticOrderByCreatedAtDesc(diagnostic))
+                    .willReturn(List.of(history2, history1));
+
+            // when
+            DiagnosticHistoryResponse response = diagnosticService.getDiagnosticHistory(1L, 1L);
+
+            // then
+            assertThat(response.getDiagnosticId()).isEqualTo(1L);
+            assertThat(response.getHistory()).hasSize(2);
+
+            // 첫 번째 이력 (SUBMITTED) - comment 있음
+            assertThat(response.getHistory().get(0).getAction()).isEqualTo("SUBMITTED");
+            assertThat(response.getHistory().get(0).getComment()).isEqualTo("검토 부탁드립니다");
+
+            // 두 번째 이력 (CREATED) - comment 없음
+            assertThat(response.getHistory().get(1).getAction()).isEqualTo("CREATED");
+            assertThat(response.getHistory().get(1).getComment()).isNull();
+        }
     }
 
     @Nested

--- a/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/review/service/ReviewServiceTest.java
@@ -3,6 +3,7 @@ package com.smartchain.platform.domain.review.service;
 import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
 import com.smartchain.platform.domain.ai.repository.AiAnalysisResultRepository;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
+import com.smartchain.platform.domain.diagnostic.repository.DiagnosticHistoryRepository;
 import com.smartchain.platform.domain.review.entity.Review;
 import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
@@ -20,6 +21,7 @@ import com.smartchain.platform.dto.review.decision.ReviewDecisionResponse;
 import com.smartchain.platform.dto.review.decision.RevisionDraftResponse;
 import com.smartchain.platform.dto.review.detail.ReviewDetailResponse;
 import com.smartchain.platform.dto.review.list.ReviewListResponse;
+import com.smartchain.platform.global.enums.DiagnosticStatus;
 import com.smartchain.platform.global.enums.ReviewStatus;
 import com.smartchain.platform.global.enums.RiskLevel;
 import com.smartchain.platform.global.error.CustomException;
@@ -68,6 +70,9 @@ class ReviewServiceTest {
 
     @Mock
     private AiAnalysisResultRepository aiAnalysisResultRepository;
+
+    @Mock
+    private DiagnosticHistoryRepository diagnosticHistoryRepository;
 
     @Mock
     private User reviewerUser;
@@ -159,6 +164,7 @@ class ReviewServiceTest {
         lenient().when(testDiagnostic.getDiagnosticCode()).thenReturn("DG-2026-00001");
         lenient().when(testDiagnostic.getTitle()).thenReturn("2026년 상반기 ESG 자가진단");
         lenient().when(testDiagnostic.getCompany()).thenReturn(testCompany);
+        lenient().when(testDiagnostic.getStatus()).thenReturn(DiagnosticStatus.REVIEWING);
 
         lenient().when(testReview.getReviewId()).thenReturn(1L);
         lenient().when(testReview.getDiagnostic()).thenReturn(testDiagnostic);
@@ -713,6 +719,7 @@ class ReviewServiceTest {
             // given
             Review esgReview = mock(Review.class);
             Diagnostic esgDiagnostic = mock(Diagnostic.class);
+            lenient().when(esgDiagnostic.getStatus()).thenReturn(DiagnosticStatus.REVIEWING);
             lenient().when(esgReview.getDomain()).thenReturn(esgDomain);
             lenient().when(esgReview.isReviewing()).thenReturn(true);
             lenient().when(esgReview.getReviewId()).thenReturn(20L);
@@ -772,6 +779,7 @@ class ReviewServiceTest {
             // given
             Review safetyReview = mock(Review.class);
             Diagnostic safetyDiagnostic = mock(Diagnostic.class);
+            lenient().when(safetyDiagnostic.getStatus()).thenReturn(DiagnosticStatus.REVIEWING);
             lenient().when(safetyReview.getDomain()).thenReturn(safetyDomain);
             lenient().when(safetyReview.isReviewing()).thenReturn(true);
             lenient().when(safetyReview.getReviewId()).thenReturn(30L);


### PR DESCRIPTION
## Summary
- 결재/심사 반려 시 DiagnosticHistory에 comment가 저장되지 않던 버그 수정
- `/api/v1/diagnostics/{id}/history` 응답에서 반려 comment 확인 가능

## Changes
- `ApprovalService.processApproval()`: 결재 승인/반려 시 DiagnosticHistory 저장
- `ReviewService.processReview()`: 심사 승인/반려 시 DiagnosticHistory 저장
- 테스트 mock 설정 추가

## Test plan
- [x] `./gradlew test` 전체 테스트 통과 (436 tests)
- [ ] 결재 반려 → 기안 이력 조회 → comment 확인
- [ ] 심사 반려 → 기안 이력 조회 → comment 확인