### PR TITLE
feat(ai): 설정 기반 교차 검증(Cross Validation) 슬롯 분리 지원

### DIFF
--- a/src/main/java/com/smartchain/platform/domain/ai/config/SlotConfigProperties.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/config/SlotConfigProperties.java
@@ -17,6 +17,7 @@ import java.util.Map;
 public class SlotConfigProperties {
 
     private Map<String, List<SlotDefinition>> domains = new HashMap<>();
+    private List<CrossValidationDefinition> crossValidations = new ArrayList<>();
 
     @Getter
     @Setter
@@ -25,6 +26,14 @@ public class SlotConfigProperties {
         private String displayName;  // 한글 표시명
         private List<String> keywords = new ArrayList<>();
         private boolean required;
+    }
+
+    @Getter
+    @Setter
+    public static class CrossValidationDefinition {
+        private String name;          // 가상 슬롯명 (예: esg.energy.electricity.month_match)
+        private String displayName;   // 한글 표시명
+        private List<String> slots = new ArrayList<>();  // 비교 대상 슬롯명
     }
 
     public List<SlotDefinition> getSlotsForDomain(String domainCode) {
@@ -68,5 +77,22 @@ public class SlotConfigProperties {
                 }
                 return slotName;
             });
+    }
+
+    /**
+     * 교차 검증 슬롯인지 판별
+     */
+    public boolean isCrossValidation(String slotName) {
+        return crossValidations.stream().anyMatch(cv -> cv.getName().equals(slotName));
+    }
+
+    /**
+     * 교차 검증 정의 조회
+     */
+    public CrossValidationDefinition getCrossValidationDefinition(String slotName) {
+        return crossValidations.stream()
+            .filter(cv -> cv.getName().equals(slotName))
+            .findFirst()
+            .orElse(null);
     }
 }

--- a/src/main/java/com/smartchain/platform/domain/ai/controller/AiAnalysisController.java
+++ b/src/main/java/com/smartchain/platform/domain/ai/controller/AiAnalysisController.java
@@ -4,6 +4,7 @@ import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
 import com.smartchain.platform.domain.ai.service.AiAnalysisAsyncService;
 import com.smartchain.platform.domain.ai.service.AiAnalysisService;
 import com.smartchain.platform.dto.ai.AiAnalysisRequest;
+import com.smartchain.platform.domain.ai.config.SlotConfigProperties;
 import com.smartchain.platform.dto.ai.AiAnalysisResultDetailResponse;
 import com.smartchain.platform.dto.ai.AiAnalysisResultResponse;
 import com.smartchain.platform.dto.ai.AiPreviewRequest;
@@ -31,10 +32,12 @@ public class AiAnalysisController {
 
     private final AiAnalysisService aiAnalysisService;
     private final AiAnalysisAsyncService aiAnalysisAsyncService;
+    private final SlotConfigProperties slotConfigProperties;
 
-    public AiAnalysisController(AiAnalysisService aiAnalysisService, AiAnalysisAsyncService aiAnalysisAsyncService) {
+    public AiAnalysisController(AiAnalysisService aiAnalysisService, AiAnalysisAsyncService aiAnalysisAsyncService, SlotConfigProperties slotConfigProperties) {
         this.aiAnalysisService = aiAnalysisService;
         this.aiAnalysisAsyncService = aiAnalysisAsyncService;
+        this.slotConfigProperties = slotConfigProperties;
     }
 
     @Operation(summary = "AI Run Preview", description = "파일 추가 시 슬롯 추정 및 필수 항목 현황 확인")
@@ -95,7 +98,7 @@ public class AiAnalysisController {
         log.info("AI 분석 결과 상세 조회 - diagnosticId: {}", diagnosticId);
 
         AiAnalysisResult result = aiAnalysisService.getLatestResult(diagnosticId);
-        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result);
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result, slotConfigProperties);
 
         return ResponseEntity.ok(BaseResponse.success("분석 결과 상세 조회 완료", response));
     }

--- a/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
+++ b/src/main/java/com/smartchain/platform/domain/review/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.smartchain.platform.domain.review.service;
 
+import com.smartchain.platform.domain.ai.config.SlotConfigProperties;
 import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
 import com.smartchain.platform.domain.ai.repository.AiAnalysisResultRepository;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
