### PR TITLE
feat(review): 심사 상세 API에 기안자 정보 및 한글 상태 라벨 추가

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -14,6 +14,7 @@ import com.smartchain.platform.domain.user.repository.CompanyRepository;
 import com.smartchain.platform.domain.user.repository.DomainRepository;
 import com.smartchain.platform.domain.user.repository.UserRepository;
 import com.smartchain.platform.dto.ai.AiAnalysisResultDetailResponse;
+import com.smartchain.platform.dto.approval.detail.RequesterDetailDto;
 import com.smartchain.platform.dto.review.common.*;
 import com.smartchain.platform.dto.review.dashboard.*;
 import com.smartchain.platform.dto.review.decision.ReviewDecisionRequest;
@@ -245,8 +246,12 @@ public class ReviewService {
 
         validateDomainReviewerAccess(currentUser, review);
 
+        // 기안자 정보 조회
+        Diagnostic diagnostic = review.getDiagnostic();
+        Long diagnosticId = diagnostic.getDiagnosticId();
+        RequesterDetailDto drafterDto = buildDrafterDto(diagnostic.getDrafterId());
+
         // AI 분석 결과 조회 (있는 경우에만)
-        Long diagnosticId = review.getDiagnostic().getDiagnosticId();
         Object aiAnalysisData = fetchAiAnalysisResult(diagnosticId);
 
         // Diagnostic Info
@@ -283,6 +288,7 @@ public class ReviewService {
         return ReviewDetailResponse.builder()
                 .reviewId(review.getReviewId())
                 .reviewIdLabel("심사 ID: REVIEW-" + String.format("%04d", review.getReviewId()))
+                .drafter(drafterDto)
                 .diagnostic(diagnosticDto)
                 .company(companyDto)
                 .domainCode(domainCode)
@@ -293,6 +299,7 @@ public class ReviewService {
                 .riskLevelLabel(riskLevelStr != null ? RISK_LEVEL_LABEL_MAP.get(riskLevelStr) : null)
                 .riskColorClass(riskLevelStr != null ? RISK_COLOR_MAP.get(riskLevelStr) : null)
                 .status(review.getStatus().name())
+                .statusLabel(STATUS_LABEL_MAP.get(review.getStatus().name()))
                 .submittedAt(review.getSubmittedAt())
                 .files(new ArrayList<>())
                 .tabs(new ArrayList<>())
@@ -490,6 +497,20 @@ public class ReviewService {
                 throw new CustomException(ErrorCode.INVALID_CATEGORY_FOR_DOMAIN);
             }
         }
+    }
+
+    private RequesterDetailDto buildDrafterDto(Long drafterId) {
+        if (drafterId == null) {
+            return null;
+        }
+        return userRepository.findById(drafterId)
+                .map(drafter -> RequesterDetailDto.builder()
+                        .userId(drafter.getUserId())
+                        .name(drafter.getName())
+                        .maskedName(NameMaskingUtil.mask(drafter.getName()))
+                        .email(drafter.getEmail())
+                        .build())
+                .orElse(null);
     }
 
     private void validateDomainReviewerAccess(User user, Review review) {

--- a/src/main/java/com/smartchain/platform/dto/review/detail/ReviewDetailResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/review/detail/ReviewDetailResponse.java
@@ -1,5 +1,6 @@
 package com.smartchain.platform.dto.review.detail;
 
+import com.smartchain.platform.dto.approval.detail.RequesterDetailDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,6 +16,7 @@ import java.util.List;
 public class ReviewDetailResponse {
     private Long reviewId;
     private String reviewIdLabel;        // "심사 ID: REVIEW-2026-0001"
+    private RequesterDetailDto drafter;          // 기안자 정보
     private DiagnosticDetailInfoDto diagnostic;  // v3.0: 진단 정보 구조화
     private CompanyDetailInfoDto company;        // v3.0: 회사 정보 구조화
     private String domainCode;           // 도메인 코드 (ESG, SAFETY, COMPLIANCE)
@@ -25,6 +27,7 @@ public class ReviewDetailResponse {
     private String riskLevelLabel;
     private String riskColorClass;
     private String status;
+    private String statusLabel;          // 한글 상태 라벨 (검수중, 승인, 보완요청)
     private LocalDateTime submittedAt;
     
     // 파일 정보


### PR DESCRIPTION
## 변경 요약
- `ReviewDetailResponse`에 `drafter` 필드 추가 (기안자 이름, 마스킹 이름, 이메일)
- `ReviewDetailResponse`에 `statusLabel` 필드 추가 (한글 상태 라벨)
- `ReviewService.getReviewDetail()`에서 `Diagnostic.drafterId`로 기안자 User 조회 → `RequesterDetailDto` 빌드
- 기존 `STATUS_LABEL_MAP` 재사용 (REVIEWING→검수중, APPROVED→승인, REVISION_REQUIRED→보완요청)

## 관련 이슈
Closes #219

## 테스트 방법
1. 로컬에서 `./gradlew bootRun`으로 서버 기동
2. 기안자 계정으로 로그인 → 진단 제출 → 결재 → 심사 단계까지 진행
3. 수신자 계정으로 `GET /api/v1/reviews/{id}` 호출
4. 응답에 `drafter` 객체(userId, name, maskedName, email)와 `statusLabel`(한글) 확인
5. `drafterId`가 null인 레거시 데이터의 경우 `drafter: null` 반환 확인

## 명세 준수 체크
- [x] `RequesterDetailDto` 재사용 (approval 패키지 기존 DTO)
- [x] `maskedName`은 `NameMaskingUtil.mask()` 사용
- [x] `statusLabel`은 목록 API(`ReviewListItemDto`)와 동일한 `STATUS_LABEL_MAP` 사용
- [x] 빌드 성공 (`./gradlew build -x test` PASS)

## 리뷰 포인트
- `buildDrafterDto()`에서 `drafterId` null / User 미존재 시 `null` 반환 — 별도 에러 처리 불필요한지 확인
- `RequesterDetailDto`를 approval 패키지에서 import하여 사용 — 공통 패키지로 이동 필요 여부

## TODO / 질문
- [ ] 결재자(approver) 정보도 추가 필요한지 FE 확인 필요
- [ ] `COMPLETED` 상태의 한글 라벨이 `STATUS_LABEL_MAP`에 없음 — 필요 시 추가
- [ ] score 필드 제거는 별도 PR로 진행 예정