### PR TITLE
fix(review): 리뷰 리스트 ESG/SAFETY riskLevel 미표시 수정

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
@@ -10,8 +10,11 @@ import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
 import com.smartchain.platform.domain.evidence.entity.EvidenceFile;
 import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository;
+import com.smartchain.platform.domain.review.entity.Review;
+import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.dto.ai.run.*;
 import com.smartchain.platform.global.enums.ParsingStatus;
+import com.smartchain.platform.global.enums.RiskLevel;
 import com.smartchain.platform.global.error.CustomException;
 import com.smartchain.platform.global.error.ErrorCode;
 import org.slf4j.Logger;
@@ -45,6 +48,7 @@ public class AiAnalysisService {
     private final AiAnalysisResultRepository resultRepository;
     private final DiagnosticRepository diagnosticRepository;
     private final EvidenceFileRepository evidenceFileRepository;
+    private final ReviewRepository reviewRepository;
     private final ObjectMapper objectMapper;
     private final SlotConfigProperties slotConfigProperties;
 
@@ -56,6 +60,7 @@ public class AiAnalysisService {
         AiAnalysisResultRepository resultRepository,
         DiagnosticRepository diagnosticRepository,
         EvidenceFileRepository evidenceFileRepository,
+        ReviewRepository reviewRepository,
         ObjectMapper objectMapper,
         SlotConfigProperties slotConfigProperties
     ) {
@@ -63,6 +68,7 @@ public class AiAnalysisService {
         this.resultRepository = resultRepository;
         this.diagnosticRepository = diagnosticRepository;
         this.evidenceFileRepository = evidenceFileRepository;
+        this.reviewRepository = reviewRepository;
         this.objectMapper = objectMapper;
         this.slotConfigProperties = slotConfigProperties;
     }
@@ -360,6 +366,20 @@ public class AiAnalysisService {
             .analyzedAt(LocalDateTime.now())
             .build();
 
-        return resultRepository.save(result);
+        AiAnalysisResult saved = resultRepository.save(result);
+
+        // Review가 존재하면 riskLevel 업데이트
+        RiskLevel riskLevel = RiskLevel.fromString(response.riskLevel());
+        reviewRepository.findByDiagnostic(diagnostic).ifPresentOrElse(
+            review -> {
+                review.updateRiskLevel(riskLevel);
+                log.info("Review riskLevel 업데이트 - diagnosticId: {}, riskLevel: {}",
+                    diagnostic.getDiagnosticId(), riskLevel);
+            },
+            () -> log.info("Review 미존재 (결재 전) - diagnosticId: {}, riskLevel은 심사 생성 시 반영 예정",
+                diagnostic.getDiagnosticId())
+        );
+
+        return saved;
     }
 }

--- a/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
+++ b/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
@@ -138,4 +138,8 @@ public class Review extends BaseTimeEntity {
         this.score = score;
         this.riskLevel = RiskLevel.fromScore(score);
     }
+
+    public void updateRiskLevel(RiskLevel riskLevel) {
+        this.riskLevel = riskLevel;
+    }
 }

--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -630,7 +630,17 @@ public class ReviewService {
                 .companyType(review.getCompany().getScale())
                 .build();
 
-        String riskLevelStr = review.getRiskLevel() != null ? review.getRiskLevel().name() : null;
+        // Review에 riskLevel이 없으면 ai_analysis_result에서 fallback 조회
+        String riskLevelStr;
+        if (review.getRiskLevel() != null) {
+            riskLevelStr = review.getRiskLevel().name();
+        } else {
+            riskLevelStr = aiAnalysisResultRepository
+                    .findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(
+                            review.getDiagnostic().getDiagnosticId())
+                    .map(AiAnalysisResult::getRiskLevel)
+                    .orElse(null);
+        }
 
         AssignedToDto assignedToDto = null;
         if (review.getAssignedReviewer() != null) {

--- a/src/test/java/com/smartchain/platform/domain/ai/service/AiAnalysisServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/ai/service/AiAnalysisServiceTest.java
@@ -9,6 +9,7 @@ import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import com.smartchain.platform.domain.diagnostic.repository.DiagnosticRepository;
 import com.smartchain.platform.domain.evidence.entity.EvidenceFile;
 import com.smartchain.platform.domain.evidence.repository.EvidenceFileRepository;
+import com.smartchain.platform.domain.review.repository.ReviewRepository;
 import com.smartchain.platform.domain.user.entity.Company;
 import com.smartchain.platform.domain.user.entity.Domain;
 import com.smartchain.platform.dto.ai.run.*;
@@ -47,6 +48,8 @@ class AiAnalysisServiceTest {
     @Mock
     private EvidenceFileRepository evidenceFileRepository;
     @Mock
+    private ReviewRepository reviewRepository;
+    @Mock
     private SlotConfigProperties slotConfigProperties;
 
     private ObjectMapper objectMapper;
@@ -60,6 +63,7 @@ class AiAnalysisServiceTest {
             resultRepository,
             diagnosticRepository,
             evidenceFileRepository,
+            reviewRepository,
             objectMapper,
             slotConfigProperties
         );


### PR DESCRIPTION
## 변경 요약
- AI 분석 완료 시 Review.riskLevel을 즉시 업데이트하여 신규 분석부터 반영
- 리스트 조회 시 Review.riskLevel이 null인 경우 ai_analysis_result 테이블에서 fallback 조회
- 기존 데이터(ESG/SAFETY)도 별도 마이그레이션 없이 즉시 표시

## 관련 이슈
- Closes #224

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `Review.java` | `updateRiskLevel(RiskLevel)` 메서드 추가 |
| `AiAnalysisService.java` | `ReviewRepository` 주입, `saveAnalysisResult()`에서 Review riskLevel 업데이트 |
| `ReviewService.java` | `mapToListItemDto()`에서 ai_analysis_result fallback 조회 |
| `AiAnalysisServiceTest.java` | `ReviewRepository` mock 추가 |

## 테스트 방법
1. `./gradlew build` 빌드/테스트 성공 확인
2. AI 분석 submit 완료 후 `GET /v1/reviews` 호출 → ESG/SAFETY 항목에 riskLevelLabel 표시 확인
3. AI 분석 완료 + Review 존재하는 기존 데이터에서도 riskLevelLabel 표시 확인
4. AI 분석 미완료 항목은 riskLevelLabel이 null인지 확인

## 명세 준수 체크
- [x] API 응답 스키마 변경 없음 (기존 riskLevel/riskLevelLabel/riskColorClass 필드 그대로)
- [x] Review가 없는 경우 (결재 전) 에러 없이 로그만 남김
- [x] RiskLevel.fromString()으로 안전한 변환 (유효하지 않은 값은 null)

## 리뷰 포인트
- fallback 조회가 리스트 N+1 쿼리를 유발할 수 있음 → riskLevel이 null인 Review가 많으면 성능 영향 가능
- 장기적으로는 기존 데이터 일괄 마이그레이션 후 fallback 제거 고려

## TODO / 질문
- 기존 데이터 일괄 마이그레이션 SQL 실행 여부 (UPDATE review SET risk_level = ... FROM ai_analysis_result)
- fallback 조회 제거 시점 결정 필요