@@ -52,6 +53,7 @@ public class ReviewService {
     private final DomainRepository domainRepository;
     private final AiAnalysisResultRepository aiAnalysisResultRepository;
     private final DiagnosticHistoryRepository diagnosticHistoryRepository;
+    private final SlotConfigProperties slotConfigProperties;
 
     private static final Map<String, String> RISK_LEVEL_LABEL_MAP = Map.of(
             "HIGH", "고위험군",
@@ -431,7 +433,7 @@ public class ReviewService {
         }
 
         AiAnalysisResult result = latestResult.get();
-        AiAnalysisResultDetailResponse detailResponse = AiAnalysisResultDetailResponse.from(result);
+        AiAnalysisResultDetailResponse detailResponse = AiAnalysisResultDetailResponse.from(result, slotConfigProperties);
 
         // clarifications를 RevisionDraftItemDto로 변환
         List<RevisionDraftResponse.RevisionDraftItemDto> draftItems = detailResponse.clarifications() != null

--- a/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponse.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponse.java
@@ -2,6 +2,8 @@ package com.smartchain.platform.dto.ai;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartchain.platform.domain.ai.config.SlotConfigProperties;
+import com.smartchain.platform.domain.ai.config.SlotConfigProperties.CrossValidationDefinition;
 import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
 import com.smartchain.platform.dto.ai.run.Clarification;
 import com.smartchain.platform.dto.ai.run.CrossValidation;
@@ -16,7 +18,7 @@ import java.util.Map;
 /**
  * AI 분석 결과 상세 응답 DTO
  * resultJson을 파싱하여 슬롯별 결과와 보완요청 메시지를 구조화하여 제공
- * __x__ 교차 검증 슬롯은 slotResults에서 분리하여 crossValidations로 제공
+ * __x__ 교차 검증 슬롯 및 설정 기반 교차 검증 슬롯은 slotResults에서 분리하여 crossValidations로 제공
  */
 public record AiAnalysisResultDetailResponse(
     Long id,
@@ -36,15 +38,14 @@ public record AiAnalysisResultDetailResponse(
     private static final String CROSS_VALIDATION_SEPARATOR = "__x__";
 
     /**
-     * AiAnalysisResult 엔티티를 상세 응답 DTO로 변환
-     * resultJson을 파싱하여 슬롯 결과와 보완요청을 추출
+     * AiAnalysisResult 엔티티를 상세 응답 DTO로 변환 (설정 기반 교차 검증 지원)
      */
-    public static AiAnalysisResultDetailResponse from(AiAnalysisResult result) {
+    public static AiAnalysisResultDetailResponse from(AiAnalysisResult result, SlotConfigProperties slotConfig) {
         Long diagId = result.getDiagnostic() != null
             ? result.getDiagnostic().getDiagnosticId()
             : null;
 
-        ParsedResult parsed = parseResultJson(result.getResultJson());
+        ParsedResult parsed = parseResultJson(result.getResultJson(), slotConfig);
 
         return new AiAnalysisResultDetailResponse(
             result.getId(),
@@ -63,16 +64,26 @@ public record AiAnalysisResultDetailResponse(
     }
 
     /**
-     * 슬롯명이 교차 검증 슬롯인지 판별
+     * AiAnalysisResult 엔티티를 상세 응답 DTO로 변환 (하위 호환)
      */
-    static boolean isCrossValidationSlot(String slotName) {
-        return slotName != null && slotName.contains(CROSS_VALIDATION_SEPARATOR);
+    public static AiAnalysisResultDetailResponse from(AiAnalysisResult result) {
+        return from(result, null);
+    }
+
+    /**
+     * 슬롯명이 교차 검증 슬롯인지 판별 (__x__ 또는 설정 기반)
+     */
+    static boolean isCrossValidationSlot(String slotName, SlotConfigProperties slotConfig) {
+        if (slotName == null) return false;
+        if (slotName.contains(CROSS_VALIDATION_SEPARATOR)) return true;
+        if (slotConfig != null) return slotConfig.isCrossValidation(slotName);
+        return false;
     }
 
     /**
      * resultJson을 파싱하여 구조화된 데이터 추출
      */
-    private static ParsedResult parseResultJson(String resultJson) {
+    private static ParsedResult parseResultJson(String resultJson, SlotConfigProperties slotConfig) {
         if (resultJson == null || resultJson.isBlank()) {
             return new ParsedResult(
                 Collections.emptyList(),
@@ -90,14 +101,14 @@ public record AiAnalysisResultDetailResponse(
 
             List<SlotResult> allSlotResults = parseSlotResults(jsonMap);
 
-            // __x__ 슬롯 분리
+            // __x__ 슬롯 및 설정 기반 교차 검증 슬롯 분리
             List<SlotResult> normalSlots = allSlotResults.stream()
-                .filter(sr -> !isCrossValidationSlot(sr.slotName()))
+                .filter(sr -> !isCrossValidationSlot(sr.slotName(), slotConfig))
                 .toList();
 
             List<CrossValidation> crossValidations = allSlotResults.stream()
-                .filter(sr -> isCrossValidationSlot(sr.slotName()))
-                .map(AiAnalysisResultDetailResponse::toCrossValidation)
+                .filter(sr -> isCrossValidationSlot(sr.slotName(), slotConfig))
+                .map(sr -> toCrossValidation(sr, slotConfig))
                 .toList();
 
             List<Clarification> clarifications = parseClarifications(jsonMap);
@@ -115,22 +126,49 @@ public record AiAnalysisResultDetailResponse(
     }
 
     /**
-     * __x__ 슬롯의 SlotResult를 CrossValidation으로 변환
+     * SlotResult를 CrossValidation으로 변환 (__x__ 및 설정 기반 모두 지원)
      */
-    private static CrossValidation toCrossValidation(SlotResult slotResult) {
-        List<String> slots = Arrays.asList(slotResult.slotName().split(CROSS_VALIDATION_SEPARATOR));
+    private static CrossValidation toCrossValidation(SlotResult slotResult, SlotConfigProperties slotConfig) {
+        String slotName = slotResult.slotName();
 
-        // displayName이 "A ↔ B" 형식이면 분리, 아니면 슬롯명을 그대로 사용
-        List<String> displayNames;
-        if (slotResult.displayName() != null && slotResult.displayName().contains(" ↔ ")) {
-            displayNames = Arrays.asList(slotResult.displayName().split(" ↔ "));
-        } else {
-            displayNames = slots;
+        // __x__ 형식 (기존 로직)
+        if (slotName != null && slotName.contains(CROSS_VALIDATION_SEPARATOR)) {
+            List<String> slots = Arrays.asList(slotName.split(CROSS_VALIDATION_SEPARATOR));
+
+            List<String> displayNames;
+            if (slotResult.displayName() != null && slotResult.displayName().contains(" ↔ ")) {
+                displayNames = Arrays.asList(slotResult.displayName().split(" ↔ "));
+            } else {
+                displayNames = slots;
+            }
+
+            return new CrossValidation(
+                slots,
+                displayNames,
+                slotResult.verdict(),
+                slotResult.reasons(),
+                slotResult.extras()
+            );
         }
 
+        // 설정 기반 교차 검증
+        if (slotConfig != null) {
+            CrossValidationDefinition cvDef = slotConfig.getCrossValidationDefinition(slotName);
+            if (cvDef != null) {
+                return new CrossValidation(
+                    cvDef.getSlots(),
+                    List.of(cvDef.getDisplayName()),
+                    slotResult.verdict(),
+                    slotResult.reasons(),
+                    slotResult.extras()
+                );
+            }
+        }
+
+        // fallback
         return new CrossValidation(
-            slots,
-            displayNames,
+            List.of(slotName),
+            List.of(slotResult.displayName() != null ? slotResult.displayName() : slotName),
             slotResult.verdict(),
             slotResult.reasons(),
             slotResult.extras()

--- a/src/main/java/com/smartchain/platform/dto/ai/run/CrossValidation.java
+++ b/src/main/java/com/smartchain/platform/dto/ai/run/CrossValidation.java
@@ -12,5 +12,5 @@ public record CrossValidation(
     List<String> displayNames,    // 비교 대상 한글 표시명 (예: ["교육 출석부", "교육일 사진"])
     String verdict,               // PASS, NEED_FIX 등
     List<String> reasons,
-    Map<String, String> extras    // 교차 검증 추가 데이터 (예: {"attendance_count": "9", "photo_count": "10"})
+    Map<String, Object> extras    // 교차 검증 추가 데이터 (예: {"attendance_count": "9", "photo_count": "10"})
 ) {}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -231,6 +231,22 @@ ai:
           display-name: 기타 문서
           keywords: []
           required: false
+    cross-validations:
+      - name: esg.energy.electricity.month_match
+        display-name: 전기 월별 대사(사용량 vs 고지서)
+        slots: [esg.energy.electricity.usage, esg.energy.electricity.bill]
+      - name: esg.energy.gas.month_match
+        display-name: 가스 월별 대사(사용량 vs 고지서)
+        slots: [esg.energy.gas.usage, esg.energy.gas.bill]
+      - name: esg.energy.water.month_match
+        display-name: 용수 월별 대사(사용량 vs 고지서)
+        slots: [esg.energy.water.usage, esg.energy.water.bill]
+      - name: esg.energy.electricity.peak_2024_vs_2025
+        display-name: 전기 사용량 피크 비교(2024 vs 2025)
+        slots: [esg.energy.electricity.usage]
+      - name: esg.hazmat.msds.coverage
+        display-name: 유해물질 MSDS 커버리지
+        slots: [esg.hazmat.msds, esg.hazmat.inventory]
 
 ---
 # ========================================

--- a/src/test/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponseTest.java
+++ b/src/test/java/com/smartchain/platform/dto/ai/AiAnalysisResultDetailResponseTest.java
@@ -1,11 +1,14 @@
 package com.smartchain.platform.dto.ai;
 
+import com.smartchain.platform.domain.ai.config.SlotConfigProperties;
+import com.smartchain.platform.domain.ai.config.SlotConfigProperties.CrossValidationDefinition;
 import com.smartchain.platform.domain.ai.entity.AiAnalysisResult;
 import com.smartchain.platform.domain.diagnostic.entity.Diagnostic;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -372,5 +375,179 @@ class AiAnalysisResultDetailResponseTest {
         assertThat(response.crossValidations().get(0).displayNames())
             .containsExactly("safety.tbm.checklist", "safety.tbm.video");
         assertThat(response.crossValidations().get(0).verdict()).isEqualTo("PASS");
+    }
+
+    @Test
+    @DisplayName("설정 기반 교차 검증 슬롯이 crossValidations로 분리")
+    void from_withConfigBasedCrossValidation_separatesIntoCrossValidations() {
+        // given
+        SlotConfigProperties slotConfig = new SlotConfigProperties();
+        CrossValidationDefinition cvDef = new CrossValidationDefinition();
+        cvDef.setName("esg.energy.electricity.month_match");
+        cvDef.setDisplayName("전기 월별 대사(사용량 vs 고지서)");
+        cvDef.setSlots(List.of("esg.energy.electricity.usage", "esg.energy.electricity.bill"));
+
+        CrossValidationDefinition cvDef2 = new CrossValidationDefinition();
+        cvDef2.setName("esg.hazmat.msds.coverage");
+        cvDef2.setDisplayName("유해물질 MSDS 커버리지");
+        cvDef2.setSlots(List.of("esg.hazmat.msds", "esg.hazmat.inventory"));
+
+        slotConfig.setCrossValidations(List.of(cvDef, cvDef2));
+
+        String resultJson = """
+            {
+                "package_id": "PKG_1",
+                "risk_level": "HIGH",
+                "verdict": "NEED_FIX",
+                "why": "테스트",
+                "slot_results": [
+                    {
+                        "slot_name": "esg.energy.electricity.usage",
+                        "display_name": "전기 사용량",
+                        "verdict": "PASS",
+                        "reasons": [],
+                        "file_ids": ["1"],
+                        "file_names": ["전기사용량.xlsx"]
+                    },
+                    {
+                        "slot_name": "esg.energy.electricity.month_match",
+                        "display_name": "esg.energy.electricity.month_match",
+                        "verdict": "NEED_FIX",
+                        "reasons": ["E3_BILL_FIELDS_MISSING"],
+                        "file_ids": [],
+                        "file_names": [],
+                        "extras": {"month": "2025-10"}
+                    },
+                    {
+                        "slot_name": "esg.hazmat.msds.coverage",
+                        "display_name": "esg.hazmat.msds.coverage",
+                        "verdict": "NEED_FIX",
+                        "reasons": ["E_MSDS_MISSING_REQUIRED"],
+                        "file_ids": [],
+                        "file_names": [],
+                        "extras": {"missing_required": "아세톤 / 톨루엔"}
+                    }
+                ],
+                "clarifications": [],
+                "extras": {}
+            }
+            """;
+
+        Diagnostic diagnostic = mock(Diagnostic.class);
+        when(diagnostic.getDiagnosticId()).thenReturn(400L);
+
+        AiAnalysisResult result = AiAnalysisResult.builder()
+            .diagnostic(diagnostic)
+            .domainCode("ESG")
+            .packageId("PKG_1")
+            .riskLevel("HIGH")
+            .verdict("NEED_FIX")
+            .whySummary("테스트")
+            .resultJson(resultJson)
+            .analyzedAt(LocalDateTime.now())
+            .build();
+
+        // when
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result, slotConfig);
+
+        // then - 일반 슬롯만 slotResults에 포함
+        assertThat(response.slotResults()).hasSize(1);
+        assertThat(response.slotResults().get(0).slotName()).isEqualTo("esg.energy.electricity.usage");
+
+        // 설정 기반 교차 검증 슬롯은 crossValidations로 분리
+        assertThat(response.crossValidations()).hasSize(2);
+
+        // electricity.month_match
+        assertThat(response.crossValidations().get(0).slots())
+            .containsExactly("esg.energy.electricity.usage", "esg.energy.electricity.bill");
+        assertThat(response.crossValidations().get(0).displayNames())
+            .containsExactly("전기 월별 대사(사용량 vs 고지서)");
+        assertThat(response.crossValidations().get(0).verdict()).isEqualTo("NEED_FIX");
+        assertThat(response.crossValidations().get(0).extras())
+            .containsEntry("month", "2025-10");
+
+        // hazmat.msds.coverage
+        assertThat(response.crossValidations().get(1).slots())
+            .containsExactly("esg.hazmat.msds", "esg.hazmat.inventory");
+        assertThat(response.crossValidations().get(1).displayNames())
+            .containsExactly("유해물질 MSDS 커버리지");
+        assertThat(response.crossValidations().get(1).reasons())
+            .containsExactly("E_MSDS_MISSING_REQUIRED");
+    }
+
+    @Test
+    @DisplayName("__x__ 교차 검증과 설정 기반 교차 검증이 혼합된 경우 모두 crossValidations로 분리")
+    void from_withMixedCrossValidations_separatesBothTypes() {
+        // given
+        SlotConfigProperties slotConfig = new SlotConfigProperties();
+        CrossValidationDefinition cvDef = new CrossValidationDefinition();
+        cvDef.setName("esg.energy.water.month_match");
+        cvDef.setDisplayName("용수 월별 대사(사용량 vs 고지서)");
+        cvDef.setSlots(List.of("esg.energy.water.usage", "esg.energy.water.bill"));
+        slotConfig.setCrossValidations(List.of(cvDef));
+
+        String resultJson = """
+            {
+                "package_id": "PKG_1",
+                "risk_level": "LOW",
+                "verdict": "PASS",
+                "why": "테스트",
+                "slot_results": [
+                    {
+                        "slot_name": "safety.education.attendance__x__safety.education.photo",
+                        "display_name": "교육 출석부 ↔ 교육일 사진",
+                        "verdict": "PASS",
+                        "reasons": ["일치"],
+                        "file_ids": [],
+                        "file_names": []
+                    },
+                    {
+                        "slot_name": "esg.energy.water.month_match",
+                        "display_name": "esg.energy.water.month_match",
+                        "verdict": "NEED_FIX",
+                        "reasons": ["PARSE_FAILED"],
+                        "file_ids": [],
+                        "file_names": []
+                    }
+                ],
+                "clarifications": [],
+                "extras": {}
+            }
+            """;
+
+        Diagnostic diagnostic = mock(Diagnostic.class);
+        when(diagnostic.getDiagnosticId()).thenReturn(500L);
+
+        AiAnalysisResult result = AiAnalysisResult.builder()
+            .diagnostic(diagnostic)
+            .domainCode("ESG")
+            .packageId("PKG_1")
+            .riskLevel("LOW")
+            .verdict("PASS")
+            .whySummary("테스트")
+            .resultJson(resultJson)
+            .analyzedAt(LocalDateTime.now())
+            .build();
+
+        // when
+        AiAnalysisResultDetailResponse response = AiAnalysisResultDetailResponse.from(result, slotConfig);
+
+        // then - 일반 슬롯 없음
+        assertThat(response.slotResults()).isEmpty();
+
+        // 두 종류 교차 검증 모두 crossValidations에 포함
+        assertThat(response.crossValidations()).hasSize(2);
+
+        // __x__ 타입
+        assertThat(response.crossValidations().get(0).slots())
+            .containsExactly("safety.education.attendance", "safety.education.photo");
+        assertThat(response.crossValidations().get(0).displayNames())
+            .containsExactly("교육 출석부", "교육일 사진");
+
+        // 설정 기반 타입
+        assertThat(response.crossValidations().get(1).slots())
+            .containsExactly("esg.energy.water.usage", "esg.energy.water.bill");
+        assertThat(response.crossValidations().get(1).displayNames())
+            .containsExactly("용수 월별 대사(사용량 vs 고지서)");
     }
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -188,3 +188,19 @@ ai:
           display-name: 기타 문서
           keywords: []
           required: false
+    cross-validations:
+      - name: esg.energy.electricity.month_match
+        display-name: 전기 월별 대사(사용량 vs 고지서)
+        slots: [esg.energy.electricity.usage, esg.energy.electricity.bill]
+      - name: esg.energy.gas.month_match
+        display-name: 가스 월별 대사(사용량 vs 고지서)
+        slots: [esg.energy.gas.usage, esg.energy.gas.bill]
+      - name: esg.energy.water.month_match
+        display-name: 용수 월별 대사(사용량 vs 고지서)
+        slots: [esg.energy.water.usage, esg.energy.water.bill]
+      - name: esg.energy.electricity.peak_2024_vs_2025
+        display-name: 전기 사용량 피크 비교(2024 vs 2025)
+        slots: [esg.energy.electricity.usage]
+      - name: esg.hazmat.msds.coverage
+        display-name: 유해물질 MSDS 커버리지
+        slots: [esg.hazmat.msds, esg.hazmat.inventory]


### PR DESCRIPTION
## 변경요약
- 기존 `__x__` 네이밍 외에 `application.yaml`의 `ai.slots.cross-validations` 설정으로 교차 검증 슬롯 정의 가능
- `SlotConfigProperties`에 `CrossValidationDefinition` 내부 클래스 및 조회 메서드 추가
- `AiAnalysisResultDetailResponse.from()`에 `SlotConfigProperties` 주입하여 설정 기반 판별
- `CrossValidation.extras` 타입 `Map<String, String>` → `Map<String, Object>` 변경
- YAML에 교차 검증 정의 5건 추가 (전기/가스/용수 월별 대사, 전기 피크 비교, MSDS 커버리지)

## 관련 이슈
- Closes #243

## 테스트 방법
1. `./gradlew test --tests "AiAnalysisResultDetailResponseTest"` 실행
2. 추가된 테스트 2건 확인:
   - `from_withConfigBasedCrossValidation_separatesIntoCrossValidations`
   - `from_withMixedCrossValidations_separatesBothTypes`
3. 전체 빌드: `./gradlew build`

## 명세 준수 체크
- [x] AI Run API 응답 스키마(`slotResults`, `crossValidations` 분리) 유지
- [x] 하위 호환: `from(result)` 오버로드 유지 (slotConfig 없이도 동작)
- [x] `__x__` 기존 방식도 그대로 동작

## 리뷰 포인트
- `CrossValidation.extras` 타입 변경(`String` → `Object`)이 기존 프론트엔드 파싱에 영향 없는지 확인
- `SlotConfigProperties`를 Controller/Service에 직접 주입 — 향후 별도 서비스로 분리 필요 여부

## TODO / 질문
- AI 서버에서 반환하는 교차 검증 슬롯명이 YAML 설정의 `name`과 정확히 일치하는지 연동 테스트 필요
- safety/compliance 도메인 교차 검증 정의 추가 여부 확인