### PR TITLE
feat(diagnostic): 진단 상세 createdBy에 email 필드 추가

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/service/DiagnosticService.java
@@ -234,6 +234,7 @@ public class DiagnosticService {
                     .userId(drafter.getUserId())
                     .name(drafter.getName())
                     .maskedName(NameMaskingUtil.mask(drafter.getName()))
+                    .email(drafter.getEmail())
                     .build();
         }
 

--- a/src/main/java/com/smartchain/platform/dto/diagnostic/detail/CreatedByDto.java
+++ b/src/main/java/com/smartchain/platform/dto/diagnostic/detail/CreatedByDto.java
@@ -13,4 +13,5 @@ public class CreatedByDto {
     private Long userId;
     private String name;
     private String maskedName;
+    private String email;
 }


### PR DESCRIPTION
## 변경 요약
- `CreatedByDto`에 `email` 필드 추가
- `DiagnosticService`에서 `drafter.getEmail()`로 세팅
- 프론트 심사 상세 페이지에서 기안자 이메일 표시 지원

## 관련 이슈
- Closes #227

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `CreatedByDto.java` | `email` 필드 추가 |
| `DiagnosticService.java` | `createdByDto` 빌드 시 `.email(drafter.getEmail())` 추가 |

## 테스트 방법
1. `./gradlew build` 빌드 성공 확인
2. `GET /v1/diagnostics/:id` 호출 → `createdBy.email` 값 확인
3. drafter가 null인 경우 createdBy 자체가 null → 에러 없음

## 명세 준수 체크
- [x] 기존 필드(userId, name, maskedName) 변경 없음
- [x] email 필드 추가만 (하위 호환)

## 리뷰 포인트
- email이 민감 정보이므로 권한 없는 사용자에게 노출되는지 확인 필요 (현재 진단 상세는 권한 검증 후 접근)

## TODO / 질문
- 리뷰 상세 API의 requester 정보에도 email 추가 필요 여부 확인