### PR TITLE
fix(data): 안전보건·컴플라이언스 하반기 캠페인 시작일 변경

### DIFF
--- a/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
+++ b/src/main/java/com/smartchain/platform/global/config/DataInitializer.java
@@ -265,7 +265,7 @@ public class DataInitializer implements CommandLineRunner {
         Campaign safetyCampaignCurrent = campaignRepository.save(Campaign.builder()
                 .campaignCode("CAMP-SAFETY-2025-H2").ownerCompanyId(ownerCompany.getCompanyId()).domain(safetyDomain)
                 .title("2025년 하반기 안전보건 점검").content("2025년 하반기 협력사 안전보건 관리 현황 점검")
-                .periodStartDate(LocalDate.of(2025, 7, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .periodStartDate(LocalDate.of(2025, 9, 30)).periodEndDate(LocalDate.of(2026, 6, 30))
                 .deadline(LocalDate.of(2026, 8, 31)).isActive(true).build());
 
         Campaign safetyCampaignPast = campaignRepository.save(Campaign.builder()
@@ -277,7 +277,7 @@ public class DataInitializer implements CommandLineRunner {
         Campaign complianceCampaignCurrent = campaignRepository.save(Campaign.builder()
                 .campaignCode("CAMP-COMPL-2025-H2").ownerCompanyId(ownerCompany.getCompanyId()).domain(complianceDomain)
                 .title("2025년 하반기 하도급 컴플라이언스 점검").content("2025년 하반기 협력사 하도급 계약 법규 준수 점검")
-                .periodStartDate(LocalDate.of(2025, 7, 1)).periodEndDate(LocalDate.of(2026, 6, 30))
+                .periodStartDate(LocalDate.of(2025, 9, 30)).periodEndDate(LocalDate.of(2026, 2, 13))
                 .deadline(LocalDate.of(2026, 8, 31)).isActive(true).build());
 
         Campaign complianceCampaignPast = campaignRepository.save(Campaign.builder()


### PR DESCRIPTION
## 변경요약
- 안전보건(SAFETY) 하반기 캠페인 `periodStartDate` 2025-07-01 → **2025-09-30**
- 컴플라이언스(COMPLIANCE) 하반기 캠페인 `periodStartDate` 2025-07-01 → **2025-09-30**
- 컴플라이언스 `periodEndDate` 2026-06-30 → **2026-02-13**

## 관련 이슈
- Closes #244

## 테스트 방법
1. 서버 재시작 (`ddl-auto: create`로 DB 리셋됨)
2. Swagger 또는 캠페인 목록 API 호출하여 SAFETY/COMPLIANCE 캠페인의 startDate가 `2025-09-30`인지 확인

## 명세 준수 체크
- [x] DataInitializer 초기 데이터 날짜 변경만 포함
- [x] 다른 캠페인(ESG, 과거 캠페인) 영향 없음

## 리뷰 포인트
- 컴플라이언스 periodEndDate도 `2026-02-13`으로 변경 — 의도된 변경인지 확인 필요

## TODO / 질문
- 프론트엔드에서 날짜 표시 off-by-one 이슈 별도 확인 필요