### PR TITLE
AiAnalysisResult whySummary 컬럼 TEXT 타입 변경 (#236)

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/ai/entity/AiAnalysisResult.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/entity/AiAnalysisResult.java
@@ -39,7 +39,7 @@ public class AiAnalysisResult extends BaseTimeEntity {
     @Column(nullable = false)
     private String verdict;  // PASS, WARN, NEED_CLARIFY, NEED_FIX
 
-    @Column(name = "why_summary", length = 500)
+    @Column(name = "why_summary", columnDefinition = "TEXT")
     private String whySummary;
 
     @Column(name = "result_json", columnDefinition = "TEXT")


### PR DESCRIPTION
## Summary
- `whySummary` 컬럼 정의를 `@Column(length=500)` → `@Column(columnDefinition="TEXT")`로 변경
- AI 서버에서 긴 요약 텍스트 반환 시 데이터 잘림 방지

Closes #236