### PR TITLE
feat(diagnostic): 진단 이력 중간 항목 이름 마스킹 처리

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -519,9 +519,19 @@ public class DiagnosticService {
 
         List<DiagnosticHistory> histories = diagnosticHistoryRepository.findByDiagnosticOrderByCreatedAtDesc(diagnostic);
 
-        List<DiagnosticHistoryItemDto> historyItems = histories.stream()
+        List<DiagnosticHistoryItemDto> historyItems = new ArrayList<>(histories.stream()
                 .map(this::mapToHistoryItemDto)
-                .toList();
+                .toList());
+
+        // 첫 번째/마지막 항목 제외하고 이름 마스킹
+        if (historyItems.size() > 2) {
+            for (int i = 1; i < historyItems.size() - 1; i++) {
+                PerformedByDto performer = historyItems.get(i).getPerformedBy();
+                if (performer != null && performer.getName() != null) {
+                    performer.setName(NameMaskingUtil.mask(performer.getName()));
+                }
+            }
+        }
 
         return DiagnosticHistoryResponse.builder()
                 .diagnosticId(diagnosticId)


### PR DESCRIPTION
## 변경 요약
- 진단 이력 조회 시 첫 번째/마지막 항목을 제외한 중간 항목의 수행자 이름을 마스킹 처리
- `NameMaskingUtil.mask()` 적용하여 개인정보 보호

## 관련 이슈
- Closes #223

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `DiagnosticService.java` | `getDiagnosticHistory()`에서 중간 항목 이름 마스킹 로직 추가 |

## 테스트 방법
1. `./gradlew build` 빌드 성공 확인
2. 진단 이력 조회 API 호출 → 3개 이상 이력 시 중간 항목 이름이 마스킹되는지 확인
3. 이력 2개 이하인 경우 마스킹 없이 원본 표시 확인

## 명세 준수 체크
- [x] 기존 API 응답 스키마 변경 없음 (name 필드 값만 마스킹)
- [x] maskedName 필드는 별도 존재, name 필드 자체를 마스킹

## 리뷰 포인트
- 첫 번째/마지막 항목 기준이 적절한지 (index 0과 size-1)
- 이력이 정확히 2개일 때 마스킹 스킵 조건 (`size > 2`)

## TODO / 질문
- 마스킹 기준을 "첫/마지막 제외"가 아닌 다른 기준으로 변경 필요 시 추가 논의 필요