### PR TITLE
fix(ai): preview/submit 간헐적 500 에러 수정 (#209)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,31 @@
 # Claude Code Learnings
 
+## 2026-02-08: AI Preview 간헐적 500 에러 및 파싱 미완료 파일 처리
+
+### 원인
+- `AiAnalysisService.preview()`에서 `diagnostic.getPeriodStartDate().format()`를 호출하는데, `periodStartDate`/`periodEndDate`가 nullable 컬럼이라 NPE 발생 → catch-all handler가 500 + `S001` 반환
+- `toFileInfo()`에서 `EvidenceFile.parsingStatus`를 검증하지 않아 파싱 미완료(WAITING/PROCESSING) 파일도 AI 서비스로 전달
+- 프론트에서 AI001~AI006만 처리하므로 `S001`, `S003` 등 코드가 "알 수 없는 오류"로 표시
+
+### 해결
+- `ErrorCode`에 `AI_FILE_NOT_READY(AI009)`, `AI_MISSING_PERIOD_DATES(AI010)` 추가
+- `preview()`/`submit()`에 `periodStartDate`/`periodEndDate` null 체크 추가
+- `toFileInfo()`에 `parsingStatus != SUCCESS` 검증 추가
+- `submit()`에도 동일한 파싱 상태 일괄 검증 추가
+
+### 재발방지
+- nullable 필드를 참조할 때는 반드시 null 체크 후 접근
+- 비동기 처리(파일 파싱) 결과에 의존하는 API는 상태 검증 필수
+
+### 검증방법
+- `./gradlew test --tests "AiAnalysisServiceTest"` — 파싱 미완료 테스트 케이스 포함 전체 통과
+- 프론트에서 파일 업로드 직후 Add 클릭 시 AI009 에러 코드 반환 확인
+
+### 관련커밋
+- (커밋 전)
+
+---
+
 ## 2026-02-06: 반려 후 재제출 시 Review 중복 생성 버그 수정
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
@@ -11,6 +11,7 @@ import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository
 import com.smartchain.platform.domain.evidence.entity.EvidenceFile;
 import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository;
 import com.smartchain.platform.dto.ai.run.*;
+import com.smartchain.platform.global.enums.ParsingStatus;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
 import org.slf4j.Logger;
@@ -83,6 +84,10 @@ public class AiAnalysisService {
             .map(AiAnalysisResult::getPackageId)
             .orElse(null);
 
+        if (diagnostic.getPeriodStartDate() == null || diagnostic.getPeriodEndDate() == null) {
+            throw new CustomException(ErrorCode.AI_MISSING_PERIOD_DATES);
+        }
+
         RunPreviewRequest request = new RunPreviewRequest(
             domainCode.toLowerCase(),
             diagnostic.getPeriodStartDate().format(DATE_FORMATTER),
@@ -102,10 +107,24 @@ public class AiAnalysisService {
         Diagnostic diagnostic = getDiagnostic(diagnosticId);
         String domainCode = getDomainCode(diagnostic);
 
+        if (diagnostic.getPeriodStartDate() == null || diagnostic.getPeriodEndDate() == null) {
+            throw new CustomException(ErrorCode.AI_MISSING_PERIOD_DATES);
+        }
+
         // 증빙 파일 목록 조회
         List<EvidenceFile> evidenceFiles = evidenceFileRepository.findByDiagnosticId(diagnosticId);
         if (evidenceFiles.isEmpty()) {
             throw new CustomException(ErrorCode.DIAGNOSTIC_MISSING_EVIDENCE);
+        }
+
+        // 파싱 미완료 파일 검증
+        List<Long> notReadyFileIds = evidenceFiles.stream()
+            .filter(ef -> ef.getParsingStatus() != ParsingStatus.SUCCESS)
+            .map(EvidenceFile::getResultFileId)
+            .toList();
+        if (!notReadyFileIds.isEmpty()) {
+            log.warn("파일 파싱 미완료 - diagnosticId: {}, fileIds: {}", diagnosticId, notReadyFileIds);
+            throw new CustomException(ErrorCode.AI_FILE_NOT_READY);
         }
 
         // FileInfo 변환 (절대 경로로 변환)
@@ -256,6 +275,12 @@ public class AiAnalysisService {
     private FileInfo toFileInfo(Long fileId) {
         EvidenceFile ef = evidenceFileRepository.findById(fileId)
             .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
+
+        if (ef.getParsingStatus() != ParsingStatus.SUCCESS) {
+            log.warn("파일 파싱 미완료 - fileId: {}, status: {}", fileId, ef.getParsingStatus());
+            throw new CustomException(ErrorCode.AI_FILE_NOT_READY);
+        }
+
         return new FileInfo(
             ef.getResultFileId().toString(),
             ef.getFilePath(),

--- a/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
+++ b/src/main/java/com/smartchain/platform/global/error/ErrorCode.java
@@ -105,6 +105,8 @@ public enum ErrorCode {
     AI_INVALID_RISK_LEVEL(HttpStatus.BAD_GATEWAY, "AI006", "AI 서비스의 riskLevel 값이 유효하지 않습니다"),
     AI_BAD_REQUEST(HttpStatus.BAD_REQUEST, "AI007", "AI 서비스 요청 파라미터가 올바르지 않습니다"),
     AI_MISSING_REQUIRED_SLOTS(HttpStatus.UNPROCESSABLE_ENTITY, "AI008", "필수 슬롯에 해당하는 파일이 제출되지 않았습니다"),
+    AI_FILE_NOT_READY(HttpStatus.CONFLICT, "AI009", "파일 파싱이 완료되지 않았습니다. 잠시 후 다시 시도해주세요"),
+    AI_MISSING_PERIOD_DATES(HttpStatus.UNPROCESSABLE_ENTITY, "AI010", "진단 기간(시작일/종료일)이 설정되지 않았습니다"),
 
     // AI Chat Service
     AI_CHAT_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT001", "AI 채팅 서비스 오류가 발생했습니다"),

--- a/src/test/java/com/smartchain/platform/domain/ai/service/AiAnalysisServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/ai/service/AiAnalysisServiceTest.java
@@ -12,6 +12,7 @@ import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.dto.ai.run.*;
+import com.smartchain.platform.global.enums.ParsingStatus;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -267,6 +268,28 @@ class AiAnalysisServiceTest {
         }
 
         @Test
+        @DisplayName("파일 파싱이 완료되지 않으면 AI_FILE_NOT_READY 에러를 발생시킨다")
+        void preview_fileNotReady_throwsException() {
+            // given
+            Long diagnosticId = 1L;
+            Diagnostic diagnostic = createTestDiagnostic(diagnosticId);
+            EvidenceFile evidenceFile = createTestEvidenceFileWithStatus(1L, "전기사용량.xlsx", ParsingStatus.PROCESSING);
+
+            when(diagnosticRepository.findById(diagnosticId)).thenReturn(Optional.of(diagnostic));
+            when(evidenceFileRepository.findById(1L)).thenReturn(Optional.of(evidenceFile));
+
+            // when & then
+            assertThatThrownBy(() -> aiAnalysisService.preview(diagnosticId, List.of(1L)))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> {
+                    CustomException customEx = (CustomException) ex;
+                    assertThat(customEx.getErrorCode()).isEqualTo(ErrorCode.AI_FILE_NOT_READY);
+                });
+
+            verify(aiRunApiClient, never()).previewSync(any());
+        }
+
+        @Test
         @DisplayName("정상적인 preview 호출 시 AI 응답을 반환한다")
         void preview_success_returnsResponse() {
             // given
@@ -424,6 +447,18 @@ class AiAnalysisServiceTest {
             .originalFileName(fileName)
             .build();
         ReflectionTestUtils.setField(evidenceFile, "resultFileId", id);
+        // 파싱 완료 상태로 설정 (preview/submit 시 파싱 상태 검증 통과)
+        evidenceFile.completeParsing(null, null, null);
+        return evidenceFile;
+    }
+
+    private EvidenceFile createTestEvidenceFileWithStatus(Long id, String fileName, ParsingStatus status) {
+        EvidenceFile evidenceFile = EvidenceFile.builder()
+            .filePath("/path/to/" + fileName)
+            .originalFileName(fileName)
+            .build();
+        ReflectionTestUtils.setField(evidenceFile, "resultFileId", id);
+        ReflectionTestUtils.setField(evidenceFile, "parsingStatus", status);
         return evidenceFile;
     }
 


### PR DESCRIPTION
## 변경 요약

파일 업로드 후 Add 버튼 클릭 시 간헐적으로 "알 수 없는 오류"가 발생하는 문제를 수정합니다.

- `AiAnalysisService.preview()`/`submit()`에서 nullable인 `periodStartDate`/`periodEndDate`에 대한 null 체크 추가 (NPE → 500 방지)
- `toFileInfo()`에 `EvidenceFile.parsingStatus` 검증 추가 (파싱 미완료 파일이 AI 서비스로 전달되는 것 방지)
- `submit()`에도 동일한 파싱 상태 일괄 검증 추가
- `ErrorCode`에 `AI_FILE_NOT_READY(AI009, 409)`, `AI_MISSING_PERIOD_DATES(AI010, 422)` 추가
- 파싱 미완료 시나리오 테스트 케이스 추가

## 관련 이슈

- Closes #209

## 테스트 방법

```bash
# 단위 테스트 실행
./gradlew test --tests "AiAnalysisServiceTest"

# 전체 테스트 (ChatServiceTest 1건 기존 실패 - 본 PR 무관)
./gradlew test
```

**수동 테스트:**
1. 파일 업로드 직후(파싱 완료 전) Add 버튼 클릭 → `AI009` 에러 코드 + "파일 파싱이 완료되지 않았습니다" 메시지 반환 확인
2. `periodStartDate`/`periodEndDate`가 null인 진단에서 preview 호출 → `AI010` 에러 코드 반환 확인
3. 파싱 완료된 파일로 preview 호출 → 정상 동작 확인

## 명세 준수 체크

- [x] `ErrorResponse` 응답에 `code` 필드 포함 (AI009, AI010)
- [x] 기존 AI001~AI008 에러 코드 동작에 영향 없음
- [x] preview/submit 정상 흐름 변경 없음 (파싱 완료 파일 + period dates 있는 경우)
- [x] `BaseTimeEntity` 상속 패턴 준수
- [x] `CustomException` + `ErrorCode` 에러 처리 패턴 준수

## 리뷰 포인트

1. **AI009 HTTP 상태코드**: `409 Conflict`로 설정했는데, `425 Too Early`나 `422`가 더 적절한지 의견 부탁드립니다
2. **submit 파싱 검증 위치**: 증빙 파일 목록 조회 직후에 일괄 검증하는 방식 vs 개별 FileInfo 변환 시 검증 - 현재는 일괄 검증으로 구현 (불필요한 쿼리 방지)
3. **파싱 FAILED 파일 처리**: 현재 `parsingStatus != SUCCESS`이면 모두 AI009로 처리합니다. FAILED인 경우 별도 에러 코드가 필요한지?

## TODO / 프론트팀 전달 사항

- [ ] 프론트엔드 에러 코드 분기 로직에 `AI009`, `AI010` 추가 필요
- [ ] `AI009` 수신 시 "파일 처리 중입니다. 잠시 후 다시 시도해주세요" UX 안내 추가
- [ ] 프론트에서 처리 가능한 에러 코드 범위를 `AI001~AI010`으로 확장 필요
- [ ] 파일 업로드 후 파싱 완료 여부를 폴링하는 UX 개선 검토 (선택)