### PR TITLE
refactor: application.yaml 프로필 구조 정리 및 prod 프로필 추가

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,10 @@
       "Bash(git fetch:*)",
       "Bash(git merge:*)",
       "Bash(gh issue view:*)",
-      "Bash(find:*)"
+      "Bash(find:*)",
+      "Bash(git log:*)",
+      "Bash(grep:*)",
+      "Bash(python3:*)"
     ]
   }
 }

--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1821,3 +1821,90 @@ src/test/java/.../domain/review/service/ReviewServiceTest.java (AI 분석 결과
 src/main/java/.../domain/approval/service/ApprovalService.java (ReviewRepository 추가, Review 생성 로직)
 src/test/java/.../domain/approval/service/ApprovalServiceTest.java (+2 테스트 케이스)
 ```
+
+## 2026-02-09: QA 이슈 일괄 수정 (BE-02, BE-03, BE-05, BE-07)
+
+### BE-02: 보완 요청(REVISION_REQUIRED) 시 서버 에러
+
+#### 원인
+- `ReviewService.processReview()`에서 decision 종류와 무관하게 `validateCategoryComments()` 호출
+- SAFETY/COMPLIANCE 도메인은 ESG 카테고리 키(E,S,G)가 없어 `allowedKeys`가 빈 리스트
+- FE에서 categoryComments가 포함된 REVISION_REQUIRED 요청 시 `INVALID_CATEGORY_FOR_DOMAIN` (RV004) 에러 발생
+
+#### 해결
+- categoryComments 검증을 APPROVED decision일 때만 수행하도록 분기 추가
+- REVISION_REQUIRED는 카테고리별 코멘트가 불필요하므로 검증 스킵
+
+#### 재발방지
+- decision별 검증 로직은 decision 분기 전이 아닌 해당 분기 내에서 수행
+
+#### 검증방법
+```bash
+./gradlew test --tests "ReviewServiceTest"
+```
+
+### BE-03: 결재 상세 화면에서 기안자 이름 미표시
+
+#### 원인
+- `RequesterDetailDto`에 `maskedName` 필드 누락 (목록용 `RequesterDto`에만 존재)
+- `ApprovalService.getApprovalDetail()`에서 `NameMaskingUtil.mask()` 미호출
+- FE에서 `requester.maskedName`을 참조하나 null → '-' 표시
+
+#### 해결
+- `RequesterDetailDto`에 `maskedName` 필드 추가
+- `ApprovalService`에서 마스킹 유틸 적용
+
+#### 재발방지
+- 신규 DTO 생성 시 기존 유사 DTO와 필드 비교 체크리스트 확인
+
+#### 검증방법
+```bash
+./gradlew test --tests "ApprovalServiceTest"
+```
+
+### BE-05: 2025 하반기 캠페인 기간 1년 표시
+
+#### 원인
+- `DataInitializer.java`에서 3개 하반기 캠페인의 `periodEndDate`가 `2026-06-30`으로 설정됨
+- 주석에는 `기간: 2025.07~12`로 명시되어 있으나 코드가 불일치
+
+#### 해결
+- `periodEndDate`를 `2025-12-31`로 수정 (ESG, SAFETY, COMPLIANCE 3건 모두)
+- `deadline`도 주석과 일치하도록 `2026-02-28`로 수정
+
+#### 재발방지
+- 시드 데이터의 날짜 값은 주석과 반드시 일치시킬 것
+
+#### 검증방법
+```bash
+./gradlew bootRun # 로컬 실행 후 캠페인 목록 API 확인
+```
+
+### BE-07: 파일 업로드 에러 코드 S001 대신 S002 반환
+
+#### 원인
+- `LocalFileStorageService`, `AzureBlobStorageService`에서 IOException 시 `RuntimeException` throw
+- `GlobalExceptionHandler`에서 RuntimeException은 제네릭 핸들러로 잡혀 S001 (INTERNAL_ERROR) 반환
+- 정의된 S002 (FILE_UPLOAD_ERROR)가 실제로 사용되지 않음
+
+#### 해결
+- 두 스토리지 서비스에서 `RuntimeException` → `CustomException(ErrorCode.FILE_UPLOAD_ERROR)` 변경
+- 이제 파일 업로드 실패 시 S002 에러 코드가 정상 반환됨
+
+#### 재발방지
+- ErrorCode enum에 정의된 에러 코드가 실제 throw되는지 주기적 점검
+
+#### 검증방법
+```bash
+./gradlew test --tests "FileServiceTest"
+```
+
+### 수정 파일
+```
+src/main/java/.../domain/review/service/ReviewService.java (categoryComments 검증 분기)
+src/main/java/.../dto/approval/detail/RequesterDetailDto.java (maskedName 필드 추가)
+src/main/java/.../domain/approval/service/ApprovalService.java (마스킹 적용)
+src/main/java/.../global/config/DataInitializer.java (캠페인 날짜 수정)
+src/main/java/.../domain/file/storage/LocalFileStorageService.java (CustomException 변경)
+src/main/java/.../domain/file/storage/AzureBlobStorageService.java (CustomException 변경)
+```

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,40 +1,18 @@
+# ========================================
+# 공통 설정 (모든 프로필 적용)
+# ========================================
 spring:
   application:
     name: platform
   profiles:
-    active: local  # 기본값: local (Azure에서는 환경변수 SPRING_PROFILES_ACTIVE=dev 로 오버라이드)
+    active: local
   servlet:
     multipart:
       max-file-size: 50MB
       max-request-size: 50MB
+
 server:
   port: 8080
----
-# ========================================
-# 로컬 개발 환경
-# ========================================
-spring:
-  config:
-    activate:
-      on-profile: local
-  datasource:
-    url: jdbc:postgresql://localhost:5432/smartchain
-    username: esg
-    password: esg1234
-    driver-class-name: org.postgresql.Driver
-  sql:
-    init:
-      mode: always
-  jpa:
-    defer-datasource-initialization: true
-    hibernate:
-      ddl-auto: create
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-    open-in-view: false
 
 # Swagger 설정
 springdoc:
@@ -48,52 +26,14 @@ springdoc:
   api-docs:
     path: /v3/api-docs
 
-# JWT 설정
+# JWT 설정 (공통)
 jwt:
-  secret: smartchainPlatformSecretKeyForJwtTokenGenerationMustBe256BitsLongNiceDay
+  secret: ${JWT_SECRET:smartchainPlatformSecretKeyForJwtTokenGenerationMustBe256BitsLongNiceDay}
   access-token-validity: 3600000      # 1시간 (밀리초)
   refresh-token-validity: 604800000   # 7일 (밀리초)
 
-# 로깅 설정
-logging:
-  level:
-    com.smartchain.platform: DEBUG
-    org.hibernate.SQL: DEBUG
-
-# reCAPTCHA v3 설정
-recaptcha:
-  secret-key: ${RECAPTCHA_SECRET_KEY:6LcC-V8sAAAAAHpYoUj5q31vQh9hDduj-4m7hvGc}
-  score-threshold: ${RECAPTCHA_SCORE_THRESHOLD:0.5}
-  enabled: ${RECAPTCHA_ENABLED:false}
-
-# 파일 저장소 설정 (로컬)
-file:
-  storage:
-    local:
-      base-path: ./uploads
-
-# AI Run API 설정
+# AI 슬롯 정의 (공통)
 ai:
-  run-api:
-    url: http://127.0.0.1:8000
-    timeout-seconds: 180
-    max-retry: 3
-    preview-timeout-seconds: 30
-    preview-max-retry: 1
-  chat:
-    base-url: http://127.0.0.1:8001
-    admin-api-key: ${AI_CHAT_ADMIN_KEY:test-key}
-    timeout-seconds: 30
-  risk-api:
-    url: ${AI_RISK_API_URL:http://127.0.0.1:8002}
-    timeout-seconds: 300
-    max-retry: 3
-    target-companies:
-      - 포스코홀딩스
-      - 현대제철
-      - 성광벤드
-      - 동국제강
-      - HD현대일렉트릭
   slots:
     # 슬롯 정의: docs/API_CONTRACT_SSOT.md §8.6 기준
     domains:
@@ -226,44 +166,127 @@ ai:
 
 ---
 # ========================================
-# 개발 서버 환경 (Azure)
+# 로컬 개발 환경
+# ========================================
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:postgresql://localhost:5432/smartchain
+    username: esg
+    password: esg1234
+    driver-class-name: org.postgresql.Driver
+  sql:
+    init:
+      mode: always
+  jpa:
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    open-in-view: false
+
+# reCAPTCHA 비활성화 (로컬)
+recaptcha:
+  secret-key: ${RECAPTCHA_SECRET_KEY:6LcC-V8sAAAAAHpYoUj5q31vQh9hDduj-4m7hvGc}
+  score-threshold: ${RECAPTCHA_SCORE_THRESHOLD:0.5}
+  enabled: false
+
+# 파일 저장소 설정 (로컬)
+file:
+  storage:
+    local:
+      base-path: ./uploads
+
+# AI 서비스 (로컬)
+ai:
+  run-api:
+    url: http://127.0.0.1:8000
+    timeout-seconds: 180
+    max-retry: 3
+    preview-timeout-seconds: 30
+    preview-max-retry: 1
+  chat:
+    base-url: http://127.0.0.1:8001
+    admin-api-key: ${AI_CHAT_ADMIN_KEY:test-key}
+    timeout-seconds: 30
+  risk-api:
+    url: http://127.0.0.1:8002
+    timeout-seconds: 300
+    max-retry: 3
+    target-companies:
+      - 포스코홀딩스
+      - 현대제철
+      - 성광벤드
+      - 동국제강
+      - HD현대일렉트릭
+
+# 로깅 (로컬)
+logging:
+  level:
+    com.smartchain.platform: DEBUG
+    org.hibernate.SQL: DEBUG
+
+---
+# ========================================
+# 개발 서버 환경 (Azure Dev)
 # ========================================
 spring:
   config:
     activate:
       on-profile: dev
-
   datasource:
     url: jdbc:postgresql://${DB_HOST}:5432/${DB_NAME}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
-
   sql:
     init:
       mode: always
-
   jpa:
     defer-datasource-initialization: true
     hibernate:
       ddl-auto: validate
     show-sql: false
 
-# Azure Blob Storage 설정
+# reCAPTCHA (dev)
+recaptcha:
+  secret-key: ${RECAPTCHA_SECRET_KEY}
+  score-threshold: ${RECAPTCHA_SCORE_THRESHOLD:0.5}
+  enabled: ${RECAPTCHA_ENABLED:false}
+
+# Azure Blob Storage
 azure:
   storage:
     connection-string: ${AZURE_STORAGE_CONNECTION_STRING}
     container-name: ${AZURE_STORAGE_CONTAINER:smartchain-files}
 
-logging:
-  level:
-    com.smartchain.platform: INFO
-
-# AI Chat API 설정 (dev)
+# AI 서비스 (dev)
 ai:
+  run-api:
+    url: ${AI_RUN_API_URL:http://127.0.0.1:8000}
+    timeout-seconds: 180
+    max-retry: 3
+    preview-timeout-seconds: 30
+    preview-max-retry: 1
   chat:
     base-url: ${AI_CHAT_URL:http://127.0.0.1:8001}
     admin-api-key: ${AI_CHAT_ADMIN_KEY}
     timeout-seconds: 30
+  risk-api:
+    url: ${AI_RISK_API_URL:http://127.0.0.1:8002}
+    timeout-seconds: 300
+    max-retry: 3
+    target-companies:
+      - 포스코홀딩스
+      - 현대제철
+      - 성광벤드
+      - 동국제강
+      - HD현대일렉트릭
 
 # 이메일 설정 (SMTP)
 spring.mail:
@@ -275,3 +298,86 @@ spring.mail:
     mail.smtp.auth: true
     mail.smtp.starttls.enable: true
     mail.smtp.starttls.required: true
+
+# 로깅 (dev)
+logging:
+  level:
+    com.smartchain.platform: INFO
+
+---
+# ========================================
+# 운영 환경 (Azure Prod)
+# ========================================
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:5432/${DB_NAME}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  sql:
+    init:
+      mode: never
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+
+# reCAPTCHA (prod - 활성화)
+recaptcha:
+  secret-key: ${RECAPTCHA_SECRET_KEY}
+  score-threshold: ${RECAPTCHA_SCORE_THRESHOLD:0.5}
+  enabled: true
+
+# Swagger 비활성화 (prod)
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
+
+# Azure Blob Storage
+azure:
+  storage:
+    connection-string: ${AZURE_STORAGE_CONNECTION_STRING}
+    container-name: ${AZURE_STORAGE_CONTAINER:smartchain-files}
+
+# AI 서비스 (prod)
+ai:
+  run-api:
+    url: ${AI_RUN_API_URL}
+    timeout-seconds: 180
+    max-retry: 3
+    preview-timeout-seconds: 30
+    preview-max-retry: 1
+  chat:
+    base-url: ${AI_CHAT_URL}
+    admin-api-key: ${AI_CHAT_ADMIN_KEY}
+    timeout-seconds: 30
+  risk-api:
+    url: ${AI_RISK_API_URL}
+    timeout-seconds: 300
+    max-retry: 3
+    target-companies:
+      - 포스코홀딩스
+      - 현대제철
+      - 성광벤드
+      - 동국제강
+      - HD현대일렉트릭
+
+# 이메일 설정 (SMTP)
+spring.mail:
+  host: ${MAIL_HOST:smtp.gmail.com}
+  port: ${MAIL_PORT:587}
+  username: ${MAIL_USERNAME}
+  password: ${MAIL_PASSWORD}
+  properties:
+    mail.smtp.auth: true
+    mail.smtp.starttls.enable: true
+    mail.smtp.starttls.required: true
+
+# 로깅 (prod)
+logging:
+  level:
+    com.smartchain.platform: WARN


### PR DESCRIPTION
## Summary
- 공통 설정(JWT, Swagger, AI slots)을 프로필 밖으로 분리하여 모든 환경에서 공유
- `spring.profiles.active: local`이 프로필 문서 안에 있어 prod/dev 프로필이 무시되던 문제 해결
- prod 프로필 추가 (sql.init.mode=never, reCAPTCHA 활성화, Swagger 비활성화, 로깅 WARN)
- dev/prod에서 AI 서버 주소를 환경변수로 관리하도록 변경

## Azure 배포 시 필요한 환경변수
```
SPRING_PROFILES_ACTIVE=prod
DB_HOST, DB_NAME, DB_USER, DB_PASSWORD
AZURE_STORAGE_CONNECTION_STRING
AI_RUN_API_URL, AI_CHAT_URL, AI_RISK_API_URL
AI_CHAT_ADMIN_KEY
RECAPTCHA_SECRET_KEY (prod)
JWT_SECRET (선택, 미설정 시 기본값 사용)
```

## Test plan
- [x] `./gradlew build` 통과
- [ ] local 프로필로 로컬 기동 확인
- [ ] Azure 환경변수 세팅 후 prod 프로필 기동 확인