### PR TITLE
feat(ai): __x__ 교차 검증 슬롯 분리 처리 (#229)

### DIFF
--- a/docs/claude/LEARNINGS.md
+++ b/docs/claude/LEARNINGS.md
@@ -1,5 +1,27 @@
 # Claude Code Learnings
 
+## 2026-02-12: AI 교차 검증 슬롯(`__x__`) displayName 빈 문자열 문제
+
+### 원인
+- AI Run API submit 응답에 `safety.education.attendance__x__safety.education.photo` 같은 교차 검증 슬롯이 포함됨
+- `SlotConfigProperties.getDisplayName()`이 `__x__` 전체를 하나의 슬롯명으로 조회하므로 매칭 실패 → 슬롯명 그대로 반환
+- 프론트에서 이를 일반 슬롯과 동일하게 표시하면 의미 없는 항목으로 노출
+
+### 해결
+- `AiAnalysisResultDetailResponse`에 `crossValidations` 필드 추가, `__x__` 슬롯을 `slotResults`에서 분리
+- `CrossValidation` DTO 신규 생성 (slots, displayNames, verdict, reasons, extras)
+- `AiAnalysisService.enrichWithDisplayNames()`에서 `__x__` 슬롯에 대해 구성 슬롯들의 displayName을 " ↔ "로 조합
+
+### 재발방지
+- `__x__` 패턴은 AI 서버 교차 검증 표준 포맷 — 새 교차 검증 슬롯 추가 시 자동 처리됨
+- `isCrossValidationSlot()` 유틸 메서드로 판별 로직 중앙 집중
+
+### 검증방법
+- `./gradlew test --tests "AiAnalysisResultDetailResponseTest"` — 교차 검증 분리 테스트 2개 포함
+
+### 관련커밋
+- (미커밋) feat(ai): __x__ 교차 검증 슬롯 분리 처리
+
 ## 2026-02-11: REVISION_REQUIRED 처리 시 간헐적 500 에러 (DiagnosticHistory comment 길이 불일치)
 
 ### 원인

--- a/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
@@ -180,6 +180,7 @@ public class AiAnalysisService {
     /**
      * AI 응답의 slotResults에 displayName 추가
      * 프론트에서 보낸 slotHints의 displayName 우선, 없으면 설정에서 조회
+     * __x__ 교차 검증 슬롯은 구성 슬롯들의 displayName을 "A ↔ B" 형태로 조합
      */
     private RunSubmitResponse enrichWithDisplayNames(RunSubmitResponse response,
                                                       List<SlotHint> slotHints,
@@ -200,10 +201,16 @@ public class AiAnalysisService {
         // slotResults에 displayName 추가
         List<SlotResult> enrichedResults = response.slotResults().stream()
             .map(result -> {
-                String displayName = frontendDisplayNames.getOrDefault(
-                    result.slotName(),
-                    slotConfigProperties.getDisplayName(result.slotName(), domainCode)
-                );
+                String displayName;
+                if (result.slotName() != null && result.slotName().contains("__x__")) {
+                    // 교차 검증 슬롯: 구성 슬롯들의 displayName을 "A ↔ B" 형태로 조합
+                    displayName = buildCrossValidationDisplayName(result.slotName(), frontendDisplayNames, domainCode);
+                } else {
+                    displayName = frontendDisplayNames.getOrDefault(
+                        result.slotName(),
+                        slotConfigProperties.getDisplayName(result.slotName(), domainCode)
+                    );
+                }
                 return result.withDisplayName(displayName);
             })
             .toList();
@@ -217,6 +224,22 @@ public class AiAnalysisService {
             response.clarifications(),
             response.extras()
         );
+    }
+
+    /**
+     * __x__ 교차 검증 슬롯의 displayName 생성
+     * 구성 슬롯들의 displayName을 " ↔ " 구분자로 조합
+     */
+    private String buildCrossValidationDisplayName(String crossSlotName,
+                                                     Map<String, String> frontendDisplayNames,
+                                                     String domainCode) {
+        String[] parts = crossSlotName.split("__x__");
+        return java.util.Arrays.stream(parts)
+            .map(part -> frontendDisplayNames.getOrDefault(
+                part,
+                slotConfigProperties.getDisplayName(part, domainCode)
+            ))
+            .collect(Collectors.joining(" ↔ "));
     }
 
     /**

--- a/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponse.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
 import com.smartchain.platform.dto.ai.run.Clarification;
+import com.smartchain.platform.dto.ai.run.CrossValidation;
 import com.smartchain.platform.dto.ai.run.SlotResult;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -14,6 +16,7 @@ import java.util.Map;
 /**
  * AI 분석 결과 상세 응답 DTO
  * resultJson을 파싱하여 슬롯별 결과와 보완요청 메시지를 구조화하여 제공
+ * __x__ 교차 검증 슬롯은 slotResults에서 분리하여 crossValidations로 제공
  */
 public record AiAnalysisResultDetailResponse(
     Long id,
@@ -24,11 +27,13 @@ public record AiAnalysisResultDetailResponse(
     String verdict,
     String whySummary,
     List<SlotResult> slotResults,
+    List<CrossValidation> crossValidations,
     List<Clarification> clarifications,
     Map<String, Object> extras,
     LocalDateTime analyzedAt
 ) {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String CROSS_VALIDATION_SEPARATOR = "__x__";
 
     /**
      * AiAnalysisResult 엔티티를 상세 응답 DTO로 변환
@@ -50,10 +55,18 @@ public record AiAnalysisResultDetailResponse(
             result.getVerdict(),
             result.getWhySummary(),
             parsed.slotResults(),
+            parsed.crossValidations(),
             parsed.clarifications(),
             parsed.extras(),
             result.getAnalyzedAt()
         );
+    }
+
+    /**
+     * 슬롯명이 교차 검증 슬롯인지 판별
+     */
+    static boolean isCrossValidationSlot(String slotName) {
+        return slotName != null && slotName.contains(CROSS_VALIDATION_SEPARATOR);
     }
 
     /**
@@ -62,6 +75,7 @@ public record AiAnalysisResultDetailResponse(
     private static ParsedResult parseResultJson(String resultJson) {
         if (resultJson == null || resultJson.isBlank()) {
             return new ParsedResult(
+                Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyMap()
@@ -74,18 +88,53 @@ public record AiAnalysisResultDetailResponse(
                 new TypeReference<Map<String, Object>>() {}
             );
 
-            List<SlotResult> slotResults = parseSlotResults(jsonMap);
+            List<SlotResult> allSlotResults = parseSlotResults(jsonMap);
+
+            // __x__ 슬롯 분리
+            List<SlotResult> normalSlots = allSlotResults.stream()
+                .filter(sr -> !isCrossValidationSlot(sr.slotName()))
+                .toList();
+
+            List<CrossValidation> crossValidations = allSlotResults.stream()
+                .filter(sr -> isCrossValidationSlot(sr.slotName()))
+                .map(AiAnalysisResultDetailResponse::toCrossValidation)
+                .toList();
+
             List<Clarification> clarifications = parseClarifications(jsonMap);
             Map<String, Object> extras = parseExtras(jsonMap);
 
-            return new ParsedResult(slotResults, clarifications, extras);
+            return new ParsedResult(normalSlots, crossValidations, clarifications, extras);
         } catch (Exception e) {
             return new ParsedResult(
+                Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyMap()
             );
         }
+    }
+
+    /**
+     * __x__ 슬롯의 SlotResult를 CrossValidation으로 변환
+     */
+    private static CrossValidation toCrossValidation(SlotResult slotResult) {
+        List<String> slots = Arrays.asList(slotResult.slotName().split(CROSS_VALIDATION_SEPARATOR));
+
+        // displayName이 "A ↔ B" 형식이면 분리, 아니면 슬롯명을 그대로 사용
+        List<String> displayNames;
+        if (slotResult.displayName() != null && slotResult.displayName().contains(" ↔ ")) {
+            displayNames = Arrays.asList(slotResult.displayName().split(" ↔ "));
+        } else {
+            displayNames = slots;
+        }
+
+        return new CrossValidation(
+            slots,
+            displayNames,
+            slotResult.verdict(),
+            slotResult.reasons(),
+            slotResult.extras()
+        );
     }
 
     @SuppressWarnings("unchecked")
@@ -102,6 +151,7 @@ public record AiAnalysisResultDetailResponse(
                     Map<String, Object> map = (Map<String, Object>) item;
                     return new SlotResult(
                         getStringValue(map, "slot_name", "slotName"),
+                        getStringValue(map, "display_name", "displayName"),
                         (String) map.get("verdict"),
                         getListValue(map, "reasons"),
                         getListValue(map, "file_ids", "fileIds"),
@@ -187,6 +237,7 @@ public record AiAnalysisResultDetailResponse(
      */
     private record ParsedResult(
         List<SlotResult> slotResults,
+        List<CrossValidation> crossValidations,
         List<Clarification> clarifications,
         Map<String, Object> extras
     ) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/CrossValidation.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/CrossValidation.java
@@ -1,0 +1,16 @@
+package com.smartchain.platform.dto.ai.run;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AI Run API 교차 검증 결과 DTO
+ * __x__ 구분자로 연결된 슬롯 간 교차 검증 결과를 표현
+ */
+public record CrossValidation(
+    List<String> slots,           // 비교 대상 슬롯명 (예: ["safety.education.attendance", "safety.education.photo"])
+    List<String> displayNames,    // 비교 대상 한글 표시명 (예: ["교육 출석부", "교육일 사진"])
+    String verdict,               // PASS, NEED_FIX 등
+    List<String> reasons,
+    Map<String, String> extras    // 교차 검증 추가 데이터 (예: {"attendance_count": "9", "photo_count": "10"})
+) {}

--- a/src/test/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponseTest.java
+++ b/src/test/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponseTest.java
@@ -88,8 +88,9 @@ class AiAnalysisResultDetailResponseTest {
         assertThat(response.verdict()).isEqualTo("PASS");
         assertThat(response.riskLevel()).isEqualTo("MEDIUM");
 
-        // slot_results 검증
+        // slot_results 검증 (일반 슬롯만)
         assertThat(response.slotResults()).hasSize(2);
+        assertThat(response.crossValidations()).isEmpty();
         assertThat(response.slotResults().get(0).slotName()).isEqualTo("esg.energy.usage");
         assertThat(response.slotResults().get(0).verdict()).isEqualTo("PASS");
         assertThat(response.slotResults().get(0).reasons()).containsExactly("데이터 형식 적합", "기간 일치");
@@ -131,6 +132,7 @@ class AiAnalysisResultDetailResponseTest {
 
         // then
         assertThat(response.slotResults()).isEmpty();
+        assertThat(response.crossValidations()).isEmpty();
         assertThat(response.clarifications()).isEmpty();
         assertThat(response.extras()).isEmpty();
     }
@@ -158,6 +160,7 @@ class AiAnalysisResultDetailResponseTest {
 
         // then
         assertThat(response.slotResults()).isEmpty();
+        assertThat(response.crossValidations()).isEmpty();
         assertThat(response.clarifications()).isEmpty();
         assertThat(response.extras()).isEmpty();
     }
@@ -185,6 +188,7 @@ class AiAnalysisResultDetailResponseTest {
 
         // then
         assertThat(response.slotResults()).isEmpty();
+        assertThat(response.crossValidations()).isEmpty();
         assertThat(response.clarifications()).isEmpty();
         assertThat(response.extras()).isEmpty();
         // 기본 필드는 정상적으로 설정
@@ -237,5 +241,136 @@ class AiAnalysisResultDetailResponseTest {
         assertThat(response.slotResults()).hasSize(1);
         assertThat(response.slotResults().get(0).slotName()).isEqualTo("esg.energy.usage");
         assertThat(response.slotResults().get(0).fileNames()).containsExactly("test.xlsx");
+    }
+
+    @Test
+    @DisplayName("__x__ 교차 검증 슬롯이 slotResults에서 분리되어 crossValidations로 이동")
+    void from_withCrossValidationSlots_separatesIntoCrossValidations() {
+        // given
+        String resultJson = """
+            {
+                "package_id": "PKG_1_202601_1",
+                "risk_level": "LOW",
+                "verdict": "PASS",
+                "why": "안전 교육 증빙 확인 완료",
+                "slot_results": [
+                    {
+                        "slot_name": "safety.education.attendance",
+                        "display_name": "교육 출석부",
+                        "verdict": "PASS",
+                        "reasons": ["출석부 확인 완료"],
+                        "file_ids": ["1"],
+                        "file_names": ["attendance.xlsx"]
+                    },
+                    {
+                        "slot_name": "safety.education.photo",
+                        "display_name": "교육일 사진",
+                        "verdict": "PASS",
+                        "reasons": ["교육 사진 확인 완료"],
+                        "file_ids": ["2"],
+                        "file_names": ["photo.jpg"]
+                    },
+                    {
+                        "slot_name": "safety.education.attendance__x__safety.education.photo",
+                        "display_name": "교육 출석부 ↔ 교육일 사진",
+                        "verdict": "NEED_FIX",
+                        "reasons": ["출석 인원 9명, 사진 속 인원 10명 - 불일치"],
+                        "file_ids": [],
+                        "file_names": [],
+                        "extras": {"attendance_count": "9", "photo_count": "10"}
+                    }
+                ],
+                "clarifications": [],
+                "extras": {}
+            }
+            """;
+
+        Diagnostic diagnostic = mock(Diagnostic.class);
+        when(diagnostic.getDiagnosticId()).thenReturn(200L);
+
+        AiAnalysisResult result = AiAnalysisResult.builder()
+            .diagnostic(diagnostic)
+            .domainCode("SAFETY")
+            .packageId("PKG_1_202601_1")
+            .riskLevel("LOW")
+            .verdict("PASS")
+            .whySummary("안전 교육 증빙 확인 완료")
+            .resultJson(resultJson)
+            .analyzedAt(LocalDateTime.now())
+            .build();
+
+        // when
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result);
+
+        // then - 일반 슬롯만 slotResults에 포함
+        assertThat(response.slotResults()).hasSize(2);
+        assertThat(response.slotResults().get(0).slotName()).isEqualTo("safety.education.attendance");
+        assertThat(response.slotResults().get(1).slotName()).isEqualTo("safety.education.photo");
+
+        // __x__ 슬롯은 crossValidations로 분리
+        assertThat(response.crossValidations()).hasSize(1);
+        assertThat(response.crossValidations().get(0).slots())
+            .containsExactly("safety.education.attendance", "safety.education.photo");
+        assertThat(response.crossValidations().get(0).displayNames())
+            .containsExactly("교육 출석부", "교육일 사진");
+        assertThat(response.crossValidations().get(0).verdict()).isEqualTo("NEED_FIX");
+        assertThat(response.crossValidations().get(0).reasons())
+            .containsExactly("출석 인원 9명, 사진 속 인원 10명 - 불일치");
+        assertThat(response.crossValidations().get(0).extras())
+            .containsEntry("attendance_count", "9")
+            .containsEntry("photo_count", "10");
+    }
+
+    @Test
+    @DisplayName("__x__ 슬롯에 displayName이 없으면 슬롯명을 displayNames로 사용")
+    void from_withCrossValidationWithoutDisplayName_usesSlotNames() {
+        // given
+        String resultJson = """
+            {
+                "package_id": "PKG_1_202601_1",
+                "risk_level": "LOW",
+                "verdict": "PASS",
+                "why": "테스트",
+                "slot_results": [
+                    {
+                        "slot_name": "safety.tbm.checklist__x__safety.tbm.video",
+                        "verdict": "PASS",
+                        "reasons": ["일치"],
+                        "file_ids": [],
+                        "file_names": []
+                    }
+                ],
+                "clarifications": [],
+                "extras": {}
+            }
+            """;
+
+        Diagnostic diagnostic = mock(Diagnostic.class);
+        when(diagnostic.getDiagnosticId()).thenReturn(300L);
+
+        AiAnalysisResult result = AiAnalysisResult.builder()
+            .diagnostic(diagnostic)
+            .domainCode("SAFETY")
+            .packageId("PKG_1_202601_1")
+            .riskLevel("LOW")
+            .verdict("PASS")
+            .whySummary("테스트")
+            .resultJson(resultJson)
+            .analyzedAt(LocalDateTime.now())
+            .build();
+
+        // when
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result);
+
+        // then - slotResults에서 제외
+        assertThat(response.slotResults()).isEmpty();
+
+        // crossValidations에 포함, displayName 없으므로 슬롯명 사용
+        assertThat(response.crossValidations()).hasSize(1);
+        assertThat(response.crossValidations().get(0).slots())
+            .containsExactly("safety.tbm.checklist", "safety.tbm.video");
+        assertThat(response.crossValidations().get(0).displayNames())
+            .containsExactly("safety.tbm.checklist", "safety.tbm.video");
+        assertThat(response.crossValidations().get(0).verdict()).isEqualTo("PASS");
     }
 }


### PR DESCRIPTION
## 변경 요약
- AI Run API 응답의 `__x__` 교차 검증 슬롯을 `slotResults`에서 분리하여 `crossValidations` 필드로 구조화
- `CrossValidation` DTO 신규 추가 (slots, displayNames, verdict, reasons, extras)
- `AiAnalysisService.enrichWithDisplayNames()`에서 교차 검증 슬롯의 displayName을 구성 슬롯들의 이름을 "A ↔ B" 형태로 조합
- `AiAnalysisResultDetailResponse` 파싱 로직에서 `__x__` 슬롯 자동 분리

## 관련 이슈
- Closes #229

## 테스트 방법
```bash
./gradlew test --tests "AiAnalysisResultDetailResponseTest"
```
- `from_withCrossValidationSlots_separatesIntoCrossValidations` — 교차 검증 슬롯 분리 + displayName 파싱 검증
- `from_withCrossValidationWithoutDisplayName_usesSlotNames` — displayName 없을 때 슬롯명 폴백 검증

## 명세 준수 체크
- [x] `RunSubmitResponse` 고정 스키마 유지 (기존 필드 변경 없음)
- [x] `AiAnalysisResultDetailResponse`에 `crossValidations` 필드 추가 (하위 호환)
- [x] AI Run API 엔드포인트 변경 없음
- [x] `slotResults`에서 일반 슬롯만 포함 (교차 검증 슬롯 제외)

## 리뷰 포인트
1. `CrossValidation` DTO의 `extras` 타입이 `Map<String, String>` — AI 서버에서 `Map<String, Object>`로 내려올 가능성 확인 필요
2. `__x__` 구분자는 AI 서버 표준이나, 향후 구분자 변경 시 `CROSS_VALIDATION_SEPARATOR` 상수만 수정하면 됨
3. 교차 검증 결과의 `verdict` 값이 기존 `PASS/FAIL/PENDING` 외에 `NEED_FIX` 등 추가 값 사용 — 프론트 대응 필요

## TODO / 질문
- [ ] 프론트엔드에서 `crossValidations` 렌더링 컴포넌트 구현 필요
- [ ] AI 서버에서 3개 이상 슬롯 교차 검증(`A__x__B__x__C`) 가능 여부 확인