### PR TITLE
fix(ai): preview 다량 파일 요청 시 무반응 해결 - 타임아웃 분리 (#211)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,30 @@
 # Claude Code Learnings
 
+## 2026-02-08: AI Preview 다량 파일 시 무반응(타임아웃) 문제
+
+### 원인
+- `AiRunApiClient.previewSync()`가 `.block()`으로 서블릿 스레드를 블로킹
+- preview와 submit이 동일한 타임아웃(180초) × 재시도(3회) 설정을 공유
+- 최악의 경우 ~727초(12분) 동안 서블릿 스레드가 점유되어 프론트에서 "아무 반응 없음"
+
+### 해결
+- `AiRunApiConfig`에 preview 전용 설정 분리: `previewTimeoutSeconds(30)`, `previewMaxRetry(1)`
+- `AiRunApiClient.preview()`에 `Mono.timeout(Duration.ofSeconds(30))` 추가
+- 최악의 경우 ~62초로 단축, 타임아웃 시 AI001 에러 코드로 명확한 응답 반환
+
+### 재발방지
+- 동기 블로킹(`.block()`) 사용 시 반드시 용도별 타임아웃 분리
+- preview(경량 조회)와 submit(중량 처리)은 성격이 다르므로 설정을 분리할 것
+
+### 검증방법
+- `./gradlew test --tests "AiAnalysisServiceTest"` 전체 통과
+- preview 요청 시 30초 내 응답 또는 타임아웃 에러 반환 확인
+
+### 관련커밋
+- (커밋 전)
+
+---
+
 ## 2026-02-08: AI Preview 간헐적 500 에러 및 파싱 미완료 파일 처리
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/ai/client/AiRunApiClient.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/client/AiRunApiClient.java
@@ -36,6 +36,8 @@ public class AiRunApiClient {
 
     private final WebClient webClient;
     private final int maxRetry;
+    private final int previewTimeoutSeconds;
+    private final int previewMaxRetry;
 
     public AiRunApiClient(
         @Qualifier("aiRunApiWebClient") WebClient webClient,
@@ -43,6 +45,8 @@ public class AiRunApiClient {
     ) {
         this.webClient = webClient;
         this.maxRetry = config.getMaxRetry();
+        this.previewTimeoutSeconds = config.getPreviewTimeoutSeconds();
+        this.previewMaxRetry = config.getPreviewMaxRetry();
     }
 
     /**
@@ -60,7 +64,8 @@ public class AiRunApiClient {
             .bodyValue(request)
             .retrieve()
             .bodyToMono(RunPreviewResponse.class)
-            .retryWhen(Retry.backoff(maxRetry, Duration.ofSeconds(1))
+            .timeout(Duration.ofSeconds(previewTimeoutSeconds))
+            .retryWhen(Retry.backoff(previewMaxRetry, Duration.ofSeconds(1))
                 .filter(this::isRetryableError)
                 .onRetryExhaustedThrow((spec, signal) ->
                     new CustomException(ErrorCode.AI_SERVICE_UNAVAILABLE)))

--- a/src/main/java/com/smartchain/platform/domain/ai/config/AiRunApiConfig.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/config/AiRunApiConfig.java
@@ -19,6 +19,8 @@ public class AiRunApiConfig {
     private String url = "http://localhost:8000";
     private int timeoutSeconds = 180;
     private int maxRetry = 3;
+    private int previewTimeoutSeconds = 30;
+    private int previewMaxRetry = 1;
 
     @Bean
     public WebClient aiRunApiWebClient() {
@@ -54,5 +56,21 @@ public class AiRunApiConfig {
 
     public void setMaxRetry(int maxRetry) {
         this.maxRetry = maxRetry;
+    }
+
+    public int getPreviewTimeoutSeconds() {
+        return previewTimeoutSeconds;
+    }
+
+    public void setPreviewTimeoutSeconds(int previewTimeoutSeconds) {
+        this.previewTimeoutSeconds = previewTimeoutSeconds;
+    }
+
+    public int getPreviewMaxRetry() {
+        return previewMaxRetry;
+    }
+
+    public void setPreviewMaxRetry(int previewMaxRetry) {
+        this.previewMaxRetry = previewMaxRetry;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -78,6 +78,8 @@ ai:
     url: http://127.0.0.1:8000
     timeout-seconds: 180
     max-retry: 3
+    preview-timeout-seconds: 30
+    preview-max-retry: 1
   chat:
     base-url: http://127.0.0.1:8001
     admin-api-key: ${AI_CHAT_ADMIN_KEY:test-key}


### PR DESCRIPTION
## 변경 요약

파일이 다량으로 들어갔을 때 Add 버튼 클릭 시 장시간 아무 반응이 없는 문제를 수정합니다.

- `AiRunApiConfig`에 preview 전용 타임아웃(30초)/재시도(1회) 설정 분리
- `AiRunApiClient.preview()`에 `Mono.timeout(Duration.ofSeconds(30))` 적용
- `application.yaml`에 `preview-timeout-seconds: 30`, `preview-max-retry: 1` 추가
- submit은 기존 설정 유지 (180초/3회 - 전체 검증이므로 긴 타임아웃 필요)

**Before:** preview 최악 대기 ~727초(12분) → 프론트에서 무반응 상태
**After:** preview 최악 대기 ~62초 → 타임아웃 시 AI001 에러 코드로 명확한 응답 반환

## 관련 이슈

- Closes #211
- Related: #209 (간헐적 500 에러 수정)

## 테스트 방법

```bash
# 단위 테스트
./gradlew test --tests "AiAnalysisServiceTest"

# 전체 테스트 (ChatServiceTest 1건 기존 실패 - 본 PR 무관)
./gradlew test
```

**수동 테스트:**
1. 다량 파일(5개 이상) 업로드 후 Add 클릭 → 30초 내 응답 또는 에러 반환 확인
2. AI 서비스 중단 상태에서 preview 호출 → ~62초 내 AI001 에러 반환 확인
3. submit 호출 → 기존과 동일하게 180초 타임아웃 동작 확인

## 명세 준수 체크

- [x] preview/submit 분리 설정 - preview는 경량 조회, submit은 중량 처리
- [x] 기존 submit 타임아웃/재시도 설정 변경 없음
- [x] `Mono.timeout()`이 던지는 `TimeoutException`은 기존 `isNetworkOrTimeoutError()`에서 처리됨
- [x] 타임아웃 → 재시도 소진 → `AI_SERVICE_UNAVAILABLE(AI001)` 에러 코드 정상 반환
- [x] `application.yaml` 설정으로 운영 환경별 튜닝 가능

## 리뷰 포인트

1. **preview 타임아웃 30초**: 슬롯 추정은 경량 작업이므로 30초면 충분한지, 또는 파일 수에 따라 더 필요한지?
2. **preview 재시도 1회**: 재시도 없이 바로 에러를 반환하는 게 나을지? (사용자가 직접 재시도 가능)
3. **submit 설정 유지**: submit도 180초가 과도한지 검토 필요 여부

## TODO / 질문

- [ ] 운영 환경에서 AI 서비스의 실제 preview 응답 시간 모니터링 후 타임아웃 값 튜닝
- [ ] 프론트에서 Add 버튼 클릭 시 로딩 스피너 추가 권장 (UX 개선)
- [ ] 장기적으로 preview도 비동기(submit처럼) 전환 검토 가능