### PR TITLE
fix(approval): 결재 상세 API requester.maskedName 누락 수정

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,26 @@
 # Claude Code Learnings
 
+## 2026-02-09: 결재 상세 API에서 기안자 maskedName 누락
+
+### 원인
+- 목록 조회(`RequesterDto`)에는 `maskedName` 필드가 있으나 상세 조회(`RequesterDetailDto`)에는 누락
+- 목록/상세가 서로 다른 DTO를 사용하면서 필드 불일치 발생
+- 서비스에서 `RequesterDetailDto` 빌드 시 `maskedName` 설정 코드 누락
+
+### 해결
+- `RequesterDetailDto`에 `maskedName` 필드 추가
+- `ApprovalService.getApprovalDetail()`에서 `NameMaskingUtil.mask()` 호출하여 값 설정
+
+### 재발방지
+- 목록/상세 DTO 간 공통 필드(userId, name, maskedName) 불일치 여부 점검
+- 새 DTO 필드 추가 시 프론트엔드가 사용하는 필드 목록과 대조
+
+### 검증방법
+- `./gradlew test --tests "ApprovalServiceTest"` 전체 통과
+- 상세 조회 테스트에서 `maskedName`, `email` 필드 검증 추가
+
+---
+
 ## 2026-02-08: AI Preview 다량 파일 시 무반응(타임아웃) 문제
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
+++ b/src/main/java/com/smartchain/platform/domain/approval/service/ApprovalService.java
@@ -205,6 +205,7 @@ public class ApprovalService {
         RequesterDetailDto requesterDto = RequesterDetailDto.builder()
                 .userId(approval.getRequester().getUserId())
                 .name(approval.getRequester().getName())
+                .maskedName(NameMaskingUtil.mask(approval.getRequester().getName()))
                 .email(approval.getRequester().getEmail())
                 .build();
 

--- a/src/main/java/com/smartchain/platform/dto/approval/detail/RequesterDetailDto.java
+++ b/src/main/java/com/smartchain/platform/dto/approval/detail/RequesterDetailDto.java
@@ -12,5 +12,6 @@ import lombok.NoArgsConstructor;
 public class RequesterDetailDto {
     private Long userId;
     private String name;
+    private String maskedName;
     private String email;
 }

--- a/src/test/java/com/smartchain/platform/domain/approval/service/ApprovalServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/approval/service/ApprovalServiceTest.java
@@ -299,6 +299,9 @@ class ApprovalServiceTest {
             assertThat(response.getDiagnostic().getDiagnosticId()).isEqualTo(100L);
             assertThat(response.getDiagnostic().getDiagnosticCode()).isEqualTo("DG-2026-00001");
             assertThat(response.getRequester().getUserId()).isEqualTo(2L);
+            assertThat(response.getRequester().getName()).isEqualTo("기안자");
+            assertThat(response.getRequester().getMaskedName()).isEqualTo("기*자");
+            assertThat(response.getRequester().getEmail()).isEqualTo("drafter@test.com");
             assertThat(response.getStatus()).isEqualTo("WAITING");
         }
 


### PR DESCRIPTION
## 변경 요약
결재 상세 조회(`GET /api/v1/approvals/{id}`) 응답에서 `requester.maskedName`이 누락되어 프론트엔드에서 기안자 이름이 `-`로 표시되던 버그 수정

- `RequesterDetailDto`에 `maskedName` 필드 추가
- `ApprovalService.getApprovalDetail()`에서 `NameMaskingUtil.mask()` 호출 추가
- 테스트에 `maskedName`, `name`, `email` 검증 추가

## 관련 이슈
- Closes #213

## 테스트 방법
```bash
./gradlew test --tests "ApprovalServiceTest"
```
- `결재 상세 조회 성공` 테스트에서 `requester.maskedName == "기*자"` 검증 확인

## 명세 준수 체크
- [x] 목록 응답(`RequesterDto`): userId, name, maskedName
- [x] 상세 응답(`RequesterDetailDto`): userId, name, maskedName, email
- [x] 기존 필드(userId, name, email) 변경 없음 — 하위 호환 유지
- [x] `NameMaskingUtil.mask()` 동일 유틸 사용 (목록과 동일 마스킹 로직)

## 리뷰 포인트
1. `RequesterDetailDto`에 `maskedName`만 추가 — 기존 필드 영향 없음
2. 서비스 변경은 `.maskedName(NameMaskingUtil.mask(...))` 1줄 추가

## TODO / 질문
- [ ] API 명세 문서(`API_CONTRACT_SSOT.md`)에 상세 응답 requester 스키마 반영 필요 여부 확인
- [ ] 프론트엔드 확인: 배포 후 결재 상세 페이지에서 기안자 마스킹 이름 정상 표시 확인