### PR TITLE
Review 코멘트 컬럼 길이 확장 (#235)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
+++ b/src/main/java/com/smartchain/platform/domain/review/entity/Review.java
@@ -58,16 +58,16 @@ public class Review extends BaseTimeEntity {
     @JoinColumn(name = "processed_by_id")
     private User processedBy;
 
-    @Column(length = 1000)
+    @Column(length = 2000)
     private String comment;
 
-    @Column(length = 500)
+    @Column(length = 2000)
     private String categoryCommentE;
 
-    @Column(length = 500)
+    @Column(length = 2000)
     private String categoryCommentS;
 
-    @Column(length = 500)
+    @Column(length = 2000)
     private String categoryCommentG;
 
     @Builder


### PR DESCRIPTION
## Summary
- `comment` 컬럼 길이 1000 → 2000으로 확장
- `categoryCommentE/S/G` 컬럼 길이 500 → 2000으로 확장
- 긴 심사평 입력 시 데이터 잘림 방지

Closes #235