### PR TITLE
AI Preview API 파일 제거 지원 및 packageId 관리 개선 (#233)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/ai/client/AiRunApiClient.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/client/AiRunApiClient.java
@@ -54,9 +54,10 @@ public class AiRunApiClient {
      * 파일 추가 시 슬롯 추정 및 필수 항목 현황 반환
      */
     public Mono<RunPreviewResponse> preview(RunPreviewRequest request) {
-        log.info("AI Run API preview 호출 - domain: {}, packageId: {}, files: {}",
+        log.info("AI Run API preview 호출 - domain: {}, packageId: {}, addedFiles: {}, removedFileIds: {}",
             request.domain(), request.packageId(),
-            request.addedFiles() != null ? request.addedFiles().size() : 0);
+            request.addedFiles() != null ? request.addedFiles().size() : 0,
+            request.removedFileIds());
 
         return webClient.post()
             .uri("/run/preview")

--- a/src/main/java/com/smartchain/platform/domain/ai/controller/AiAnalysisController.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/controller/AiAnalysisController.java
@@ -46,7 +46,7 @@ public class AiAnalysisController {
         log.info("AI 분석 미리보기 요청 - diagnosticId: {}, fileIds: {}",
             diagnosticId, request.fileIds());
 
-        RunPreviewResponse response = aiAnalysisService.preview(diagnosticId, request.fileIds());
+        RunPreviewResponse response = aiAnalysisService.preview(diagnosticId, request.fileIds(), request.removedFileIds());
 
         return ResponseEntity.ok(BaseResponse.success("슬롯 추정 완료", response));
     }

--- a/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/service/AiAnalysisService.java
@@ -74,9 +74,11 @@ public class AiAnalysisService {
     }
 
     /**
-     * Preview 호출 - 파일 추가 시 슬롯 추정
+     * Preview 호출 - 파일 추가/제거 시 슬롯 추정
+     * preview 응답의 package_id를 Diagnostic에 저장하여 다음 호출에서 재사용
      */
-    public RunPreviewResponse preview(Long diagnosticId, List<Long> fileIds) {
+    @Transactional
+    public RunPreviewResponse preview(Long diagnosticId, List<Long> fileIds, List<String> removedFileIds) {
         Diagnostic diagnostic = getDiagnostic(diagnosticId);
         String domainCode = getDomainCode(diagnostic);
 
@@ -84,11 +86,14 @@ public class AiAnalysisService {
             .map(this::toFileInfo)
             .toList();
 
-        // 기존 package_id 조회 (있으면 사용)
-        String existingPackageId = resultRepository
-            .findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(diagnosticId)
-            .map(AiAnalysisResult::getPackageId)
-            .orElse(null);
+        // package_id 조회: preview 저장분 → submit 저장분 → null (신규)
+        String existingPackageId = diagnostic.getPreviewPackageId();
+        if (existingPackageId == null) {
+            existingPackageId = resultRepository
+                .findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(diagnosticId)
+                .map(AiAnalysisResult::getPackageId)
+                .orElse(null);
+        }
 
         if (diagnostic.getPeriodStartDate() == null || diagnostic.getPeriodEndDate() == null) {
             throw new CustomException(ErrorCode.AI_MISSING_PERIOD_DATES);
@@ -99,10 +104,23 @@ public class AiAnalysisService {
             diagnostic.getPeriodStartDate().format(DATE_FORMATTER),
             diagnostic.getPeriodEndDate().format(DATE_FORMATTER),
             existingPackageId,
-            addedFiles
+            addedFiles,
+            removedFileIds
         );
 
-        return aiRunApiClient.previewSync(request);
+        log.info("Preview 요청 - diagnosticId: {}, packageId: {}, addedFiles: {}, removedFileIds: {}",
+            diagnosticId, existingPackageId,
+            addedFiles.stream().map(FileInfo::fileId).toList(),
+            removedFileIds);
+
+        RunPreviewResponse response = aiRunApiClient.previewSync(request);
+
+        // 응답의 package_id를 Diagnostic에 저장 (다음 preview에서 재사용)
+        if (response.packageId() != null) {
+            diagnostic.updatePreviewPackageId(response.packageId());
+        }
+
+        return response;
     }
 
     /**
@@ -152,11 +170,14 @@ public class AiAnalysisService {
                 diagnosticId, missingRequiredSlots);
         }
 
-        // 기존 package_id 조회
-        String packageId = resultRepository
-            .findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(diagnosticId)
-            .map(AiAnalysisResult::getPackageId)
-            .orElse(generatePackageId(diagnostic));
+        // package_id 조회: preview 저장분 → submit 저장분 → 신규 생성
+        String packageId = diagnostic.getPreviewPackageId();
+        if (packageId == null) {
+            packageId = resultRepository
+                .findTopByDiagnostic_DiagnosticIdOrderByAnalyzedAtDesc(diagnosticId)
+                .map(AiAnalysisResult::getPackageId)
+                .orElse(generatePackageId(diagnostic));
+        }
 
         RunSubmitRequest request = new RunSubmitRequest(
             packageId,

--- a/src/main/java/com/smartchain/platform/domain/diagnostic/entity/Diagnostic.java
+++ b/src/main/java/com/smartchain/platform/domain/diagnostic/entity/Diagnostic.java
@@ -56,6 +56,8 @@ public class Diagnostic extends BaseTimeEntity {
 
     private LocalDateTime submittedAt;
 
+    private String previewPackageId;
+
     @Builder
     public Diagnostic(String diagnosticCode, String title, Campaign campaign, Company company,
                       Domain domain, Long drafterId, LocalDate periodStartDate, LocalDate periodEndDate, LocalDate deadline) {
@@ -120,5 +122,9 @@ public class Diagnostic extends BaseTimeEntity {
 
     public boolean isApproved() {
         return this.status == DiagnosticStatus.APPROVED;
+    }
+
+    public void updatePreviewPackageId(String previewPackageId) {
+        this.previewPackageId = previewPackageId;
     }
 }

--- a/src/main/java/com/smartchain/platform/dto/ai/AiPreviewRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/AiPreviewRequest.java
@@ -6,5 +6,6 @@ import java.util.List;
  * AI Preview 요청 DTO
  */
 public record AiPreviewRequest(
-    List<Long> fileIds
+    List<Long> fileIds,
+    List<String> removedFileIds  // AI 패키지에서 제거할 파일 ID 목록 (optional)
 ) {}

--- a/src/main/java/com/smartchain/platform/dto/ai/run/RunPreviewRequest.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/RunPreviewRequest.java
@@ -20,5 +20,8 @@ public record RunPreviewRequest(
     String packageId,  // 첫 호출 시 null
 
     @JsonProperty("added_files")
-    List<FileInfo> addedFiles
+    List<FileInfo> addedFiles,
+
+    @JsonProperty("removed_file_ids")
+    List<String> removedFileIds
 ) {}

--- a/src/test/java/com/smartchain/platform/domain/ai/service/AiAnalysisServiceTest.java
+++ b/src/test/java/com/smartchain/platform/domain/ai/service/AiAnalysisServiceTest.java
@@ -244,7 +244,7 @@ class AiAnalysisServiceTest {
             when(diagnosticRepository.findById(diagnosticId)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> aiAnalysisService.preview(diagnosticId, List.of(1L)))
+            assertThatThrownBy(() -> aiAnalysisService.preview(diagnosticId, List.of(1L), null))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -263,7 +263,7 @@ class AiAnalysisServiceTest {
             when(evidenceFileRepository.findById(999L)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> aiAnalysisService.preview(diagnosticId, List.of(999L)))
+            assertThatThrownBy(() -> aiAnalysisService.preview(diagnosticId, List.of(999L), null))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -283,7 +283,7 @@ class AiAnalysisServiceTest {
             when(evidenceFileRepository.findById(1L)).thenReturn(Optional.of(evidenceFile));
 
             // when & then
-            assertThatThrownBy(() -> aiAnalysisService.preview(diagnosticId, List.of(1L)))
+            assertThatThrownBy(() -> aiAnalysisService.preview(diagnosticId, List.of(1L), null))
                 .isInstanceOf(CustomException.class)
                 .satisfies(ex -> {
                     CustomException customEx = (CustomException) ex;
@@ -315,7 +315,7 @@ class AiAnalysisServiceTest {
             when(aiRunApiClient.previewSync(any(RunPreviewRequest.class))).thenReturn(aiResponse);
 
             // when
-            RunPreviewResponse result = aiAnalysisService.preview(diagnosticId, List.of(1L));
+            RunPreviewResponse result = aiAnalysisService.preview(diagnosticId, List.of(1L), null);
 
             // then
             assertThat(result).isNotNull();


### PR DESCRIPTION
## Summary
- Preview 요청에 `removedFileIds` 파라미터 추가하여 AI 패키지에서 파일 제거 지원
- Preview 응답의 `packageId`를 Diagnostic 엔티티에 저장하여 다음 호출 시 재사용
- Submit에서도 Diagnostic의 `previewPackageId`를 우선 조회하도록 로직 변경

## 변경 파일
- `AiPreviewRequest` / `RunPreviewRequest` - removedFileIds 필드 추가
- `AiAnalysisController` - removedFileIds 전달
- `AiRunApiClient` - 로그에 removedFileIds 추가
- `Diagnostic` - previewPackageId 필드 추가
- `AiAnalysisService` - preview/submit packageId 조회 로직 개선
- `AiAnalysisServiceTest` - preview 호출 시그니처 업데이트

Closes #233