### PR TITLE
AI DTO extras 타입 Map<String, Object>로 변경 (#234)

### DIFF
--- a/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponse.java
@@ -218,13 +218,13 @@ public record AiAnalysisResultDetailResponse(
     }
 
     @SuppressWarnings("unchecked")
-    private static Map<String, String> getMapValue(Map<String, Object> map, String key) {
+    private static Map<String, Object> getMapValue(Map<String, Object> map, String key) {
         Object value = map.get(key);
         if (value instanceof Map<?, ?> rawMap) {
-            Map<String, String> result = new java.util.HashMap<>();
+            Map<String, Object> result = new java.util.HashMap<>();
             rawMap.forEach((k, v) -> {
-                if (k instanceof String && v instanceof String) {
-                    result.put((String) k, (String) v);
+                if (k instanceof String) {
+                    result.put((String) k, v);
                 }
             });
             return result;

--- a/src/main/java/com/smartchain/platform/dto/ai/run/SlotResult.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/SlotResult.java
@@ -24,13 +24,13 @@ public record SlotResult(
     @JsonProperty("file_names")
     List<String> fileNames,
 
-    Map<String, String> extras
+    Map<String, Object> extras
 ) {
     /**
      * displayName 없이 생성하는 생성자 (AI 서버 응답 역직렬화용)
      */
     public SlotResult(String slotName, String verdict, List<String> reasons,
-                      List<String> fileIds, List<String> fileNames, Map<String, String> extras) {
+                      List<String> fileIds, List<String> fileNames, Map<String, Object> extras) {
         this(slotName, null, verdict, reasons, fileIds, fileNames, extras);
     }
 


### PR DESCRIPTION
## Summary
- `SlotResult.extras` 타입을 `Map<String, String>` → `Map<String, Object>`로 변경
- `AiAnalysisResultDetailResponse.getMapValue()` 반환 타입을 `Map<String, Object>`로 변경
- AI 서버 응답에서 중첩 객체, 숫자 등 다양한 타입의 값 수용 가능

Closes #234