### PR TITLE
fix(config): 외부 리스크 API target-companies 설정 추가

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,6 +75,16 @@ ai:
     url: http://127.0.0.1:8000
     timeout-seconds: 180
     max-retry: 3
+  risk-api:
+    url: http://127.0.0.1:8002
+    timeout-seconds: 60
+    max-retry: 3
+    target-companies:
+      - 포스코홀딩스
+      - 현대제철
+      - 성광벤드
+      - 동국제강
+      - HD현대일렉트릭
   chat:
     base-url: http://127.0.0.1:8001
     admin-api-key: ${AI_CHAT_ADMIN_KEY:test-key}
@@ -251,6 +261,16 @@ logging:
     com.smartchain.platform: INFO
 
 ai:
+  risk-api:
+    url: ${AI_RISK_API_URL:http://127.0.0.1:8000}
+    timeout-seconds: 60
+    max-retry: 3
+    target-companies:
+      - 포스코홀딩스
+      - 현대제철
+      - 성광벤드
+      - 동국제강
+      - HD현대일렉트릭
   chat:
     base-url: ${AI_CHAT_URL:http://127.0.0.1:8001}
     admin-api-key: ${AI_CHAT_ADMIN_KEY}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -41,6 +41,12 @@ ai:
     url: http://localhost:8000
     timeout-seconds: 10
     max-retry: 1
+    target-companies:
+      - 포스코홀딩스
+      - 현대제철
+      - 성광벤드
+      - 동국제강
+      - HD현대일렉트릭
   slots:
     # 슬롯 정의: docs/API_CONTRACT_SSOT.md §8.6 기준
     domains:


### PR DESCRIPTION
## 변경 요약
- `application.yaml`의 local / dev·prod / test 프로파일에 `ai.risk-api.target-companies` 설정 추가
- `ExternalRiskApiConfig.targetCompanies`가 빈 리스트여서 `GET /api/v1/risk/external/companies`가 빈 배열을 반환하던 문제 해결
- 대상 회사 5개: 포스코홀딩스, 현대제철, 성광벤드, 동국제강, HD현대일렉트릭

## 관련 이슈
- 프론트엔드 "외부 리스크 감지 → 분석 시작" 버튼 비활성화 이슈
- 근본 원인: `ExternalRiskService.getRiskTargetCompanies()`가 config에서 빈 리스트를 읽어 `List.of()` 조기 반환

## 테스트 방법
1. `./gradlew test --tests "com.smartchain.platform.domain.risk.*"` — 전체 통과 확인 완료
2. 서버 기동 후 `GET /api/v1/risk/external/companies` 호출 → 5개 회사 목록 반환 확인
3. 프론트에서 "분석 시작" 버튼 활성화 및 `POST /api/v1/risk/external/detect` 정상 동작 확인

## 명세 준수 체크
- [x] `ExternalRiskApiConfig`의 `@ConfigurationProperties(prefix = "ai.risk-api")` 와 키 일치
- [x] local 프로파일: `url: http://127.0.0.1:8002` (사용자 수정 반영)
- [x] dev/prod 프로파일: `url: ${AI_RISK_API_URL:http://127.0.0.1:8000}` (환경변수 주입 가능)
- [x] test 프로파일: 기존 risk-api 설정에 target-companies만 추가

## 리뷰 포인트
- 5개 회사명이 DB에 등록된 `company.name`과 정확히 일치해야 동작합니다 (`companyRepository.findByNameIn` 사용)
- local 프로파일의 risk-api URL이 `8002` 포트로 설정됨 — AI 리스크 서버 포트와 맞는지 확인 필요

## TODO / 프론트팀 질문
- [ ] DB에서 5개 회사의 `company_id` 값 확인 후 프론트팀 전달 필요
  ```sql
  SELECT company_id, name FROM company
  WHERE name IN ('포스코홀딩스', '현대제철', '성광벤드', '동국제강', 'HD현대일렉트릭');
  ```
- [ ] 프론트에서 companyId를 하드코딩할 것인지, `/companies` API 응답을 사용할 것인지 확정 필요
  → API 응답 사용 시 하드코딩 불필요 (권장)